### PR TITLE
Move to a Nat-based statically-sized vector

### DIFF
--- a/src/Data/Vector/Generic/Sized.hs
+++ b/src/Data/Vector/Generic/Sized.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DataKinds #-}
+
+module Data.Vector.Generic.Sized
+    ( Vec
+      -- * Construction
+    , fromVector
+    , replicate
+    , singleton
+    , generate
+      -- * Elimination
+    , length
+    , index
+    , head
+    , last
+      -- * Extract subsets
+    , tail
+    , init
+    , take
+    , drop
+      -- * Mapping
+    , map
+      -- * Folding
+    , foldl'
+    , foldl1'
+    ) where
+
+import qualified Data.Vector.Generic as VG
+import GHC.TypeLits
+import Data.Proxy
+import Control.DeepSeq
+import Foreign.Storable
+import Prelude hiding (replicate, singleton, head, last,
+                       tail, init, map, length, drop, take)
+
+newtype Vec v (n :: Nat) a = Vec (v a)
+                           deriving (Show, Eq, Ord, Foldable, Storable,
+                                     Monoid, NFData)
+
+fromVector :: forall a v (n :: Nat). (KnownNat n, VG.Vector v a)
+           => v a -> Maybe (Vec v n a)
+fromVector v
+  | n' == fromIntegral (VG.length v) = Just (Vec v)
+  | otherwise                        = Nothing
+  where n' = natVal (Proxy :: Proxy n)
+
+singleton :: forall a v. (VG.Vector v a)
+          => a -> Vec v 1 a
+singleton a = Vec (VG.singleton a)
+
+generate :: forall (n :: Nat) a v. (VG.Vector v a, KnownNat n)
+         => Proxy n -> (Int -> a) -> Vec v n a
+generate n f = Vec (VG.generate (fromIntegral $ natVal n) f)
+
+withVector :: forall a b v (n :: Nat). (VG.Vector v a, VG.Vector v b)
+           => (v a -> v b) -> Vec v n a -> Vec v n b
+withVector f (Vec v) = Vec (f v)
+
+index :: forall (m :: Nat) a v (n :: Nat). (KnownNat n, KnownNat m, VG.Vector v a)
+      => Proxy m -> Vec v (m+n) a -> a
+index i (Vec v) = v VG.! fromIntegral (natVal i)
+
+take :: forall (m :: Nat) a v (n :: Nat). (KnownNat n, KnownNat m, VG.Vector v a)
+      => Proxy m -> Vec v (m+n) a -> Vec v m a
+take i (Vec v) = Vec (VG.take (fromIntegral $ natVal i) v)
+
+drop :: forall (m :: Nat) a v (n :: Nat). (KnownNat n, KnownNat m, VG.Vector v a)
+      => Proxy m -> Vec v (m+n) a -> Vec v n a
+drop i (Vec v) = Vec (VG.drop (fromIntegral $ natVal i) v)
+
+length :: forall a v (n :: Nat). (VG.Vector v a)
+     => Vec v n a -> Int
+length (Vec v) = VG.length v
+
+head :: forall a v (n :: Nat). (VG.Vector v a)
+     => Vec v (n+1) a -> a
+head (Vec v) = VG.head v
+
+last :: forall a v (n :: Nat). (VG.Vector v a)
+     => Vec v (n+1) a -> a
+last (Vec v) = VG.last v
+
+tail :: forall a v (n :: Nat). (VG.Vector v a)
+     => Vec v (n+1) a -> Vec v n a
+tail (Vec v) = Vec (VG.tail v)
+
+init :: forall a v (n :: Nat). (VG.Vector v a)
+     => Vec v (n+1) a -> Vec v n a
+init (Vec v) = Vec (VG.init v)
+
+replicate :: forall a v (n :: Nat). (VG.Vector v a, KnownNat n)
+          => Proxy n -> a -> Vec v n a
+replicate n a = Vec (VG.replicate (fromIntegral $ natVal n) a)
+
+map :: forall a b v (n :: Nat). (VG.Vector v a, VG.Vector v b)
+    => (a -> b) -> Vec v n a -> Vec v n b
+map f = withVector (VG.map f)
+
+foldl' :: forall a b v (n :: Nat). (VG.Vector v a, VG.Vector v b)
+       => (a -> b -> a) -> a -> Vec v n b -> a
+foldl' f z (Vec v) = VG.foldl' f z v
+
+foldl1' :: forall a v (n :: Nat). (VG.Vector v a)
+       => (a -> a -> a) -> Vec v (n+1) a -> a
+foldl1' f (Vec v) = VG.foldl1' f v

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -18,8 +18,6 @@ import Foreign.Ptr( Ptr
                   )
 import Data.Int( Int32
                )
-import Data.Vector.Fixed.Cont( ToPeano
-                             )
 import Data.Bits( Bits
                 , FiniteBits
                 )
@@ -51,8 +49,9 @@ import Graphics.Vulkan.Image( VkImageUsageFlags(..)
                             , VkImageTiling(..)
                             , VkImageCreateFlagBits(..)
                             )
-import Data.Vector.Fixed.Storable( Vec
-                                 )
+import qualified Data.Vector.Generic.Sized
+import qualified Data.Vector.Storable as VS
+
 import Graphics.Vulkan.Core( VkExtent3D(..)
                            , VkResult(..)
                            , VkDeviceSize(..)
@@ -67,6 +66,9 @@ import Foreign.C.Types( CSize
                       , CChar
                       , CSize(..)
                       )
+
+type Vec = Data.Vector.Generic.Sized.Vec VS.Vector
+
 -- ** VkPhysicalDeviceType
 
 newtype VkPhysicalDeviceType = VkPhysicalDeviceType Int32
@@ -212,9 +214,9 @@ data VkPhysicalDeviceLimits =
                         , vkMaxFragmentDualSrcAttachments :: Word32 
                         , vkMaxFragmentCombinedOutputResources :: Word32 
                         , vkMaxComputeSharedMemorySize :: Word32 
-                        , vkMaxComputeWorkGroupCount :: Vec (ToPeano 3) Word32 
+                        , vkMaxComputeWorkGroupCount :: Vec 3 Word32 
                         , vkMaxComputeWorkGroupInvocations :: Word32 
-                        , vkMaxComputeWorkGroupSize :: Vec (ToPeano 3) Word32 
+                        , vkMaxComputeWorkGroupSize :: Vec 3 Word32 
                         , vkSubPixelPrecisionBits :: Word32 
                         , vkSubTexelPrecisionBits :: Word32 
                         , vkMipmapPrecisionBits :: Word32 
@@ -223,8 +225,8 @@ data VkPhysicalDeviceLimits =
                         , vkMaxSamplerLodBias :: CFloat 
                         , vkMaxSamplerAnisotropy :: CFloat 
                         , vkMaxViewports :: Word32 
-                        , vkMaxViewportDimensions :: Vec (ToPeano 2) Word32 
-                        , vkViewportBoundsRange :: Vec (ToPeano 2) CFloat 
+                        , vkMaxViewportDimensions :: Vec 2 Word32 
+                        , vkViewportBoundsRange :: Vec 2 CFloat 
                         , vkViewportSubPixelBits :: Word32 
                         , vkMinMemoryMapAlignment :: CSize 
                         , vkMinTexelBufferOffsetAlignment :: VkDeviceSize 
@@ -257,8 +259,8 @@ data VkPhysicalDeviceLimits =
                         , vkMaxCullDistances :: Word32 
                         , vkMaxCombinedClipAndCullDistances :: Word32 
                         , vkDiscreteQueuePriorities :: Word32 
-                        , vkPointSizeRange :: Vec (ToPeano 2) CFloat 
-                        , vkLineWidthRange :: Vec (ToPeano 2) CFloat 
+                        , vkPointSizeRange :: Vec 2 CFloat 
+                        , vkLineWidthRange :: Vec 2 CFloat 
                         , vkPointSizeGranularity :: CFloat 
                         , vkLineWidthGranularity :: CFloat 
                         , vkStrictLines :: VkBool32 
@@ -552,9 +554,9 @@ pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlagB
 
 data VkPhysicalDeviceMemoryProperties =
   VkPhysicalDeviceMemoryProperties{ vkMemoryTypeCount :: Word32 
-                                  , vkMemoryTypes :: Vec (ToPeano VK_MAX_MEMORY_TYPES) VkMemoryType 
+                                  , vkMemoryTypes :: Vec VK_MAX_MEMORY_TYPES VkMemoryType 
                                   , vkMemoryHeapCount :: Word32 
-                                  , vkMemoryHeaps :: Vec (ToPeano VK_MAX_MEMORY_HEAPS) VkMemoryHeap 
+                                  , vkMemoryHeaps :: Vec VK_MAX_MEMORY_HEAPS VkMemoryHeap 
                                   }
   deriving (Eq)
 
@@ -671,8 +673,8 @@ data VkPhysicalDeviceProperties =
                             , vkVendorID :: Word32 
                             , vkDeviceID :: Word32 
                             , vkDeviceType :: VkPhysicalDeviceType 
-                            , vkDeviceName :: Vec (ToPeano VK_MAX_PHYSICAL_DEVICE_NAME_SIZE) CChar 
-                            , vkPipelineCacheUUID :: Vec (ToPeano VK_UUID_SIZE) Word8 
+                            , vkDeviceName :: Vec VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
+                            , vkPipelineCacheUUID :: Vec VK_UUID_SIZE Word8 
                             , vkLimits :: VkPhysicalDeviceLimits 
                             , vkSparseProperties :: VkPhysicalDeviceSparseProperties 
                             }

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -69,6 +69,8 @@ import Foreign.C.Types( CSize
 
 type Vec = Data.Vector.Generic.Sized.Vec VS.Vector
 
+instance Storable (VS.Vector a)
+
 -- ** VkPhysicalDeviceType
 
 newtype VkPhysicalDeviceType = VkPhysicalDeviceType Int32

--- a/vulkan.cabal
+++ b/vulkan.cabal
@@ -50,7 +50,8 @@ library
                        Graphics.Vulkan.SparseResourceMemoryManagement
                        Graphics.Vulkan.Version
   build-depends:       base >= 4.9 && < 5
-                     , fixed-vector >= 0.8 && < 0.9
+                     , vector
+                     , deepseq
   default-language:    Haskell2010
   ghc-options:         -freduction-depth=0
 


### PR DESCRIPTION
I was quite curious to know how much of an improvement this would bring so I gave it a quick try. This is quite hacked, brought just far enough to measure the improvement (which is significant, with compilation taking on the order of seconds and an orders of magnitude reduction in compiler allocations). That being said, you might find it to be a useful start. My next step would probably be to provide a `Data.Vector.Storable.Sized` module which exports a type synonym,
```haskell
type Vec = Data.Vector.Generic.Sized.Vec Data.Vector.Storable.Vector
```
and perhaps reexport the remainder of `Data.Vector.Generic.Sized`. You could also do the same for the remaining vector varieties.