### PR TITLE
fix some uses of swapSuffix to operate on base name

### DIFF
--- a/generate/src/Write/Module.hs
+++ b/generate/src/Write/Module.hs
@@ -46,7 +46,7 @@ writeModule graph nameLocations boot (ModuleName n) names = moduleString
                                         `S.difference` (S.fromList names))
         imports = vcat (getImportDeclarations (ModuleName n) nameLocations requiredNames)
         moduleWriter = do
-          definitions <- writeVertices (requiredLookup graph <$> names)
+          definitions <- writeVertices graph (requiredLookup graph <$> names)
           pure [qc|{vcat extensionDocs}
 module {n} where
 


### PR DESCRIPTION
I was trying to expose some extension stuff, and I found a couple of places where swapSuffix was called without stripping the extension tag, causing flags to be written incorrectly.

Here's my minimally invasive fix.

It would probably be cleaner to add a type to represent tagged names, but I didn't want to make a big change like that without running it by you.

