### PR TITLE
only strip extensions with unsupported types

### DIFF
--- a/generate/src/Main.hs
+++ b/generate/src/Main.hs
@@ -14,6 +14,6 @@ main = do specString <- getContents
           case specMay of
             Nothing -> do hPutStr stderr "Failed to parse spec"
                           exitFailure
-            Just spec -> let strippedSpec = stripWSIExtensions spec
+            Just spec -> let strippedSpec = stripExtensions spec
                          in writeSpecModules "out" strippedSpec
 

--- a/src/Graphics/Vulkan.hs
+++ b/src/Graphics/Vulkan.hs
@@ -9,12 +9,16 @@ module Graphics.Vulkan
   , module Graphics.Vulkan.DescriptorSet
   , module Graphics.Vulkan.Device
   , module Graphics.Vulkan.DeviceInitialization
+  , module Graphics.Vulkan.EXT.DebugReport
   , module Graphics.Vulkan.Event
   , module Graphics.Vulkan.ExtensionDiscovery
   , module Graphics.Vulkan.Fence
   , module Graphics.Vulkan.Image
   , module Graphics.Vulkan.ImageView
+  , module Graphics.Vulkan.KHR.Display
+  , module Graphics.Vulkan.KHR.DisplaySwapchain
   , module Graphics.Vulkan.KHR.Surface
+  , module Graphics.Vulkan.KHR.Swapchain
   , module Graphics.Vulkan.LayerDiscovery
   , module Graphics.Vulkan.Memory
   , module Graphics.Vulkan.MemoryManagement
@@ -42,12 +46,16 @@ import Graphics.Vulkan.Core
 import Graphics.Vulkan.DescriptorSet
 import Graphics.Vulkan.Device
 import Graphics.Vulkan.DeviceInitialization
+import Graphics.Vulkan.EXT.DebugReport
 import Graphics.Vulkan.Event
 import Graphics.Vulkan.ExtensionDiscovery
 import Graphics.Vulkan.Fence
 import Graphics.Vulkan.Image
 import Graphics.Vulkan.ImageView
+import Graphics.Vulkan.KHR.Display
+import Graphics.Vulkan.KHR.DisplaySwapchain
 import Graphics.Vulkan.KHR.Surface
+import Graphics.Vulkan.KHR.Swapchain
 import Graphics.Vulkan.LayerDiscovery
 import Graphics.Vulkan.Memory
 import Graphics.Vulkan.MemoryManagement

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -1,0 +1,271 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Graphics.Vulkan.EXT.DebugReport where
+
+import Text.Read.Lex( Lexeme(Ident)
+                    )
+import GHC.Read( expectP
+               , choose
+               )
+import Data.Word( Word64
+                , Word32
+                )
+import Foreign.Ptr( Ptr
+                  , FunPtr
+                  , plusPtr
+                  )
+import Data.Int( Int32
+               )
+import Foreign.Storable( Storable(..)
+                       )
+import Data.Void( Void
+                )
+import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
+                             , PFN_vkAllocationFunction
+                             , PFN_vkReallocationFunction
+                             , PFN_vkInternalAllocationNotification
+                             , VkAllocationCallbacks(..)
+                             , VkSystemAllocationScope(..)
+                             , PFN_vkFreeFunction
+                             , PFN_vkInternalFreeNotification
+                             )
+import Text.Read( Read(..)
+                , parens
+                )
+import Text.ParserCombinators.ReadPrec( prec
+                                      , (+++)
+                                      , step
+                                      )
+import Graphics.Vulkan.DeviceInitialization( VkInstance(..)
+                                           )
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkBool32(..)
+                           , VkFlags(..)
+                           , VkStructureType(..)
+                           )
+import Foreign.C.Types( CSize
+                      , CChar
+                      , CSize(..)
+                      )
+
+-- ** vkDebugReportMessageEXT
+foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
+  VkInstance ->
+  VkDebugReportFlagsEXT ->
+    VkDebugReportObjectTypeEXT ->
+      Word64 -> CSize -> Int32 -> Ptr CChar -> Ptr CChar -> IO ()
+
+newtype VkDebugReportCallbackEXT = VkDebugReportCallbackEXT Word64
+  deriving (Eq, Storable)
+
+-- ** VkDebugReportObjectTypeEXT
+
+newtype VkDebugReportObjectTypeEXT = VkDebugReportObjectTypeEXT Int32
+  deriving (Eq, Storable)
+
+instance Show VkDebugReportObjectTypeEXT where
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"
+  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"
+  showsPrec p (VkDebugReportObjectTypeEXT x) = showParen (p >= 11) (showString "VkDebugReportObjectTypeEXT " . showsPrec 11 x)
+
+instance Read VkDebugReportObjectTypeEXT where
+  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT)
+                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT)
+                             ] +++
+                      prec 10 (do
+                        expectP (Ident "VkDebugReportObjectTypeEXT")
+                        v <- step readPrec
+                        pure (VkDebugReportObjectTypeEXT v)
+                        )
+                    )
+
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = VkDebugReportObjectTypeEXT 0
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = VkDebugReportObjectTypeEXT 1
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = VkDebugReportObjectTypeEXT 2
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = VkDebugReportObjectTypeEXT 3
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = VkDebugReportObjectTypeEXT 4
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = VkDebugReportObjectTypeEXT 5
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = VkDebugReportObjectTypeEXT 6
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = VkDebugReportObjectTypeEXT 7
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = VkDebugReportObjectTypeEXT 8
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = VkDebugReportObjectTypeEXT 9
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = VkDebugReportObjectTypeEXT 10
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = VkDebugReportObjectTypeEXT 11
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = VkDebugReportObjectTypeEXT 12
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = VkDebugReportObjectTypeEXT 13
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = VkDebugReportObjectTypeEXT 14
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = VkDebugReportObjectTypeEXT 15
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = VkDebugReportObjectTypeEXT 16
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = VkDebugReportObjectTypeEXT 17
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = VkDebugReportObjectTypeEXT 18
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = VkDebugReportObjectTypeEXT 19
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = VkDebugReportObjectTypeEXT 20
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = VkDebugReportObjectTypeEXT 21
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = VkDebugReportObjectTypeEXT 22
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = VkDebugReportObjectTypeEXT 23
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = VkDebugReportObjectTypeEXT 24
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = VkDebugReportObjectTypeEXT 25
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = VkDebugReportObjectTypeEXT 26
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = VkDebugReportObjectTypeEXT 27
+
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = VkDebugReportObjectTypeEXT 28
+
+-- ** VkDebugReportErrorEXT
+
+newtype VkDebugReportErrorEXT = VkDebugReportErrorEXT Int32
+  deriving (Eq, Storable)
+
+instance Show VkDebugReportErrorEXT where
+  showsPrec _ VK_DEBUG_REPORT_ERROR_NONE_EXT = showString "VK_DEBUG_REPORT_ERROR_NONE_EXT"
+  showsPrec _ VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = showString "VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT"
+  showsPrec p (VkDebugReportErrorEXT x) = showParen (p >= 11) (showString "VkDebugReportErrorEXT " . showsPrec 11 x)
+
+instance Read VkDebugReportErrorEXT where
+  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_ERROR_NONE_EXT", pure VK_DEBUG_REPORT_ERROR_NONE_EXT)
+                             , ("VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT", pure VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT)
+                             ] +++
+                      prec 10 (do
+                        expectP (Ident "VkDebugReportErrorEXT")
+                        v <- step readPrec
+                        pure (VkDebugReportErrorEXT v)
+                        )
+                    )
+
+
+pattern VK_DEBUG_REPORT_ERROR_NONE_EXT = VkDebugReportErrorEXT 0
+
+pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = VkDebugReportErrorEXT 1
+
+
+data VkDebugReportCallbackCreateInfoEXT =
+  VkDebugReportCallbackCreateInfoEXT{ vkSType :: VkStructureType 
+                                    , vkPNext :: Ptr Void 
+                                    , vkFlags :: VkDebugReportFlagsEXT 
+                                    , vkPfnCallback :: PFN_vkDebugReportCallbackEXT 
+                                    , vkPUserData :: Ptr Void 
+                                    }
+  deriving (Eq)
+
+instance Storable VkDebugReportCallbackCreateInfoEXT where
+  sizeOf ~_ = 40
+  alignment ~_ = 8
+  peek ptr = VkDebugReportCallbackCreateInfoEXT <$> peek (ptr `plusPtr` 0)
+                                                <*> peek (ptr `plusPtr` 8)
+                                                <*> peek (ptr `plusPtr` 16)
+                                                <*> peek (ptr `plusPtr` 24)
+                                                <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 24) (vkPfnCallback (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 32) (vkPUserData (poked :: VkDebugReportCallbackCreateInfoEXT))
+
+
+-- ** vkDestroyDebugReportCallbackEXT
+foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallbackEXT ::
+  VkInstance ->
+  VkDebugReportCallbackEXT -> Ptr VkAllocationCallbacks -> IO ()
+
+-- ** VkDebugReportFlagsEXT
+-- | Opaque flag
+newtype VkDebugReportFlagsEXT = VkDebugReportFlagsEXT VkFlags
+  deriving (Eq, Storable)
+
+type PFN_vkDebugReportCallbackEXT = FunPtr
+  (VkDebugReportFlagsEXT ->
+     VkDebugReportObjectTypeEXT ->
+       Word64 ->
+         CSize ->
+           Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO VkBool32)
+
+-- ** vkCreateDebugReportCallbackEXT
+foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
+  VkInstance ->
+  Ptr VkDebugReportCallbackCreateInfoEXT ->
+    Ptr VkAllocationCallbacks ->
+      Ptr VkDebugReportCallbackEXT -> IO VkResult
+

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -1,0 +1,336 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Graphics.Vulkan.KHR.Display where
+
+import Graphics.Vulkan.Device( VkPhysicalDevice(..)
+                             )
+import Text.Read.Lex( Lexeme(Ident)
+                    )
+import GHC.Read( expectP
+               , choose
+               )
+import Data.Word( Word64
+                , Word32
+                )
+import Foreign.Ptr( Ptr
+                  , plusPtr
+                  )
+import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR(..)
+                                  , VkSurfaceTransformFlagsKHR(..)
+                                  , VkSurfaceKHR(..)
+                                  )
+import Data.Int( Int32
+               )
+import Data.Bits( Bits
+                , FiniteBits
+                )
+import Foreign.Storable( Storable(..)
+                       )
+import Data.Void( Void
+                )
+import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
+                             , PFN_vkAllocationFunction
+                             , PFN_vkReallocationFunction
+                             , PFN_vkInternalAllocationNotification
+                             , VkAllocationCallbacks(..)
+                             , VkSystemAllocationScope(..)
+                             , PFN_vkFreeFunction
+                             , PFN_vkInternalFreeNotification
+                             )
+import Text.Read( Read(..)
+                , parens
+                )
+import Text.ParserCombinators.ReadPrec( prec
+                                      , (+++)
+                                      , step
+                                      )
+import Graphics.Vulkan.DeviceInitialization( VkInstance(..)
+                                           )
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkBool32(..)
+                           , VkExtent2D(..)
+                           , VkFlags(..)
+                           , VkOffset2D(..)
+                           , VkStructureType(..)
+                           )
+import Foreign.C.Types( CFloat
+                      , CFloat(..)
+                      , CChar
+                      , CSize(..)
+                      )
+
+
+data VkDisplaySurfaceCreateInfoKHR =
+  VkDisplaySurfaceCreateInfoKHR{ vkSType :: VkStructureType 
+                               , vkPNext :: Ptr Void 
+                               , vkFlags :: VkDisplaySurfaceCreateFlagsKHR 
+                               , vkDisplayMode :: VkDisplayModeKHR 
+                               , vkPlaneIndex :: Word32 
+                               , vkPlaneStackIndex :: Word32 
+                               , vkTransform :: VkSurfaceTransformFlagBitsKHR 
+                               , vkGlobalAlpha :: CFloat 
+                               , vkAlphaMode :: VkDisplayPlaneAlphaFlagBitsKHR 
+                               , vkImageExtent :: VkExtent2D 
+                               }
+  deriving (Eq)
+
+instance Storable VkDisplaySurfaceCreateInfoKHR where
+  sizeOf ~_ = 64
+  alignment ~_ = 8
+  peek ptr = VkDisplaySurfaceCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 8)
+                                           <*> peek (ptr `plusPtr` 16)
+                                           <*> peek (ptr `plusPtr` 24)
+                                           <*> peek (ptr `plusPtr` 32)
+                                           <*> peek (ptr `plusPtr` 36)
+                                           <*> peek (ptr `plusPtr` 40)
+                                           <*> peek (ptr `plusPtr` 44)
+                                           <*> peek (ptr `plusPtr` 48)
+                                           <*> peek (ptr `plusPtr` 52)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (vkDisplayMode (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (vkPlaneIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (vkPlaneStackIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (vkTransform (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (vkGlobalAlpha (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 48) (vkAlphaMode (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (vkImageExtent (poked :: VkDisplaySurfaceCreateInfoKHR))
+
+
+
+data VkDisplayPlaneCapabilitiesKHR =
+  VkDisplayPlaneCapabilitiesKHR{ vkSupportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
+                               , vkMinSrcPosition :: VkOffset2D 
+                               , vkMaxSrcPosition :: VkOffset2D 
+                               , vkMinSrcExtent :: VkExtent2D 
+                               , vkMaxSrcExtent :: VkExtent2D 
+                               , vkMinDstPosition :: VkOffset2D 
+                               , vkMaxDstPosition :: VkOffset2D 
+                               , vkMinDstExtent :: VkExtent2D 
+                               , vkMaxDstExtent :: VkExtent2D 
+                               }
+  deriving (Eq)
+
+instance Storable VkDisplayPlaneCapabilitiesKHR where
+  sizeOf ~_ = 68
+  alignment ~_ = 4
+  peek ptr = VkDisplayPlaneCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 4)
+                                           <*> peek (ptr `plusPtr` 12)
+                                           <*> peek (ptr `plusPtr` 20)
+                                           <*> peek (ptr `plusPtr` 28)
+                                           <*> peek (ptr `plusPtr` 36)
+                                           <*> peek (ptr `plusPtr` 44)
+                                           <*> peek (ptr `plusPtr` 52)
+                                           <*> peek (ptr `plusPtr` 60)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSupportedAlpha (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 4) (vkMinSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 12) (vkMaxSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 20) (vkMinSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 28) (vkMaxSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 36) (vkMinDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 44) (vkMaxDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 52) (vkMinDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 60) (vkMaxDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+
+
+-- ** vkGetDisplayModePropertiesKHR
+foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
+  VkPhysicalDevice ->
+  VkDisplayKHR ->
+    Ptr Word32 -> Ptr VkDisplayModePropertiesKHR -> IO VkResult
+
+
+data VkDisplayPropertiesKHR =
+  VkDisplayPropertiesKHR{ vkDisplay :: VkDisplayKHR 
+                        , vkDisplayName :: Ptr CChar 
+                        , vkPhysicalDimensions :: VkExtent2D 
+                        , vkPhysicalResolution :: VkExtent2D 
+                        , vkSupportedTransforms :: VkSurfaceTransformFlagsKHR 
+                        , vkPlaneReorderPossible :: VkBool32 
+                        , vkPersistentContent :: VkBool32 
+                        }
+  deriving (Eq)
+
+instance Storable VkDisplayPropertiesKHR where
+  sizeOf ~_ = 48
+  alignment ~_ = 8
+  peek ptr = VkDisplayPropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 24)
+                                    <*> peek (ptr `plusPtr` 32)
+                                    <*> peek (ptr `plusPtr` 36)
+                                    <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkDisplay (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (vkDisplayName (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 16) (vkPhysicalDimensions (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 24) (vkPhysicalResolution (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 32) (vkSupportedTransforms (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 36) (vkPlaneReorderPossible (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 40) (vkPersistentContent (poked :: VkDisplayPropertiesKHR))
+
+
+-- ** vkGetDisplayPlaneSupportedDisplaysKHR
+foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSupportedDisplaysKHR ::
+  VkPhysicalDevice ->
+  Word32 -> Ptr Word32 -> Ptr VkDisplayKHR -> IO VkResult
+
+-- ** vkCreateDisplayModeKHR
+foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
+  VkPhysicalDevice ->
+  VkDisplayKHR ->
+    Ptr VkDisplayModeCreateInfoKHR ->
+      Ptr VkAllocationCallbacks -> Ptr VkDisplayModeKHR -> IO VkResult
+
+
+data VkDisplayPlanePropertiesKHR =
+  VkDisplayPlanePropertiesKHR{ vkCurrentDisplay :: VkDisplayKHR 
+                             , vkCurrentStackIndex :: Word32 
+                             }
+  deriving (Eq)
+
+instance Storable VkDisplayPlanePropertiesKHR where
+  sizeOf ~_ = 16
+  alignment ~_ = 8
+  peek ptr = VkDisplayPlanePropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                         <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkCurrentDisplay (poked :: VkDisplayPlanePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (vkCurrentStackIndex (poked :: VkDisplayPlanePropertiesKHR))
+
+
+-- ** vkGetDisplayPlaneCapabilitiesKHR
+foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" vkGetDisplayPlaneCapabilitiesKHR ::
+  VkPhysicalDevice ->
+  VkDisplayModeKHR ->
+    Word32 -> Ptr VkDisplayPlaneCapabilitiesKHR -> IO VkResult
+
+
+data VkDisplayModePropertiesKHR =
+  VkDisplayModePropertiesKHR{ vkDisplayMode :: VkDisplayModeKHR 
+                            , vkParameters :: VkDisplayModeParametersKHR 
+                            }
+  deriving (Eq)
+
+instance Storable VkDisplayModePropertiesKHR where
+  sizeOf ~_ = 24
+  alignment ~_ = 8
+  peek ptr = VkDisplayModePropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkDisplayMode (poked :: VkDisplayModePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (vkParameters (poked :: VkDisplayModePropertiesKHR))
+
+
+-- ** VkDisplayPlaneAlphaFlagsKHR
+
+newtype VkDisplayPlaneAlphaFlagBitsKHR = VkDisplayPlaneAlphaFlagBitsKHR VkFlags
+  deriving (Eq, Storable, Bits, FiniteBits)
+
+-- | Alias for VkDisplayPlaneAlphaFlagBitsKHR
+type VkDisplayPlaneAlphaFlagsKHR = VkDisplayPlaneAlphaFlagBitsKHR
+
+instance Show VkDisplayPlaneAlphaFlagBitsKHR where
+  showsPrec _ VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR"
+  showsPrec _ VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR"
+  showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR"
+  showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR"
+  
+  showsPrec p (VkDisplayPlaneAlphaFlagBitsKHR x) = showParen (p >= 11) (showString "VkDisplayPlaneAlphaFlagBitsKHR " . showsPrec 11 x)
+
+instance Read VkDisplayPlaneAlphaFlagBitsKHR where
+  readPrec = parens ( choose [ ("VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
+                             , ("VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
+                             , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
+                             , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
+                             ] +++
+                      prec 10 (do
+                        expectP (Ident "VkDisplayPlaneAlphaFlagBitsKHR")
+                        v <- step readPrec
+                        pure (VkDisplayPlaneAlphaFlagBitsKHR v)
+                        )
+                    )
+
+
+pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x1
+
+pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x2
+
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x4
+
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x8
+
+
+-- ** VkDisplayModeCreateFlagsKHR
+-- | Opaque flag
+newtype VkDisplayModeCreateFlagsKHR = VkDisplayModeCreateFlagsKHR VkFlags
+  deriving (Eq, Storable)
+
+
+data VkDisplayModeCreateInfoKHR =
+  VkDisplayModeCreateInfoKHR{ vkSType :: VkStructureType 
+                            , vkPNext :: Ptr Void 
+                            , vkFlags :: VkDisplayModeCreateFlagsKHR 
+                            , vkParameters :: VkDisplayModeParametersKHR 
+                            }
+  deriving (Eq)
+
+instance Storable VkDisplayModeCreateInfoKHR where
+  sizeOf ~_ = 32
+  alignment ~_ = 8
+  peek ptr = VkDisplayModeCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 16)
+                                        <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 20) (vkParameters (poked :: VkDisplayModeCreateInfoKHR))
+
+
+-- ** vkGetPhysicalDeviceDisplayPlanePropertiesKHR
+foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" vkGetPhysicalDeviceDisplayPlanePropertiesKHR ::
+  VkPhysicalDevice ->
+  Ptr Word32 -> Ptr VkDisplayPlanePropertiesKHR -> IO VkResult
+
+newtype VkDisplayModeKHR = VkDisplayModeKHR Word64
+  deriving (Eq, Storable)
+
+
+data VkDisplayModeParametersKHR =
+  VkDisplayModeParametersKHR{ vkVisibleRegion :: VkExtent2D 
+                            , vkRefreshRate :: Word32 
+                            }
+  deriving (Eq)
+
+instance Storable VkDisplayModeParametersKHR where
+  sizeOf ~_ = 12
+  alignment ~_ = 4
+  peek ptr = VkDisplayModeParametersKHR <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkVisibleRegion (poked :: VkDisplayModeParametersKHR))
+                *> poke (ptr `plusPtr` 8) (vkRefreshRate (poked :: VkDisplayModeParametersKHR))
+
+
+-- ** VkDisplaySurfaceCreateFlagsKHR
+-- | Opaque flag
+newtype VkDisplaySurfaceCreateFlagsKHR = VkDisplaySurfaceCreateFlagsKHR VkFlags
+  deriving (Eq, Storable)
+
+newtype VkDisplayKHR = VkDisplayKHR Word64
+  deriving (Eq, Storable)
+
+-- ** vkGetPhysicalDeviceDisplayPropertiesKHR
+foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" vkGetPhysicalDeviceDisplayPropertiesKHR ::
+  VkPhysicalDevice ->
+  Ptr Word32 -> Ptr VkDisplayPropertiesKHR -> IO VkResult
+
+-- ** vkCreateDisplayPlaneSurfaceKHR
+foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" vkCreateDisplayPlaneSurfaceKHR ::
+  VkInstance ->
+  Ptr VkDisplaySurfaceCreateInfoKHR ->
+    Ptr VkAllocationCallbacks -> Ptr VkSurfaceKHR -> IO VkResult
+

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
+module Graphics.Vulkan.KHR.DisplaySwapchain where
+
+import Graphics.Vulkan.Device( VkDevice(..)
+                             )
+import Graphics.Vulkan.KHR.Swapchain( VkSwapchainKHR(..)
+                                    , VkSwapchainCreateInfoKHR(..)
+                                    , VkSwapchainCreateFlagsKHR(..)
+                                    )
+import Data.Word( Word64
+                , Word32
+                )
+import Foreign.Ptr( Ptr
+                  , plusPtr
+                  )
+import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
+                                  , VkSurfaceTransformFlagBitsKHR(..)
+                                  , VkPresentModeKHR(..)
+                                  , VkCompositeAlphaFlagBitsKHR(..)
+                                  , VkSurfaceKHR(..)
+                                  )
+import Data.Int( Int32
+               )
+import Foreign.Storable( Storable(..)
+                       )
+import Data.Void( Void
+                )
+import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
+                             , PFN_vkAllocationFunction
+                             , PFN_vkReallocationFunction
+                             , PFN_vkInternalAllocationNotification
+                             , VkAllocationCallbacks(..)
+                             , VkSystemAllocationScope(..)
+                             , PFN_vkFreeFunction
+                             , PFN_vkInternalFreeNotification
+                             )
+import Graphics.Vulkan.Image( VkImageUsageFlags(..)
+                            , VkImageUsageFlagBits(..)
+                            )
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkBool32(..)
+                           , VkExtent2D(..)
+                           , VkFlags(..)
+                           , VkFormat(..)
+                           , VkOffset2D(..)
+                           , VkRect2D(..)
+                           , VkStructureType(..)
+                           , VkSharingMode(..)
+                           )
+import Foreign.C.Types( CSize(..)
+                      )
+
+
+data VkDisplayPresentInfoKHR =
+  VkDisplayPresentInfoKHR{ vkSType :: VkStructureType 
+                         , vkPNext :: Ptr Void 
+                         , vkSrcRect :: VkRect2D 
+                         , vkDstRect :: VkRect2D 
+                         , vkPersistent :: VkBool32 
+                         }
+  deriving (Eq)
+
+instance Storable VkDisplayPresentInfoKHR where
+  sizeOf ~_ = 56
+  alignment ~_ = 8
+  peek ptr = VkDisplayPresentInfoKHR <$> peek (ptr `plusPtr` 0)
+                                     <*> peek (ptr `plusPtr` 8)
+                                     <*> peek (ptr `plusPtr` 16)
+                                     <*> peek (ptr `plusPtr` 32)
+                                     <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (vkSrcRect (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (vkDstRect (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (vkPersistent (poked :: VkDisplayPresentInfoKHR))
+
+
+-- ** vkCreateSharedSwapchainsKHR
+foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR ::
+  VkDevice ->
+  Word32 ->
+    Ptr VkSwapchainCreateInfoKHR ->
+      Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
+

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -1,0 +1,184 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Graphics.Vulkan.KHR.Swapchain where
+
+import Graphics.Vulkan.Device( VkDevice(..)
+                             )
+import Data.Word( Word64
+                , Word32
+                )
+import Foreign.Ptr( Ptr
+                  , plusPtr
+                  )
+import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
+                                  , VkSurfaceTransformFlagBitsKHR(..)
+                                  , VkPresentModeKHR(..)
+                                  , VkCompositeAlphaFlagBitsKHR(..)
+                                  , VkSurfaceKHR(..)
+                                  )
+import Graphics.Vulkan.Queue( VkQueue(..)
+                            )
+import Foreign.Storable( Storable(..)
+                       )
+import Graphics.Vulkan.Fence( VkFence(..)
+                            )
+import Data.Void( Void
+                )
+import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
+                             , PFN_vkAllocationFunction
+                             , PFN_vkReallocationFunction
+                             , PFN_vkInternalAllocationNotification
+                             , VkAllocationCallbacks(..)
+                             , VkSystemAllocationScope(..)
+                             , PFN_vkFreeFunction
+                             , PFN_vkInternalFreeNotification
+                             )
+import Graphics.Vulkan.Image( VkImageUsageFlags(..)
+                            , VkImage(..)
+                            , VkImageUsageFlagBits(..)
+                            )
+import Graphics.Vulkan.QueueSemaphore( VkSemaphore(..)
+                                     )
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkBool32(..)
+                           , VkExtent2D(..)
+                           , VkFlags(..)
+                           , VkFormat(..)
+                           , VkStructureType(..)
+                           , VkSharingMode(..)
+                           )
+import Foreign.C.Types( CSize(..)
+                      )
+
+
+data VkSwapchainCreateInfoKHR =
+  VkSwapchainCreateInfoKHR{ vkSType :: VkStructureType 
+                          , vkPNext :: Ptr Void 
+                          , vkFlags :: VkSwapchainCreateFlagsKHR 
+                          , vkSurface :: VkSurfaceKHR 
+                          , vkMinImageCount :: Word32 
+                          , vkImageFormat :: VkFormat 
+                          , vkImageColorSpace :: VkColorSpaceKHR 
+                          , vkImageExtent :: VkExtent2D 
+                          , vkImageArrayLayers :: Word32 
+                          , vkImageUsage :: VkImageUsageFlags 
+                          , vkImageSharingMode :: VkSharingMode 
+                          , vkQueueFamilyIndexCount :: Word32 
+                          , vkPQueueFamilyIndices :: Ptr Word32 
+                          , vkPreTransform :: VkSurfaceTransformFlagBitsKHR 
+                          , vkCompositeAlpha :: VkCompositeAlphaFlagBitsKHR 
+                          , vkPresentMode :: VkPresentModeKHR 
+                          , vkClipped :: VkBool32 
+                          , vkOldSwapchain :: VkSwapchainKHR 
+                          }
+  deriving (Eq)
+
+instance Storable VkSwapchainCreateInfoKHR where
+  sizeOf ~_ = 104
+  alignment ~_ = 8
+  peek ptr = VkSwapchainCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 24)
+                                      <*> peek (ptr `plusPtr` 32)
+                                      <*> peek (ptr `plusPtr` 36)
+                                      <*> peek (ptr `plusPtr` 40)
+                                      <*> peek (ptr `plusPtr` 44)
+                                      <*> peek (ptr `plusPtr` 52)
+                                      <*> peek (ptr `plusPtr` 56)
+                                      <*> peek (ptr `plusPtr` 60)
+                                      <*> peek (ptr `plusPtr` 64)
+                                      <*> peek (ptr `plusPtr` 72)
+                                      <*> peek (ptr `plusPtr` 80)
+                                      <*> peek (ptr `plusPtr` 84)
+                                      <*> peek (ptr `plusPtr` 88)
+                                      <*> peek (ptr `plusPtr` 92)
+                                      <*> peek (ptr `plusPtr` 96)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (vkSurface (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (vkMinImageCount (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (vkImageFormat (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (vkImageColorSpace (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (vkImageExtent (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (vkImageArrayLayers (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 56) (vkImageUsage (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 60) (vkImageSharingMode (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 64) (vkQueueFamilyIndexCount (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 72) (vkPQueueFamilyIndices (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 80) (vkPreTransform (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 84) (vkCompositeAlpha (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 88) (vkPresentMode (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 92) (vkClipped (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 96) (vkOldSwapchain (poked :: VkSwapchainCreateInfoKHR))
+
+
+-- ** vkGetSwapchainImagesKHR
+foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
+  VkDevice ->
+  VkSwapchainKHR -> Ptr Word32 -> Ptr VkImage -> IO VkResult
+
+-- ** vkDestroySwapchainKHR
+foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
+  VkDevice -> VkSwapchainKHR -> Ptr VkAllocationCallbacks -> IO ()
+
+-- ** vkQueuePresentKHR
+foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
+  VkQueue -> Ptr VkPresentInfoKHR -> IO VkResult
+
+-- ** VkSwapchainCreateFlagsKHR
+-- | Opaque flag
+newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
+  deriving (Eq, Storable)
+
+-- ** vkCreateSwapchainKHR
+foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
+  VkDevice ->
+  Ptr VkSwapchainCreateInfoKHR ->
+    Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
+
+-- ** vkAcquireNextImageKHR
+foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
+  VkDevice ->
+  VkSwapchainKHR ->
+    Word64 -> VkSemaphore -> VkFence -> Ptr Word32 -> IO VkResult
+
+
+data VkPresentInfoKHR =
+  VkPresentInfoKHR{ vkSType :: VkStructureType 
+                  , vkPNext :: Ptr Void 
+                  , vkWaitSemaphoreCount :: Word32 
+                  , vkPWaitSemaphores :: Ptr VkSemaphore 
+                  , vkSwapchainCount :: Word32 
+                  , vkPSwapchains :: Ptr VkSwapchainKHR 
+                  , vkPImageIndices :: Ptr Word32 
+                  , vkPResults :: Ptr VkResult 
+                  }
+  deriving (Eq)
+
+instance Storable VkPresentInfoKHR where
+  sizeOf ~_ = 64
+  alignment ~_ = 8
+  peek ptr = VkPresentInfoKHR <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 8)
+                              <*> peek (ptr `plusPtr` 16)
+                              <*> peek (ptr `plusPtr` 24)
+                              <*> peek (ptr `plusPtr` 32)
+                              <*> peek (ptr `plusPtr` 40)
+                              <*> peek (ptr `plusPtr` 48)
+                              <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (vkWaitSemaphoreCount (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 24) (vkPWaitSemaphores (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (vkSwapchainCount (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 40) (vkPSwapchains (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (vkPImageIndices (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 56) (vkPResults (poked :: VkPresentInfoKHR))
+
+
+newtype VkSwapchainKHR = VkSwapchainKHR Word64
+  deriving (Eq, Storable)
+


### PR DESCRIPTION
What do you think about this?  I was only really looking for the KHR extensions, but it seems safe.  I could also just whitelist the KHR ones...

I'm doing WSI through SDL + a C lib I wrote (SDL_vulkan), so this is enough to get a surface/swapchain up.
