### PR TITLE
Allow digits in struct member names

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.7.0.0] - 2016-04-13
+  - Fix struct member names containing digits being erroneously truncated
+
 ## [1.6.0.0] - 2016-03-30
   - Add DebugReport, Display, DisplaySwapchain and Swapchain extension modules
 

--- a/generate/generate.cabal
+++ b/generate/generate.cabal
@@ -52,6 +52,7 @@ executable generate
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:       base >= 4.8 && < 4.9
                      , cpphs >= 1.19 && < 1.21
+                     , control-bool >= 0.2.1
                      , directory >= 1.2 && < 1.3
                      , filepath >= 1.4 && < 1.5
                      , hashable >= 1.2 && < 1.3

--- a/generate/src/Parse/Type.hs
+++ b/generate/src/Parse/Type.hs
@@ -13,6 +13,7 @@ import           Parse.Utils
 import           Spec.Type
 import           Text.Regex.TDFA   ((=~))
 import           Text.XML.HXT.Core
+import           Control.Bool ((<||>))
 
 parseTypes :: ParseArrow XmlTree [TypeDecl]
 parseTypes = extractFields "type decls" (hasName "types") extract
@@ -210,7 +211,7 @@ parseMember = extractFields "struct member"
 -- In VkImageBlit "srcOffsets" is "srcOffsets[2]" and "dstOffsets" is
 -- "dstOffsets[2]"
 memberNameWorkarounds :: String -> String
-memberNameWorkarounds = takeWhile (isAlpha \|| isDigit \|| (=='_'))
+memberNameWorkarounds = takeWhile (isAlpha <||> isDigit <||> (=='_'))
 
 inCategory :: ArrowXml a => String -> a XmlTree XmlTree
 inCategory s = hasAttrValue "category" (==s)

--- a/generate/src/Parse/Type.hs
+++ b/generate/src/Parse/Type.hs
@@ -6,7 +6,7 @@ module Parse.Type
   ( parseTypes
   ) where
 
-import           Data.Char         (isAlpha,isDigit)
+import           Data.Char         (isAlpha, isDigit)
 import           Parse.CType
 import           Parse.State
 import           Parse.Utils

--- a/generate/src/Parse/Type.hs
+++ b/generate/src/Parse/Type.hs
@@ -6,7 +6,7 @@ module Parse.Type
   ( parseTypes
   ) where
 
-import           Data.Char         (isAlpha)
+import           Data.Char         (isAlpha,isDigit)
 import           Parse.CType
 import           Parse.State
 import           Parse.Utils
@@ -210,7 +210,7 @@ parseMember = extractFields "struct member"
 -- In VkImageBlit "srcOffsets" is "srcOffsets[2]" and "dstOffsets" is
 -- "dstOffsets[2]"
 memberNameWorkarounds :: String -> String
-memberNameWorkarounds = takeWhile ((||) <$> isAlpha <*> (=='_'))
+memberNameWorkarounds = takeWhile (isAlpha \|| isDigit \|| (=='_'))
 
 inCategory :: ArrowXml a => String -> a XmlTree XmlTree
 inCategory s = hasAttrValue "category" (==s)

--- a/generate/src/Parse/Type.hs
+++ b/generate/src/Parse/Type.hs
@@ -6,6 +6,7 @@ module Parse.Type
   ( parseTypes
   ) where
 
+import           Control.Bool      ((<||>))
 import           Data.Char         (isAlpha, isDigit)
 import           Parse.CType
 import           Parse.State
@@ -13,7 +14,6 @@ import           Parse.Utils
 import           Spec.Type
 import           Text.Regex.TDFA   ((=~))
 import           Text.XML.HXT.Core
-import           Control.Bool ((<||>))
 
 parseTypes :: ParseArrow XmlTree [TypeDecl]
 parseTypes = extractFields "type decls" (hasName "types") extract

--- a/generate/src/Parse/Utils.hs
+++ b/generate/src/Parse/Utils.hs
@@ -30,7 +30,6 @@ module Parse.Utils
   , stripL
   , stripR
   , stripLines
-  , (\||)
   ) where
 
 import           Data.Char         (isSpace)
@@ -166,8 +165,3 @@ stripR = reverse . stripL . reverse
 
 stripLines :: String -> String
 stripLines = unlines . fmap strip . lines
-
--- | Make a predicate that returns True if either of the predicates is True
-infixr 2 \||
-(\||) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
-f \|| g = \x -> f x || g x

--- a/generate/src/Parse/Utils.hs
+++ b/generate/src/Parse/Utils.hs
@@ -30,6 +30,7 @@ module Parse.Utils
   , stripL
   , stripR
   , stripLines
+  , (\||)
   ) where
 
 import           Data.Char         (isSpace)
@@ -165,3 +166,8 @@ stripR = reverse . stripL . reverse
 
 stripLines :: String -> String
 stripLines = unlines . fmap strip . lines
+
+-- | Make a predicate that returns True if either of the predicates is True
+infixr 2 \||
+(\||) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
+f \|| g = \x -> f x || g x

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -550,9 +550,9 @@ pattern VK_STENCIL_FACE_BACK_BIT = VkStencilFaceFlagBits 0x2
 pattern VK_STENCIL_FRONT_AND_BACK = VkStencilFaceFlagBits 0x3
 
 -- | // Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.
-data VkClearColorValue = VkFloat (Vector 4 CFloat) 
-                       | VkInt (Vector 4 Int32) 
-                       | VkUint (Vector 4 Word32) 
+data VkClearColorValue = VkFloat32 (Vector 4 CFloat) 
+                       | VkInt32 (Vector 4 Int32) 
+                       | VkUint32 (Vector 4 Word32) 
   deriving (Eq)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
@@ -561,9 +561,9 @@ instance Storable VkClearColorValue where
   alignment ~_ = 4
   peek ~_ = error "peek@VkClearColorValue"
   poke ptr poked = case poked of
-                     VkFloat e -> poke (castPtr ptr) e
-                     VkInt e -> poke (castPtr ptr) e
-                     VkUint e -> poke (castPtr ptr) e
+                     VkFloat32 e -> poke (castPtr ptr) e
+                     VkInt32 e -> poke (castPtr ptr) e
+                     VkUint32 e -> poke (castPtr ptr) e
 
 
 -- ** VkSubpassContents

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -41,7 +41,7 @@ foreign import ccall "vkCreateDevice" vkCreateDevice ::
 
 data VkPhysicalDeviceFeatures =
   VkPhysicalDeviceFeatures{ vkRobustBufferAccess :: VkBool32 
-                          , vkFullDrawIndexUint :: VkBool32 
+                          , vkFullDrawIndexUint32 :: VkBool32 
                           , vkImageCubeArray :: VkBool32 
                           , vkIndependentBlend :: VkBool32 
                           , vkGeometryShader :: VkBool32 
@@ -60,7 +60,7 @@ data VkPhysicalDeviceFeatures =
                           , vkAlphaToOne :: VkBool32 
                           , vkMultiViewport :: VkBool32 
                           , vkSamplerAnisotropy :: VkBool32 
-                          , vkTextureCompressionETC :: VkBool32 
+                          , vkTextureCompressionETC2 :: VkBool32 
                           , vkTextureCompressionASTC_LDR :: VkBool32 
                           , vkTextureCompressionBC :: VkBool32 
                           , vkOcclusionQueryPrecise :: VkBool32 
@@ -79,19 +79,19 @@ data VkPhysicalDeviceFeatures =
                           , vkShaderStorageImageArrayDynamicIndexing :: VkBool32 
                           , vkShaderClipDistance :: VkBool32 
                           , vkShaderCullDistance :: VkBool32 
-                          , vkShaderFloat :: VkBool32 
-                          , vkShaderInt :: VkBool32 
-                          , vkShaderInt :: VkBool32 
+                          , vkShaderFloat64 :: VkBool32 
+                          , vkShaderInt64 :: VkBool32 
+                          , vkShaderInt16 :: VkBool32 
                           , vkShaderResourceResidency :: VkBool32 
                           , vkShaderResourceMinLod :: VkBool32 
                           , vkSparseBinding :: VkBool32 
                           , vkSparseResidencyBuffer :: VkBool32 
-                          , vkSparseResidencyImage :: VkBool32 
-                          , vkSparseResidencyImage :: VkBool32 
-                          , vkSparseResidency :: VkBool32 
-                          , vkSparseResidency :: VkBool32 
-                          , vkSparseResidency :: VkBool32 
-                          , vkSparseResidency :: VkBool32 
+                          , vkSparseResidencyImage2D :: VkBool32 
+                          , vkSparseResidencyImage3D :: VkBool32 
+                          , vkSparseResidency2Samples :: VkBool32 
+                          , vkSparseResidency4Samples :: VkBool32 
+                          , vkSparseResidency8Samples :: VkBool32 
+                          , vkSparseResidency16Samples :: VkBool32 
                           , vkSparseResidencyAliased :: VkBool32 
                           , vkVariableMultisampleRate :: VkBool32 
                           , vkInheritedQueries :: VkBool32 
@@ -157,7 +157,7 @@ instance Storable VkPhysicalDeviceFeatures where
                                       <*> peek (ptr `plusPtr` 212)
                                       <*> peek (ptr `plusPtr` 216)
   poke ptr poked = poke (ptr `plusPtr` 0) (vkRobustBufferAccess (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 4) (vkFullDrawIndexUint (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 4) (vkFullDrawIndexUint32 (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 8) (vkImageCubeArray (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 12) (vkIndependentBlend (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 16) (vkGeometryShader (poked :: VkPhysicalDeviceFeatures))
@@ -176,7 +176,7 @@ instance Storable VkPhysicalDeviceFeatures where
                 *> poke (ptr `plusPtr` 68) (vkAlphaToOne (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 72) (vkMultiViewport (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 76) (vkSamplerAnisotropy (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 80) (vkTextureCompressionETC (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 80) (vkTextureCompressionETC2 (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 84) (vkTextureCompressionASTC_LDR (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 88) (vkTextureCompressionBC (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 92) (vkOcclusionQueryPrecise (poked :: VkPhysicalDeviceFeatures))
@@ -195,19 +195,19 @@ instance Storable VkPhysicalDeviceFeatures where
                 *> poke (ptr `plusPtr` 144) (vkShaderStorageImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 148) (vkShaderClipDistance (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 152) (vkShaderCullDistance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 156) (vkShaderFloat (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 160) (vkShaderInt (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 164) (vkShaderInt (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 156) (vkShaderFloat64 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 160) (vkShaderInt64 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 164) (vkShaderInt16 (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 168) (vkShaderResourceResidency (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 172) (vkShaderResourceMinLod (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 176) (vkSparseBinding (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 180) (vkSparseResidencyBuffer (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 184) (vkSparseResidencyImage (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 188) (vkSparseResidencyImage (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 192) (vkSparseResidency (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 196) (vkSparseResidency (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 200) (vkSparseResidency (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 204) (vkSparseResidency (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 184) (vkSparseResidencyImage2D (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 188) (vkSparseResidencyImage3D (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 192) (vkSparseResidency2Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 196) (vkSparseResidency4Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 200) (vkSparseResidency8Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 204) (vkSparseResidency16Samples (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 208) (vkSparseResidencyAliased (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 212) (vkVariableMultisampleRate (poked :: VkPhysicalDeviceFeatures))
                 *> poke (ptr `plusPtr` 216) (vkInheritedQueries (poked :: VkPhysicalDeviceFeatures))

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -195,9 +195,9 @@ instance Storable VkApplicationInfo where
 
 
 data VkPhysicalDeviceLimits =
-  VkPhysicalDeviceLimits{ vkMaxImageDimension :: Word32 
-                        , vkMaxImageDimension :: Word32 
-                        , vkMaxImageDimension :: Word32 
+  VkPhysicalDeviceLimits{ vkMaxImageDimension1D :: Word32 
+                        , vkMaxImageDimension2D :: Word32 
+                        , vkMaxImageDimension3D :: Word32 
                         , vkMaxImageDimensionCube :: Word32 
                         , vkMaxImageArrayLayers :: Word32 
                         , vkMaxTexelBufferElements :: Word32 
@@ -413,9 +413,9 @@ instance Storable VkPhysicalDeviceLimits where
                                     <*> peek (ptr `plusPtr` 480)
                                     <*> peek (ptr `plusPtr` 488)
                                     <*> peek (ptr `plusPtr` 496)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMaxImageDimension (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 4) (vkMaxImageDimension (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 8) (vkMaxImageDimension (poked :: VkPhysicalDeviceLimits))
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkMaxImageDimension1D (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 4) (vkMaxImageDimension2D (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 8) (vkMaxImageDimension3D (poked :: VkPhysicalDeviceLimits))
                 *> poke (ptr `plusPtr` 12) (vkMaxImageDimensionCube (poked :: VkPhysicalDeviceLimits))
                 *> poke (ptr `plusPtr` 16) (vkMaxImageArrayLayers (poked :: VkPhysicalDeviceLimits))
                 *> poke (ptr `plusPtr` 20) (vkMaxTexelBufferElements (poked :: VkPhysicalDeviceLimits))
@@ -726,9 +726,9 @@ instance Storable VkImageFormatProperties where
 
 
 data VkPhysicalDeviceSparseProperties =
-  VkPhysicalDeviceSparseProperties{ vkResidencyStandard :: VkBool32 
-                                  , vkResidencyStandard :: VkBool32 
-                                  , vkResidencyStandard :: VkBool32 
+  VkPhysicalDeviceSparseProperties{ vkResidencyStandard2DBlockShape :: VkBool32 
+                                  , vkResidencyStandard2DMultisampleBlockShape :: VkBool32 
+                                  , vkResidencyStandard3DBlockShape :: VkBool32 
                                   , vkResidencyAlignedMipSize :: VkBool32 
                                   , vkResidencyNonResidentStrict :: VkBool32 
                                   }
@@ -742,9 +742,9 @@ instance Storable VkPhysicalDeviceSparseProperties where
                                               <*> peek (ptr `plusPtr` 8)
                                               <*> peek (ptr `plusPtr` 12)
                                               <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkResidencyStandard (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 4) (vkResidencyStandard (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 8) (vkResidencyStandard (poked :: VkPhysicalDeviceSparseProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkResidencyStandard2DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 4) (vkResidencyStandard2DMultisampleBlockShape (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 8) (vkResidencyStandard3DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
                 *> poke (ptr `plusPtr` 12) (vkResidencyAlignedMipSize (poked :: VkPhysicalDeviceSparseProperties))
                 *> poke (ptr `plusPtr` 16) (vkResidencyNonResidentStrict (poked :: VkPhysicalDeviceSparseProperties))
 

--- a/vulkan.cabal
+++ b/vulkan.cabal
@@ -1,5 +1,5 @@
 name:                vulkan
-version:             1.6.0.0
+version:             1.7.0.0
 synopsis:            Bindings to the Vulkan graphics API.
 description:         Please see readme.md
 homepage:            http://github.com/expipiplus1/vulkan#readme


### PR DESCRIPTION
Currently you are not allowing struct members to have any digits in names which causes names like:

```
sparseResidency2Samples
sparseResidency4Samples
sparseResidency8Samples
sparseResidency16Samples
```

to be conflated into just sparseResidency, with the rest of the name string dropped. This can be fixed by simply allowing memberNameWorkarounds function to take-in digits as well. I had embarrassingly hard time trying to add another predicate only using <$> and <*> - the way it used to be, and the best I could come up with was this:

`((||) <$> ((||) <$> isAlpha <*> (=='_')) <*> isDigit)`

Bull's pizzles isn't it? Maybe you could do better, but for myself I just define a combinator function `\|| `to combine predicates together, which works similar to boolean ||, but on predicates. You could similarly define analogs for "&&" and "not":

```
infixr 3 \&&
(\&&) :: (a -> Bool) -> (a -> Bool) -> (a -> Bool)
f \&& g = \x -> f x && g x

notP :: (a -> Bool) -> (a -> Bool)
notP f = \x -> not $ f x
```

They are pretty easy to read, I don't know why this isn't in Prelude.