### PR TITLE
[WIP] Pretty names

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,2 @@
+((haskell-mode
+  (haskell-stylish-on-save . t)))

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .stack-work/
+TAGS

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 pushd generate
-stack build
+stack build $*
 rm -rf out
 cat ./Vulkan-Docs/src/spec/vk.xml | stack exec generate
 popd
 rm -rf src
 mv generate/out src
-stack build
+stack build $*

--- a/generate/generate.cabal
+++ b/generate/generate.cabal
@@ -49,7 +49,7 @@ executable generate
                      , Write.Type.FuncPointer
                      , Write.Type.Handle
                      , Write.TypeConverter
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:       base >= 4.8 && < 4.9
                      , cpphs >= 1.19 && < 1.21
                      , control-bool >= 0.2.1

--- a/generate/src/Main.hs
+++ b/generate/src/Main.hs
@@ -3,17 +3,19 @@ module Main
   ) where
 
 import           Parse.Spec
+import           Spec.Pretty
 import           Spec.StripExtensions
 import           System.Exit
 import           System.IO            (hPutStr, stderr)
 import           Write.Spec
 
 main :: IO ()
-main = do specString <- getContents
+main = do specString <- readFile "Vulkan-Docs/src/spec/vk.xml"
           specMay <- parseSpec specString
           case specMay of
             Nothing -> do hPutStr stderr "Failed to parse spec"
                           exitFailure
             Just spec -> let strippedSpec = stripExtensions spec
-                         in writeSpecModules "out" strippedSpec
+                             prettySpec = prettifySpec strippedSpec
+                         in writeSpecModules "out" prettySpec
 

--- a/generate/src/Main.hs
+++ b/generate/src/Main.hs
@@ -18,4 +18,3 @@ main = do specString <- readFile "Vulkan-Docs/src/spec/vk.xml"
             Just spec -> let strippedSpec = stripExtensions spec
                              prettySpec = prettifySpec strippedSpec
                          in writeSpecModules "out" prettySpec
-

--- a/generate/src/Parse/Bitmask.hs
+++ b/generate/src/Parse/Bitmask.hs
@@ -18,7 +18,6 @@ parseBitmask = hasName "enums" >>> hasAttrValue "type" (== "bitmask") >>>
           bitPositions <-
                        listA (parseBitmaskBitPos <<< getChildren) -< bitmask
           returnA -< Bitmask{ bmName = name
-                            , bmHsName = name
                             , bmNamespace = namespace
                             , bmComment = comment
                             , bmValues = values

--- a/generate/src/Parse/Bitmask.hs
+++ b/generate/src/Parse/Bitmask.hs
@@ -18,6 +18,7 @@ parseBitmask = hasName "enums" >>> hasAttrValue "type" (== "bitmask") >>>
           bitPositions <-
                        listA (parseBitmaskBitPos <<< getChildren) -< bitmask
           returnA -< Bitmask{ bmName = name
+                            , bmHsName = name
                             , bmNamespace = namespace
                             , bmComment = comment
                             , bmValues = values
@@ -33,6 +34,7 @@ parseBitmaskValue = hasName "enum" >>> hasAttr "value" >>>
           value   <- requiredRead <<< requiredAttrValue "value" -< elem
           comment <- optionalAttrValue "comment" -< elem
           returnA -< BitmaskValue{ bmvName = name
+                                 , bmvHsName = name
                                  , bmvValue = value
                                  , bmvComment = comment
                                  }
@@ -46,6 +48,7 @@ parseBitmaskBitPos = hasName "enum" >>> hasAttr "bitpos" >>>
           bitpos  <- requiredRead <<< requiredAttrValue "bitpos" -< elem
           comment <- optionalAttrValue "comment" -< elem
           returnA -< BitmaskBitPosition{ bmbpName = name
+                                       , bmbpHsName = name
                                        , bmbpBitPos = bitpos
                                        , bmbpComment = comment
                                        }

--- a/generate/src/Parse/Command.hs
+++ b/generate/src/Parse/Command.hs
@@ -16,9 +16,12 @@ parseCommand = hasName "command" >>>
 
           cName <- getAllText <<< onlyChildWithName "name" -< proto
           cSymbol <- parseIdentifier -< cName
+          let cHsName = cName
 
           cReturnType <- parseCType <<<
             getAllText <<< processChildren (neg (hasName "name")) -< proto
+
+          let cHsReturnType = undefined
 
           cParameters <- listA (parseParam <<< getChildren) -< command
 
@@ -53,9 +56,11 @@ parseParam = hasName "param" >>>
              (extract `orElse` failA "Failed to extract param fields")
   where extract = proc param -> do
           pName <- getAllText <<< onlyChildWithName "name" -< param
+          let pHsName = pName
           pType <- parseCType <<<
                    getAllText <<< processChildren (neg (hasName "name"))
                    -< param
+          let pHsType = undefined
           pIsOptional <- traverseMaybeA (mapA parseBool) <<<
                          optionalCommaSepListAttr "optional" -< param
           pIsExternSync <-
@@ -69,4 +74,3 @@ parseParam = hasName "param" >>>
 parseExternSync :: String -> ExternSync
 parseExternSync "true" = ExternSyncTrue
 parseExternSync ss     = ExternSyncParams (commaSepList ss)
-

--- a/generate/src/Parse/Command.hs
+++ b/generate/src/Parse/Command.hs
@@ -60,7 +60,6 @@ parseParam = hasName "param" >>>
           pType <- parseCType <<<
                    getAllText <<< processChildren (neg (hasName "name"))
                    -< param
-          let pHsType = undefined
           pIsOptional <- traverseMaybeA (mapA parseBool) <<<
                          optionalCommaSepListAttr "optional" -< param
           pIsExternSync <-

--- a/generate/src/Parse/Command.hs
+++ b/generate/src/Parse/Command.hs
@@ -15,6 +15,7 @@ parseCommand = hasName "command" >>>
           proto <- onlyChildWithName "proto" -< command
 
           cName <- getAllText <<< onlyChildWithName "name" -< proto
+          cSymbol <- parseIdentifier -< cName
 
           cReturnType <- parseCType <<<
             getAllText <<< processChildren (neg (hasName "name")) -< proto

--- a/generate/src/Parse/Command.hs
+++ b/generate/src/Parse/Command.hs
@@ -21,8 +21,6 @@ parseCommand = hasName "command" >>>
           cReturnType <- parseCType <<<
             getAllText <<< processChildren (neg (hasName "name")) -< proto
 
-          let cHsReturnType = undefined
-
           cParameters <- listA (parseParam <<< getChildren) -< command
 
           cImplicitExternSyncParams <- oneRequired

--- a/generate/src/Parse/Constant.hs
+++ b/generate/src/Parse/Constant.hs
@@ -28,6 +28,7 @@ parseConstant = extractFields "Constant"
                               extract
   where extract = proc constant -> do
           cName    <- requiredAttrValue "name" -< constant
+          let cHsName = cName
           cValueString <- requiredAttrValue "value" -< constant
           cValue   <- (arrF parseConstantValue) `orElse`
                       failA "Failed to read constant value" -< cValueString

--- a/generate/src/Parse/Enum.hs
+++ b/generate/src/Parse/Enum.hs
@@ -17,6 +17,7 @@ parseEnum = hasName "enums" >>> hasAttrValue "type" (== "enum") >>>
           comment   <- optionalAttrValue "comment" -< enum
           elements  <- listA (parseEnumElement <<< getChildren) -< enum
           returnA -< Enum{ eName = name
+                         , eHsName = name
                          , eNamespace = namespace
                          , eExpand = expand
                          , eComment = comment
@@ -32,6 +33,7 @@ parseEnumElement = hasName "enum" >>>
           value   <- requiredRead <<< requiredAttrValue "value" -< elem
           comment <- optionalAttrValue "comment" -< elem
           returnA -< EnumElement{ eeName = name
+                                , eeHsName = name
                                 , eeValue = value
                                 , eeComment = comment
                                 }

--- a/generate/src/Parse/Extension.hs
+++ b/generate/src/Parse/Extension.hs
@@ -46,6 +46,7 @@ parseEnumExtension = extractFields "enum extension"
                                    extract
   where extract = proc enumExtension -> do
           eeName <- requiredAttrValue "name" -< enumExtension
+          let eeHsName = eeName
           eeExtends <- requiredAttrValue "extends" -< enumExtension
           eeOffset <- requiredRead <<<
                       requiredAttrValue "offset" -< enumExtension
@@ -66,6 +67,7 @@ parseExtensionConstant = extractFields "extension constant"
                                        extract
   where extract = proc extensionConstant -> do
           ecName <- requiredAttrValue "name" -< extensionConstant
+          let ecHsName = ecName
           ecValue <- ((Right ^<< arrF readMay) `orElse`
                       (Left  ^<< arrF readMay) `orElse`
                       (failString <<^

--- a/generate/src/Parse/State.hs
+++ b/generate/src/Parse/State.hs
@@ -7,6 +7,7 @@ module Parse.State
   , getSymbolTable
   , getSymbolTableFromDefineText
   , SpecParseState
+  , parseIdentifier
   , addTypeName
   , addDefines
   , preProcessorBoolOptions
@@ -14,7 +15,7 @@ module Parse.State
   ) where
 
 import qualified Data.HashSet                as HashSet
-import           Language.C.Types
+import           Language.C.Types            (CIdentifier, TypeNames)
 import           Language.Preprocessor.Cpphs
 import           Parse.Utils
 import           Spec.Type
@@ -95,14 +96,5 @@ getSymbolTableFromDefineText = fmap snd .
                                      }
 
 addTypeName :: ParseArrow String CIdentifier
-addTypeName = (not . isReservedIdentifier) `guardsP`
-              (cIdentifierFromString ^>> fromRightA >>>
-               changeUserState insertTypeName)
-
-isReservedIdentifier :: String -> Bool
-isReservedIdentifier i = i `elem` reservedIdentifiers
-  where reservedIdentifiers = [ "void"
-                              , "char"
-                              , "float"
-                              ]
+addTypeName = parseIdentifier >>> changeUserState insertTypeName
 

--- a/generate/src/Parse/Type.hs
+++ b/generate/src/Parse/Type.hs
@@ -6,14 +6,13 @@ module Parse.Type
   ( parseTypes
   ) where
 
-import           Control.Bool                 ((<||>))
-import           Data.Char                    (isAlpha, isDigit)
-import qualified Language.Haskell.Exts.Syntax as HS
+import           Control.Bool      ((<||>))
+import           Data.Char         (isAlpha, isDigit)
 import           Parse.CType
 import           Parse.State
 import           Parse.Utils
 import           Spec.Type
-import           Text.Regex.TDFA              ((=~))
+import           Text.Regex.TDFA   ((=~))
 import           Text.XML.HXT.Core
 
 parseTypes :: ParseArrow XmlTree [TypeDecl]
@@ -209,7 +208,6 @@ parseMember = extractFields "struct member"
           let smHsName = smName
           smTypeString <- preprocessTypeString <<< getAllText -< member
           smCType <- parseCType -< smTypeString
-          let smHsType = HS.TyCon $ HS.UnQual $ HS.Ident "FOO"
           smNoAutoValidity <-
             boolAttrDefault "noautovalidity" False -< member
           smIsOptional <- traverseMaybeA (mapA parseBool) <<<

--- a/generate/src/Parse/Utils.hs
+++ b/generate/src/Parse/Utils.hs
@@ -30,11 +30,13 @@ module Parse.Utils
   , stripL
   , stripR
   , stripLines
+  , parseIdentifier
   ) where
 
 import           Data.Char         (isSpace)
 import           Data.Foldable     (foldr', toList)
 import           Data.List.Split   (splitOn)
+import           Language.C.Types  (CIdentifier, cIdentifierFromString)
 import           Safe              (readMay)
 import           Text.XML.HXT.Core
 
@@ -165,3 +167,14 @@ stripR = reverse . stripL . reverse
 
 stripLines :: String -> String
 stripLines = unlines . fmap strip . lines
+
+parseIdentifier :: IOStateArrow s String CIdentifier
+parseIdentifier = (not . isReservedIdentifier) `guardsP`
+                   (cIdentifierFromString ^>> fromRightA)
+
+isReservedIdentifier :: String -> Bool
+isReservedIdentifier i = i `elem` reservedIdentifiers
+  where reservedIdentifiers = [ "void"
+                              , "char"
+                              , "float"
+                              ]

--- a/generate/src/Spec/Bitmask.hs
+++ b/generate/src/Spec/Bitmask.hs
@@ -3,6 +3,7 @@ module Spec.Bitmask where
 import           Data.Word (Word32)
 
 data Bitmask = Bitmask { bmName         :: String
+                       , bmHsName       :: String
                        , bmNamespace    :: Maybe String
                        , bmComment      :: Maybe String
                        , bmValues       :: [BitmaskValue]
@@ -11,12 +12,14 @@ data Bitmask = Bitmask { bmName         :: String
   deriving (Show)
 
 data BitmaskValue = BitmaskValue { bmvName    :: String
+                                 , bmvHsName  :: String
                                  , bmvValue   :: Word32
                                  , bmvComment :: Maybe String
                                  }
   deriving (Show)
 
 data BitmaskBitPosition = BitmaskBitPosition { bmbpName    :: String
+                                             , bmbpHsName  :: String
                                              , bmbpBitPos  :: !Int
                                              , bmbpComment :: Maybe String
                                              }

--- a/generate/src/Spec/Bitmask.hs
+++ b/generate/src/Spec/Bitmask.hs
@@ -3,7 +3,6 @@ module Spec.Bitmask where
 import           Data.Word (Word32)
 
 data Bitmask = Bitmask { bmName         :: String
-                       , bmHsName       :: String
                        , bmNamespace    :: Maybe String
                        , bmComment      :: Maybe String
                        , bmValues       :: [BitmaskValue]

--- a/generate/src/Spec/Command.hs
+++ b/generate/src/Spec/Command.hs
@@ -1,8 +1,10 @@
 module Spec.Command where
 
+import           Language.C.Types (CIdentifier)
 import           Spec.Type
 
 data Command = Command { cName                     :: String
+                       , cSymbol                   :: CIdentifier
                        , cReturnType               :: CType
                        , cParameters               :: [Parameter]
                        , cImplicitExternSyncParams :: Maybe [String]

--- a/generate/src/Spec/Command.hs
+++ b/generate/src/Spec/Command.hs
@@ -1,11 +1,14 @@
 module Spec.Command where
 
-import           Language.C.Types (CIdentifier)
+import           Language.C.Types             (CIdentifier)
+import           Language.Haskell.Exts.Syntax as HS
 import           Spec.Type
 
 data Command = Command { cName                     :: String
                        , cSymbol                   :: CIdentifier
+                       , cHsName                   :: String
                        , cReturnType               :: CType
+                       , cHsReturnType             :: HS.Type
                        , cParameters               :: [Parameter]
                        , cImplicitExternSyncParams :: Maybe [String]
                        , cQueues                   :: Maybe [String]
@@ -18,7 +21,9 @@ data Command = Command { cName                     :: String
   deriving (Show)
 
 data Parameter = Parameter { pName           :: String
+                           , pHsName         :: String
                            , pType           :: CType
+                           , pHsType         :: HS.Type
                            , pIsOptional     :: Maybe [Bool]
                              -- ^ Values further into the list represent the
                              -- "optionality" of the types as it is

--- a/generate/src/Spec/Command.hs
+++ b/generate/src/Spec/Command.hs
@@ -23,7 +23,6 @@ data Command = Command { cName                     :: String
 data Parameter = Parameter { pName           :: String
                            , pHsName         :: String
                            , pType           :: CType
-                           , pHsType         :: HS.Type
                            , pIsOptional     :: Maybe [Bool]
                              -- ^ Values further into the list represent the
                              -- "optionality" of the types as it is

--- a/generate/src/Spec/Command.hs
+++ b/generate/src/Spec/Command.hs
@@ -1,14 +1,12 @@
 module Spec.Command where
 
-import           Language.C.Types             (CIdentifier)
-import           Language.Haskell.Exts.Syntax as HS
+import           Language.C.Types (CIdentifier)
 import           Spec.Type
 
 data Command = Command { cName                     :: String
                        , cSymbol                   :: CIdentifier
                        , cHsName                   :: String
                        , cReturnType               :: CType
-                       , cHsReturnType             :: HS.Type
                        , cParameters               :: [Parameter]
                        , cImplicitExternSyncParams :: Maybe [String]
                        , cQueues                   :: Maybe [String]

--- a/generate/src/Spec/Constant.hs
+++ b/generate/src/Spec/Constant.hs
@@ -3,6 +3,7 @@ module Spec.Constant where
 import           Data.Word (Word32, Word64)
 
 data Constant = Constant { cName        :: String
+                         , cHsName      :: String
                          , cValueString :: String
                          , cValue       :: ConstantValue
                          , cComment     :: Maybe String

--- a/generate/src/Spec/Enum.hs
+++ b/generate/src/Spec/Enum.hs
@@ -4,6 +4,7 @@ import           Data.Int (Int32)
 
 -- TODO: Parse the XML comments into here
 data Enum = Enum { eName      :: String
+                 , eHsName    :: String
                  , eNamespace :: Maybe String
                  , eExpand    :: Maybe String
                  , eComment   :: Maybe String
@@ -12,6 +13,7 @@ data Enum = Enum { eName      :: String
   deriving (Show)
 
 data EnumElement = EnumElement { eeName    :: String
+                               , eeHsName  :: String
                                , eeValue   :: !Int32
                                , eeComment :: Maybe String
                                }

--- a/generate/src/Spec/Extension.hs
+++ b/generate/src/Spec/Extension.hs
@@ -20,14 +20,16 @@ data Direction = Negative
   deriving(Show)
 
 data EnumExtension = EnumExtension{ eeName      :: String
+                                  , eeHsName    :: String
                                   , eeExtends   :: String
                                   , eeOffset    :: Int32
                                   , eeDirection :: Direction
                                   }
   deriving(Show)
 
-data ExtensionConstant = ExtensionConstant{ ecName  :: String
-                                          , ecValue :: Either String Integer
+data ExtensionConstant = ExtensionConstant{ ecName   :: String
+                                          , ecHsName :: String
+                                          , ecValue  :: Either String Integer
                                           }
   deriving(Show)
 

--- a/generate/src/Spec/Graph.hs
+++ b/generate/src/Spec/Graph.hs
@@ -201,13 +201,16 @@ vertexToConstant v = case vSourceEntity v of
 getGraphConstants :: SpecGraph -> [Constant]
 getGraphConstants graph = catMaybes (vertexToConstant <$> gVertices graph)
 
-vertexCType :: Vertex -> Maybe CType
-vertexCType v = case vSourceEntity v of
+entityCType :: SourceEntity -> Maybe CType
+entityCType e = case e of
                   ABaseType bt -> Just $ btCType bt
                   ABitmaskType bmt _ -> Just $ bmtCType bmt
                   AHandleType ht -> Just $ htCType ht
                   AFuncPointerType fpt -> Just $ fptCType fpt
                   _ -> Nothing
+
+vertexCType :: Vertex -> Maybe CType
+vertexCType = entityCType . vSourceEntity
 
 getGraphCTypes :: SpecGraph -> [(String, CType)]
 getGraphCTypes graph =
@@ -237,9 +240,25 @@ vertexToEnumType v = case vSourceEntity v of
 getGraphEnumTypes :: SpecGraph -> [EnumType]
 getGraphEnumTypes graph = catMaybes (vertexToEnumType <$> gVertices graph)
 
-vertexExportName :: Vertex -> Maybe String
-vertexExportName v =
-  case vSourceEntity v of
+entityName :: SourceEntity -> Maybe String
+entityName e =
+  case e of
+    ABaseType bt -> Just $ btName bt
+    ABitmaskType bmt _ -> Just $ bmtName bmt
+    AHandleType ht -> Just $ htName ht
+    AnEnumType et -> Just $ etName et
+    AFuncPointerType fpt -> Just $ fptName fpt
+    AStructType st -> Just $ stName st
+    AUnionType ut -> Just $ utName ut
+    ACommand co -> Just $ Command.cName co
+    AnEnum en -> Just $ eName en
+    ABitmask bm -> Just $ bmName bm
+    AConstant c -> Just $ Constant.cName c
+    _ -> Nothing
+
+entityExportName :: SourceEntity -> Maybe String
+entityExportName e =
+  case e of
     ABaseType bt -> Just $ btHsName bt
     ABitmaskType bmt _ -> Just $ bmtHsName bmt
     AHandleType ht -> Just $ htHsName ht
@@ -248,10 +267,13 @@ vertexExportName v =
     AStructType st -> Just $ stHsName st
     AUnionType ut -> Just $ utHsName ut
     ACommand co -> Just $ Command.cHsName co
-    AnEnum e -> Just $ eHsName e
+    AnEnum en -> Just $ eHsName en
     ABitmask bm -> Just $ bmHsName bm
     AConstant c -> Just $ Constant.cHsName c
     _ -> Nothing
+
+vertexExportName :: Vertex -> Maybe String
+vertexExportName = entityExportName . vSourceEntity
 
 getGraphTypeMap :: SpecGraph -> [(String, String)]
 getGraphTypeMap graph =

--- a/generate/src/Spec/Graph.hs
+++ b/generate/src/Spec/Graph.hs
@@ -236,21 +236,21 @@ vertexToEnumType v = case vSourceEntity v of
 getGraphEnumTypes :: SpecGraph -> [EnumType]
 getGraphEnumTypes graph = catMaybes (vertexToEnumType <$> gVertices graph)
 
-entityName :: SourceEntity -> Maybe String
-entityName e =
+entityNames :: SourceEntity -> [String]
+entityNames e =
   case e of
-    ABaseType bt -> Just $ btName bt
-    ABitmaskType bmt _ -> Just $ bmtName bmt
-    AHandleType ht -> Just $ htName ht
-    AnEnumType et -> Just $ etName et
-    AFuncPointerType fpt -> Just $ fptName fpt
-    AStructType st -> Just $ stName st
-    AUnionType ut -> Just $ utName ut
-    ACommand co -> Just $ Command.cName co
-    AnEnum en -> Just $ eName en
-    ABitmask bm -> Just $ bmName bm
-    AConstant c -> Just $ Constant.cName c
-    _ -> Nothing
+    ABaseType bt -> [btName bt]
+    ABitmaskType bmt bm -> [bmtName bmt] ++ maybeToList (bmName <$> bm)
+    AHandleType ht -> [htName ht]
+    AnEnumType et -> [etName et]
+    AFuncPointerType fpt -> [fptName fpt]
+    AStructType st -> [stName st]
+    AUnionType ut -> [utName ut]
+    ACommand co -> [Command.cName co]
+    AnEnum en -> [eName en]
+    ABitmask bm -> [bmName bm]
+    AConstant c -> [Constant.cName c]
+    _ -> []
 
 entityExportName :: SourceEntity -> Maybe String
 entityExportName e =
@@ -264,7 +264,6 @@ entityExportName e =
     AUnionType ut -> Just $ utHsName ut
     ACommand co -> Just $ Command.cHsName co
     AnEnum en -> Just $ eHsName en
-    ABitmask bm -> Just $ bmHsName bm
     AConstant c -> Just $ Constant.cHsName c
     _ -> Nothing
 

--- a/generate/src/Spec/Graph.hs
+++ b/generate/src/Spec/Graph.hs
@@ -237,6 +237,26 @@ vertexToEnumType v = case vSourceEntity v of
 getGraphEnumTypes :: SpecGraph -> [EnumType]
 getGraphEnumTypes graph = catMaybes (vertexToEnumType <$> gVertices graph)
 
+vertexExportName :: Vertex -> Maybe String
+vertexExportName v =
+  case vSourceEntity v of
+    ABaseType bt -> Just $ btHsName bt
+    ABitmaskType bmt _ -> Just $ bmtHsName bmt
+    AHandleType ht -> Just $ htHsName ht
+    AnEnumType et -> Just $ etHsName et
+    AFuncPointerType fpt -> Just $ fptHsName fpt
+    AStructType st -> Just $ stHsName st
+    AUnionType ut -> Just $ utHsName ut
+    ACommand co -> Just $ Command.cHsName co
+    AnEnum e -> Just $ eHsName e
+    ABitmask bm -> Just $ bmHsName bm
+    AConstant c -> Just $ Constant.cHsName c
+    _ -> Nothing
+
+getGraphTypeMap :: SpecGraph -> [(String, String)]
+getGraphTypeMap graph =
+  catMaybes $ (\v -> (vName v,) <$> vertexExportName v) <$> gVertices graph
+
 
 ------------------------------------------------------------------------------
 -- predicates

--- a/generate/src/Spec/Graph.hs
+++ b/generate/src/Spec/Graph.hs
@@ -250,6 +250,7 @@ entityNames e =
     AnEnum en -> [eName en]
     ABitmask bm -> [bmName bm]
     AConstant c -> [Constant.cName c]
+    ADefine d -> [dName d]
     _ -> []
 
 entityExportName :: SourceEntity -> Maybe String
@@ -265,6 +266,7 @@ entityExportName e =
     ACommand co -> Just $ Command.cHsName co
     AnEnum en -> Just $ eHsName en
     AConstant c -> Just $ Constant.cHsName c
+    ADefine d -> Just $ dHsName d
     _ -> Nothing
 
 vertexExportName :: Vertex -> Maybe String

--- a/generate/src/Spec/Partition.hs
+++ b/generate/src/Spec/Partition.hs
@@ -65,12 +65,12 @@ partitionSpec spec =
       moduleExports = (fmap (vSourceEntity . requiredLookup graph) . toList) <$>
         moduleExportNames
 
-      nameLocation :: (ModuleName, [SourceEntity]) -> [(String, (ModuleName, String))]
-      nameLocation (m, names) = concat
-        (blarf m <$> names)
+      moduleNameLocations :: (ModuleName, [SourceEntity]) -> [(String, (ModuleName, String))]
+      moduleNameLocations (m, names) = concat
+        (entityNameLocations m <$> names)
 
-      blarf :: ModuleName -> SourceEntity -> [(String, (ModuleName, String))]
-      blarf m e =
+      entityNameLocations :: ModuleName -> SourceEntity -> [(String, (ModuleName, String))]
+      entityNameLocations m e =
         let
           names = entityNames e
           export = entityExportName e
@@ -79,7 +79,7 @@ partitionSpec spec =
             Just export' -> (flip (,) (m, export')) <$> names
             Nothing -> []
 
-      nameLocations = M.fromList $ concat (nameLocation <$> M.toList moduleExports)
+      nameLocations = M.fromList $ concat (moduleNameLocations <$> M.toList moduleExports)
 
       allEntityNames = S.fromList (M.keys (gNameVertexMap graph))
                        `S.difference` ignoredNames

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -1,0 +1,49 @@
+module Spec.Pretty
+  ( prettifySpec
+  ) where
+
+import           Data.HashMap.Lazy   as M
+import           Data.Maybe          (catMaybes)
+import           Language.C.Types
+import           Spec.Command
+import           Spec.Spec
+import           Spec.Type
+import           Write.TypeConverter
+import           Write.Utils
+import           Write.WriteMonad
+
+lowerArrayToPointer :: CType -> CType
+lowerArrayToPointer cType =
+  case cType of
+    Array _ t -> Ptr [] t
+    t -> t
+
+prettifySpec :: Spec -> Spec
+prettifySpec spec = spec { sTypes = types
+                         , sCommands = commands
+                         }
+  where
+    types = nameType <$> sTypes spec
+    nameType (ADefine d) = ADefine d { dHsName = camelCase_ $ dHsName d }
+    nameType (AStructType st) = AStructType st { stMembers = nameStructMember <$> stMembers st }
+    nameType (AUnionType ut) = AUnionType ut { utMembers = nameStructMember <$> utMembers ut }
+    nameType (AHandleType h) = AHandleType h { htHsName = dropVK $ htHsName h }
+    nameType t = t
+    nameStructMember sm = sm { smHsName = recordName $ smHsName sm
+                             , smHsType = mapType $ smCType sm
+                             }
+
+    recordName "type" = "_type"
+    recordName "module" = "_module"
+    recordName "alignment" = "_alignment"
+    recordName n = n
+
+    typeNameMap = M.fromList $ catMaybes $ typeDeclTypeNameMap <$> types
+    mapType t = fst $ runWrite undefined undefined (cTypeToHsTypeMap typeNameMap t)
+
+    commands = nameCommand <$> sCommands spec
+    nameCommand c = c { cHsReturnType = mapType $ cReturnType c
+                      , cParameters = nameParameter <$> cParameters c
+                      }
+    nameParameter p = p { pHsType = mapType $ lowerArrayToPointer $ pType p
+                        }

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -42,6 +42,10 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
     nameRecord "type" = "_type"
     nameRecord "module" = "_module"
     nameRecord "alignment" = "_alignment"
+    nameRecord "r" = "red"
+    nameRecord "g" = "green"
+    nameRecord "b" = "blue"
+    nameRecord "a" = "alpha"
     nameRecord n = n
 
     nameEnum e = e { eHsName = name $ eHsName e

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -2,11 +2,14 @@ module Spec.Pretty
   ( prettifySpec
   ) where
 
+import           Data.Maybe        (catMaybes)
 import           Spec.Bitmask
 import           Spec.Command
 import           Spec.Constant
 import           Spec.Enum
+import           Spec.ExtensionTag
 import           Spec.Spec
+import           Spec.Tag
 import           Spec.Type
 import           Write.Utils
 
@@ -18,17 +21,20 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
                          , sCommands = nameCommand <$> sCommands spec
                          }
   where
-    nameType (ADefine d) = ADefine d { dHsName = camelCase_ . dropVK $ dHsName d }
-    nameType (AStructType st) = AStructType st { stHsName = dropVK $ stHsName st
+    tags = (tName <$> sTags spec) ++ (catMaybes $ stringToExtensionTag <$> ["KHR", "EXT"])
+    name = fst . breakNameTag tags . dropVK
+
+    nameType (ADefine d) = ADefine d { dHsName = camelCase_ . name $ dHsName d }
+    nameType (AStructType st) = AStructType st { stHsName = name $ stHsName st
                                                , stMembers = nameStructMember <$> stMembers st
                                                }
-    nameType (AUnionType ut) = AUnionType ut { utHsName = dropVK $ utHsName ut
+    nameType (AUnionType ut) = AUnionType ut { utHsName = name $ utHsName ut
                                              , utMembers = nameStructMember <$> utMembers ut
                                              }
-    nameType (AHandleType h) = AHandleType h { htHsName = dropVK $ htHsName h }
-    nameType (AnEnumType h) = AnEnumType h { etHsName = dropVK $ etHsName h }
-    nameType (ABitmaskType h) = ABitmaskType h { bmtHsName = dropVK $ bmtHsName h }
-    nameType (ABaseType h) = ABaseType h { btHsName = dropVK $ btHsName h }
+    nameType (AHandleType h) = AHandleType h { htHsName = name $ htHsName h }
+    nameType (AnEnumType h) = AnEnumType h { etHsName = name $ etHsName h }
+    nameType (ABitmaskType h) = ABitmaskType h { bmtHsName = name $ bmtHsName h }
+    nameType (ABaseType h) = ABaseType h { btHsName = name $ btHsName h }
     nameType t = t
     nameStructMember sm = sm { smHsName = nameRecord $ smHsName sm
                              }
@@ -38,22 +44,22 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
     nameRecord "alignment" = "_alignment"
     nameRecord n = n
 
-    nameEnum e = e { eHsName = dropVK $ eHsName e
+    nameEnum e = e { eHsName = name $ eHsName e
                    , eElements = nameEnumElement <$> eElements e
                    }
 
-    nameConstant c = c { Spec.Constant.cHsName = pascalCase_ . dropVK $ Spec.Constant.cHsName c }
+    nameConstant c = c { Spec.Constant.cHsName = pascalCase_ . name $ Spec.Constant.cHsName c }
 
-    nameEnumElement ee = ee { eeHsName = pascalCase_ . dropVK $ eeHsName ee }
+    nameEnumElement ee = ee { eeHsName = pascalCase_ . name $ eeHsName ee }
 
     nameBitmask bm = bm { bmValues = nameBitmaskValue <$> bmValues bm
                         , bmBitPositions = nameBitmaskBitPosition <$> bmBitPositions bm
                         }
 
-    nameBitmaskValue bmv = bmv { bmvHsName = pascalCase_ . dropVK $ bmvHsName bmv }
-    nameBitmaskBitPosition bmbp = bmbp { bmbpHsName = pascalCase_ . dropVK $ bmbpHsName bmbp }
+    nameBitmaskValue bmv = bmv { bmvHsName = pascalCase_ . name $ bmvHsName bmv }
+    nameBitmaskBitPosition bmbp = bmbp { bmbpHsName = pascalCase_ . name $ bmbpHsName bmbp }
 
-    nameCommand c = c { Spec.Command.cHsName = lowerFirst . dropVK $ Spec.Command.cHsName c
+    nameCommand c = c { Spec.Command.cHsName = lowerFirst . name $ Spec.Command.cHsName c
                       , cParameters = nameParameter <$> cParameters c
                       }
     nameParameter p = p

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -18,7 +18,7 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
                          , sCommands = nameCommand <$> sCommands spec
                          }
   where
-    nameType (ADefine d) = ADefine d { dHsName = camelCase_ $ dHsName d }
+    nameType (ADefine d) = ADefine d { dHsName = camelCase_ . dropVK $ dHsName d }
     nameType (AStructType st) = AStructType st { stHsName = dropVK $ stHsName st
                                                , stMembers = nameStructMember <$> stMembers st
                                                }

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -26,15 +26,19 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
     nameType (ABitmaskType h) = ABitmaskType h { bmtHsName = dropVK $ bmtHsName h }
     nameType (ABaseType h) = ABaseType h { btHsName = dropVK $ btHsName h }
     nameType t = t
-    nameStructMember sm = sm { smHsName = recordName $ smHsName sm
+    nameStructMember sm = sm { smHsName = nameRecord $ smHsName sm
                              }
 
-    nameEnum e = e { eHsName = dropVK $ eHsName e }
+    nameRecord "type" = "_type"
+    nameRecord "module" = "_module"
+    nameRecord "alignment" = "_alignment"
+    nameRecord n = n
 
-    recordName "type" = "_type"
-    recordName "module" = "_module"
-    recordName "alignment" = "_alignment"
-    recordName n = n
+    nameEnum e = e { eHsName = dropVK $ eHsName e
+                   , eElements = nameEnumElement <$> eElements e
+                   }
+
+    nameEnumElement ee = ee { eeHsName = pascalCase_ . dropVK $ eeHsName ee }
 
     nameCommand c = c { cHsName = lowerFirst . dropVK $ cHsName c
                       , cParameters = nameParameter <$> cParameters c

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -14,8 +14,12 @@ prettifySpec spec = spec { sTypes = types
   where
     types = nameType <$> sTypes spec
     nameType (ADefine d) = ADefine d { dHsName = camelCase_ $ dHsName d }
-    nameType (AStructType st) = AStructType st { stMembers = nameStructMember <$> stMembers st }
-    nameType (AUnionType ut) = AUnionType ut { utMembers = nameStructMember <$> utMembers ut }
+    nameType (AStructType st) = AStructType st { stHsName = dropVK $ stHsName st
+                                               , stMembers = nameStructMember <$> stMembers st
+                                               }
+    nameType (AUnionType ut) = AUnionType ut { utHsName = dropVK $ utHsName ut
+                                             , utMembers = nameStructMember <$> utMembers ut
+                                             }
     nameType (AHandleType h) = AHandleType h { htHsName = dropVK $ htHsName h }
     nameType t = t
     nameStructMember sm = sm { smHsName = recordName $ smHsName sm
@@ -30,3 +34,5 @@ prettifySpec spec = spec { sTypes = types
     nameCommand c = c { cParameters = nameParameter <$> cParameters c
                       }
     nameParameter p = p
+
+

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -2,7 +2,9 @@ module Spec.Pretty
   ( prettifySpec
   ) where
 
+import           Spec.Bitmask
 import           Spec.Command
+import           Spec.Constant
 import           Spec.Enum
 import           Spec.Spec
 import           Spec.Type
@@ -11,6 +13,8 @@ import           Write.Utils
 prettifySpec :: Spec -> Spec
 prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
                          , sEnums = nameEnum <$> sEnums spec
+                         , sConstants = nameConstant <$> sConstants spec
+                         , sBitmasks = nameBitmask <$> sBitmasks spec
                          , sCommands = nameCommand <$> sCommands spec
                          }
   where
@@ -38,9 +42,18 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
                    , eElements = nameEnumElement <$> eElements e
                    }
 
+    nameConstant c = c { Spec.Constant.cHsName = pascalCase_ . dropVK $ Spec.Constant.cHsName c }
+
     nameEnumElement ee = ee { eeHsName = pascalCase_ . dropVK $ eeHsName ee }
 
-    nameCommand c = c { cHsName = lowerFirst . dropVK $ cHsName c
+    nameBitmask bm = bm { bmValues = nameBitmaskValue <$> bmValues bm
+                        , bmBitPositions = nameBitmaskBitPosition <$> bmBitPositions bm
+                        }
+
+    nameBitmaskValue bmv = bmv { bmvHsName = pascalCase_ . dropVK $ bmvHsName bmv }
+    nameBitmaskBitPosition bmbp = bmbp { bmbpHsName = pascalCase_ . dropVK $ bmbpHsName bmbp }
+
+    nameCommand c = c { Spec.Command.cHsName = lowerFirst . dropVK $ Spec.Command.cHsName c
                       , cParameters = nameParameter <$> cParameters c
                       }
     nameParameter p = p

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -3,16 +3,17 @@ module Spec.Pretty
   ) where
 
 import           Spec.Command
+import           Spec.Enum
 import           Spec.Spec
 import           Spec.Type
 import           Write.Utils
 
 prettifySpec :: Spec -> Spec
-prettifySpec spec = spec { sTypes = types
+prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
+                         , sEnums = nameEnum <$> sEnums spec
                          , sCommands = commands
                          }
   where
-    types = nameType <$> sTypes spec
     nameType (ADefine d) = ADefine d { dHsName = camelCase_ $ dHsName d }
     nameType (AStructType st) = AStructType st { stHsName = dropVK $ stHsName st
                                                , stMembers = nameStructMember <$> stMembers st
@@ -21,9 +22,13 @@ prettifySpec spec = spec { sTypes = types
                                              , utMembers = nameStructMember <$> utMembers ut
                                              }
     nameType (AHandleType h) = AHandleType h { htHsName = dropVK $ htHsName h }
+    nameType (AnEnumType h) = AnEnumType h { etHsName = dropVK $ etHsName h }
+    nameType (ABitmaskType h) = ABitmaskType h { bmtHsName = dropVK $ bmtHsName h }
     nameType t = t
     nameStructMember sm = sm { smHsName = recordName $ smHsName sm
                              }
+
+    nameEnum e = e { eHsName = dropVK $ eHsName e }
 
     recordName "type" = "_type"
     recordName "module" = "_module"

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -11,7 +11,7 @@ import           Write.Utils
 prettifySpec :: Spec -> Spec
 prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
                          , sEnums = nameEnum <$> sEnums spec
-                         , sCommands = commands
+                         , sCommands = nameCommand <$> sCommands spec
                          }
   where
     nameType (ADefine d) = ADefine d { dHsName = camelCase_ $ dHsName d }
@@ -36,9 +36,7 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
     recordName "alignment" = "_alignment"
     recordName n = n
 
-    commands = nameCommand <$> sCommands spec
-    nameCommand c = c { cParameters = nameParameter <$> cParameters c
+    nameCommand c = c { cHsName = lowerFirst . dropVK $ cHsName c
+                      , cParameters = nameParameter <$> cParameters c
                       }
     nameParameter p = p
-
-

--- a/generate/src/Spec/Pretty.hs
+++ b/generate/src/Spec/Pretty.hs
@@ -24,6 +24,7 @@ prettifySpec spec = spec { sTypes = nameType <$> sTypes spec
     nameType (AHandleType h) = AHandleType h { htHsName = dropVK $ htHsName h }
     nameType (AnEnumType h) = AnEnumType h { etHsName = dropVK $ etHsName h }
     nameType (ABitmaskType h) = ABitmaskType h { bmtHsName = dropVK $ bmtHsName h }
+    nameType (ABaseType h) = ABaseType h { btHsName = dropVK $ btHsName h }
     nameType t = t
     nameStructMember sm = sm { smHsName = recordName $ smHsName sm
                              }

--- a/generate/src/Spec/Type.hs
+++ b/generate/src/Spec/Type.hs
@@ -1,8 +1,7 @@
 module Spec.Type where
 
-import           Control.Arrow                ((&&&))
-import           Language.C.Types             (CIdentifier, Type)
-import qualified Language.Haskell.Exts.Syntax as HS
+import           Control.Arrow    ((&&&))
+import           Language.C.Types (CIdentifier, Type)
 
 type CType = Type CIdentifier
 
@@ -83,7 +82,6 @@ data StructMember = StructMember { smName           :: String
                                  , smHsName         :: String
                                  , smTypeString     :: String
                                  , smCType          :: CType
-                                 , smHsType         :: HS.Type
                                  , smNoAutoValidity :: Bool
                                  , smIsOptional     :: Maybe [Bool]
                                  , smLengths        :: Maybe [String]

--- a/generate/src/Spec/Type.hs
+++ b/generate/src/Spec/Type.hs
@@ -1,6 +1,8 @@
 module Spec.Type where
 
-import           Language.C.Types (CIdentifier, Type)
+import           Control.Arrow                ((&&&))
+import           Language.C.Types             (CIdentifier, Type)
+import qualified Language.Haskell.Exts.Syntax as HS
 
 type CType = Type CIdentifier
 
@@ -22,12 +24,14 @@ data Include = Include { iName     :: String
   deriving (Show, Eq)
 
 data Define = Define { dName   :: String
+                     , dHsName :: String
                      , dText   :: String
                      , dSymTab :: [(String, String)]
                      }
   deriving (Show, Eq)
 
 data BaseType = BaseType { btName       :: String
+                         , btHsName     :: String
                          , btTypeString :: String
                          , btCType      :: CType
                          }
@@ -39,6 +43,7 @@ data PlatformType = PlatformType { ptName     :: String
   deriving (Show, Eq)
 
 data BitmaskType = BitmaskType { bmtName       :: String
+                               , bmtHsName     :: String
                                , bmtTypeString :: String
                                , bmtRequires   :: Maybe String
                                , bmtCType      :: CType
@@ -46,23 +51,27 @@ data BitmaskType = BitmaskType { bmtName       :: String
   deriving (Show, Eq)
 
 data HandleType = HandleType { htName       :: String
+                             , htHsName     :: String
                              , htParents    :: [String]
                              , htTypeString :: String
                              , htCType      :: CType
                              }
   deriving (Show, Eq)
 
-data EnumType = EnumType { etName :: String
+data EnumType = EnumType { etName   :: String
+                         , etHsName :: String
                          }
   deriving (Show, Eq)
 
 data FuncPointerType = FuncPointerType { fptName       :: String
+                                       , fptHsName     :: String
                                        , fptTypeString :: String
                                        , fptCType      :: CType
                                        }
   deriving (Show, Eq)
 
 data StructType = StructType { stName           :: String
+                             , stHsName         :: String
                              , stComment        :: Maybe String
                              , stMembers        :: [StructMember]
                              , stUsage          :: [String]
@@ -71,8 +80,10 @@ data StructType = StructType { stName           :: String
   deriving (Show, Eq)
 
 data StructMember = StructMember { smName           :: String
+                                 , smHsName         :: String
                                  , smTypeString     :: String
                                  , smCType          :: CType
+                                 , smHsType         :: HS.Type
                                  , smNoAutoValidity :: Bool
                                  , smIsOptional     :: Maybe [Bool]
                                  , smLengths        :: Maybe [String]
@@ -81,6 +92,7 @@ data StructMember = StructMember { smName           :: String
   deriving (Show, Eq)
 
 data UnionType = UnionType { utName           :: String
+                           , utHsName         :: String
                            , utComment        :: Maybe String
                            , utMembers        :: [StructMember]
                            , utUsage          :: [String]
@@ -99,6 +111,18 @@ typeDeclTypeName (AnEnumType et)        = Just $ etName et
 typeDeclTypeName (AFuncPointerType fpt) = Just $ fptName fpt
 typeDeclTypeName (AStructType st)       = Just $ stName st
 typeDeclTypeName (AUnionType ut)        = Just $ utName ut
+
+typeDeclTypeNameMap :: TypeDecl -> Maybe (String, String)
+typeDeclTypeNameMap (AnInclude _)          = Nothing
+typeDeclTypeNameMap (ADefine _)            = Nothing
+typeDeclTypeNameMap (ABaseType bt)         = Just $ (btName &&& btHsName) bt
+typeDeclTypeNameMap (APlatformType _)     = Nothing
+typeDeclTypeNameMap (ABitmaskType bmt)     = Just $ (bmtName &&& bmtHsName) bmt
+typeDeclTypeNameMap (AHandleType ht)       = Just $ (htName &&& htHsName) ht
+typeDeclTypeNameMap (AnEnumType et)        = Just $ (etName &&& etHsName) et
+typeDeclTypeNameMap (AFuncPointerType fpt) = Just $ (fptName &&& fptHsName) fpt
+typeDeclTypeNameMap (AStructType st)       = Just $ (stName &&& stHsName) st
+typeDeclTypeNameMap (AUnionType ut)        = Just $ (utName &&& utHsName) ut
 
 typeDeclCType :: TypeDecl -> Maybe CType
 typeDeclCType (AnInclude _)          = Nothing

--- a/generate/src/Spec/TypeEnv.hs
+++ b/generate/src/Spec/TypeEnv.hs
@@ -1,10 +1,11 @@
 module Spec.TypeEnv where
 
 import qualified Data.HashMap.Lazy as Map
+import           Write.Utils
 
 data TypeEnv = TypeEnv{ teTypeInfo          :: Map.HashMap String TypeInfo
                       , teIntegralConstants :: Map.HashMap String Integer
-                      , teTypeMap           :: Map.HashMap String String
+                      , teNameLocations     :: NameLocations
                       }
 
 data TypeInfo = TypeInfo{ tiSize      :: !Int

--- a/generate/src/Spec/TypeEnv.hs
+++ b/generate/src/Spec/TypeEnv.hs
@@ -4,6 +4,7 @@ import qualified Data.HashMap.Lazy as Map
 
 data TypeEnv = TypeEnv{ teTypeInfo          :: Map.HashMap String TypeInfo
                       , teIntegralConstants :: Map.HashMap String Integer
+                      , teTypeMap           :: Map.HashMap String String
                       }
 
 data TypeInfo = TypeInfo{ tiSize      :: !Int

--- a/generate/src/Write/BreakCycle.hs
+++ b/generate/src/Write/BreakCycle.hs
@@ -14,19 +14,18 @@ cycleBreakers = M.fromList [ (ModuleName "Graphics.Vulkan.Device", ["VkDevice"])
                            , (ModuleName "Graphics.Vulkan.Pass", ["VkRenderPass"])
                            ]
 
-writeHsBootFiles :: FilePath -> SpecGraph -> NameLocations -> IO ()
-writeHsBootFiles root graph nameLocations =
-  void $ M.traverseWithKey (writeHsBootFile root graph nameLocations)
+writeHsBootFiles :: FilePath -> SpecGraph -> IO ()
+writeHsBootFiles root graph =
+  void $ M.traverseWithKey (writeHsBootFile root graph)
                            cycleBreakers
 
 writeHsBootFile :: FilePath      -- ^ The source root
                 -> SpecGraph     -- ^ The specification graph
-                -> NameLocations -- ^ The map of names to modules
                 -> ModuleName    -- ^ The module name we're writing
                 -> [String]      -- ^ The symbols to export
                 -> IO ()
-writeHsBootFile root graph nameLocations moduleName exports = do
+writeHsBootFile root graph moduleName exports = do
   createModuleDirectory root moduleName
-  let moduleString = writeModule graph nameLocations moduleName exports
+  let moduleString = writeModule graph moduleName exports
   writeFile (moduleNameToFile root moduleName) moduleString
 

--- a/generate/src/Write/Command.hs
+++ b/generate/src/Write/Command.hs
@@ -18,7 +18,7 @@ writeCommand :: Command -> Write Doc
 writeCommand c = do
   commandType <- writeCommandType c
   pure [qc|-- ** {cName c}
-foreign import ccall "{cName c}" {cName c} ::
+foreign import ccall "{unCIdentifier $ cSymbol c}" {cName c} ::
   {commandType}
 |]
 

--- a/generate/src/Write/Command.hs
+++ b/generate/src/Write/Command.hs
@@ -17,8 +17,8 @@ import           Write.WriteMonad
 writeCommand :: Command -> Write Doc
 writeCommand c = do
   commandType <- writeCommandType c
-  pure [qc|-- ** {cName c}
-foreign import ccall "{unCIdentifier $ cSymbol c}" {cName c} ::
+  pure [qc|-- ** {cHsName c}
+foreign import ccall "{unCIdentifier $ cSymbol c}" {cHsName c} ::
   {commandType}
 |]
 

--- a/generate/src/Write/Constant.hs
+++ b/generate/src/Write/Constant.hs
@@ -24,15 +24,15 @@ writeConstant c = do
 writeConstantPattern :: Constant -> Write Doc
 writeConstantPattern c = case cValue c of
   IntegralValue i
-    -> pure [qc|pattern {cName c} = {i}|]
+    -> pure [qc|pattern {cHsName c} = {i}|]
   FloatValue f
-    -> pure [qc|pattern {cName c} = {f}|]
+    -> pure [qc|pattern {cHsName c} = {f}|]
   Word32Value i
     -> do tellRequiredName (ExternalName (ModuleName "Data.Word") "Word32")
-          pure [qc|pattern {cName c} = {showHex' i} :: Word32|]
+          pure [qc|pattern {cHsName c} = {showHex' i} :: Word32|]
   Word64Value i
     -> do tellRequiredName (ExternalName (ModuleName "Data.Word") "Word64")
-          pure [qc|pattern {cName c} = {showHex' i} :: Word64|]
+          pure [qc|pattern {cHsName c} = {showHex' i} :: Word64|]
 
 maybeWriteConstantType :: Constant -> Write (Maybe Doc)
 maybeWriteConstantType c
@@ -40,7 +40,7 @@ maybeWriteConstantType c
   , i >= 0
   = do tellExtension "DataKinds"
        pure $ Just [qc|
-type {cName c} = {i}|]
+type {cHsName c} = {i}|]
   | otherwise
   = pure Nothing
 

--- a/generate/src/Write/CycleBreak.hs
+++ b/generate/src/Write/CycleBreak.hs
@@ -3,23 +3,25 @@ module Write.CycleBreak where
 import           Control.Monad       (void)
 import           Data.HashMap.Strict as M
 import           Spec.Graph
+import           Spec.Partition
 import           Write.Module
 import           Write.Quirks
 import           Write.Utils
 import           Write.WriteMonad
 
-writeHsBootFiles :: FilePath -> SpecGraph -> IO ()
-writeHsBootFiles root graph =
-  void $ M.traverseWithKey (writeHsBootFile root graph)
+writeHsBootFiles :: FilePath -> SpecGraph -> PartitionedSpec -> IO ()
+writeHsBootFiles root graph part =
+  void $ M.traverseWithKey (writeHsBootFile root graph part)
     (fmap (vSourceEntity . requiredLookup graph) <$> cycleBreakers)
 
 writeHsBootFile :: FilePath      -- ^ The source root
                 -> SpecGraph     -- ^ The specification graph
+                -> PartitionedSpec
                 -> ModuleName    -- ^ The module name we're writing
                 -> [SourceEntity]      -- ^ The symbols to export
                 -> IO ()
-writeHsBootFile root graph moduleName exports = do
+writeHsBootFile root graph part moduleName exports = do
   createModuleDirectory root moduleName
-  let moduleString = writeModule graph Boot moduleName exports
+  let moduleString = writeModule graph part Boot moduleName exports
   writeFile (moduleNameToFile root moduleName ++ "-boot") moduleString
 

--- a/generate/src/Write/CycleBreak.hs
+++ b/generate/src/Write/CycleBreak.hs
@@ -8,19 +8,18 @@ import           Write.Quirks
 import           Write.Utils
 import           Write.WriteMonad
 
-writeHsBootFiles :: FilePath -> SpecGraph -> NameLocations -> IO ()
-writeHsBootFiles root graph nameLocations =
-  void $ M.traverseWithKey (writeHsBootFile root graph nameLocations)
-                           cycleBreakers
+writeHsBootFiles :: FilePath -> SpecGraph -> IO ()
+writeHsBootFiles root graph =
+  void $ M.traverseWithKey (writeHsBootFile root graph)
+    (fmap (vSourceEntity . requiredLookup graph) <$> cycleBreakers)
 
 writeHsBootFile :: FilePath      -- ^ The source root
                 -> SpecGraph     -- ^ The specification graph
-                -> NameLocations -- ^ The map of names to modules
                 -> ModuleName    -- ^ The module name we're writing
-                -> [String]      -- ^ The symbols to export
+                -> [SourceEntity]      -- ^ The symbols to export
                 -> IO ()
-writeHsBootFile root graph nameLocations moduleName exports = do
+writeHsBootFile root graph moduleName exports = do
   createModuleDirectory root moduleName
-  let moduleString = writeModule graph nameLocations Boot moduleName exports
+  let moduleString = writeModule graph Boot moduleName exports
   writeFile (moduleNameToFile root moduleName ++ "-boot") moduleString
 

--- a/generate/src/Write/Enum.hs
+++ b/generate/src/Write/Enum.hs
@@ -34,22 +34,22 @@ writeEnum e = do
                                               ])
   tellExtension "GeneralizedNewtypeDeriving"
   tellExtension "PatternSynonyms"
-  pure [qc|-- ** {eName e}
+  pure [qc|-- ** {eHsName e}
 {predocComment $ fromMaybe "" (eComment e)}
-newtype {eName e} = {eName e} Int32
+newtype {eHsName e} = {eHsName e} Int32
   deriving (Eq, Storable)
 
-instance Show {eName e} where
+instance Show {eHsName e} where
   {indent 0 $ vcat (writeElementShowsPrec <$> eElements e)}
-  showsPrec p ({eName e} x) = showParen (p >= 11) (showString "{eName e} " . showsPrec 11 x)
+  showsPrec p ({eHsName e} x) = showParen (p >= 11) (showString "{eHsName e} " . showsPrec 11 x)
 
-instance Read {eName e} where
+instance Read {eHsName e} where
   readPrec = parens ( choose [ {indent (-2) . vcat $ intercalatePrepend "," (writeReadTuple <$> eElements e)}
                              ] +++
                       prec 10 (do
-                        expectP (Ident "{eName e}")
+                        expectP (Ident "{eHsName e}")
                         v <- step readPrec
-                        pure ({eName e} v)
+                        pure ({eHsName e} v)
                         )
                     )
 
@@ -59,11 +59,11 @@ instance Read {eName e} where
 writeElement :: Enum -> EnumElement -> Doc
 writeElement e el =
   [qc|{maybe "" predocComment (eeComment el)}
-pattern {eeName el} = {eName e} {showsPrec 10 (eeValue el) ""}|]
+pattern {eeHsName el} = {eHsName e} {showsPrec 10 (eeValue el) ""}|]
 
 writeElementShowsPrec :: EnumElement -> Doc
 writeElementShowsPrec el =
-  [qc|showsPrec _ {eeName el} = showString "{eeName el}"|]
+  [qc|showsPrec _ {eeHsName el} = showString "{eeHsName el}"|]
 
 writeReadTuple :: EnumElement -> Doc
-writeReadTuple el = [qc|("{eeName el}", pure {eeName el})|]
+writeReadTuple el = [qc|("{eeHsName el}", pure {eeHsName el})|]

--- a/generate/src/Write/Enum.hs
+++ b/generate/src/Write/Enum.hs
@@ -37,7 +37,7 @@ writeEnum e = do
   pure [qc|-- ** {eHsName e}
 {predocComment $ fromMaybe "" (eComment e)}
 newtype {eHsName e} = {eHsName e} Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show {eHsName e} where
   {indent 0 $ vcat (writeElementShowsPrec <$> eElements e)}

--- a/generate/src/Write/Module.hs
+++ b/generate/src/Write/Module.hs
@@ -11,6 +11,7 @@ import           Data.HashSet                  as S
 import           Data.Maybe                    (catMaybes)
 import           Data.String
 import           Spec.Graph
+import           Spec.Partition
 import           Text.InterpolatedString.Perl6
 import           Text.PrettyPrint.Leijen.Text  hiding ((<$>))
 import           Write.Quirks
@@ -20,12 +21,13 @@ import           Write.Vertex
 import           Write.WriteMonad
 
 writeModule :: SpecGraph
+            -> PartitionedSpec
             -> FileType
             -> ModuleName
             -> [SourceEntity]
             -> String
-writeModule graph boot (ModuleName n) entities = moduleString
-  where typeEnv = buildTypeEnvFromSpecGraph graph
+writeModule graph part boot (ModuleName n) entities = moduleString
+  where typeEnv = buildTypeEnvFromSpecGraph graph part
         (moduleString, (extraRequiredNames, extensions)) =
           runWrite typeEnv boot moduleWriter
         extensionDocs = getExtensionDoc <$> S.toList extensions

--- a/generate/src/Write/Module.hs
+++ b/generate/src/Write/Module.hs
@@ -11,7 +11,6 @@ import           Data.HashSet                  as S
 import           Data.Maybe                    (catMaybes)
 import           Data.String
 import           Spec.Graph
-import           Spec.Partition
 import           Text.InterpolatedString.Perl6
 import           Text.PrettyPrint.Leijen.Text  hiding ((<$>))
 import           Write.Quirks
@@ -21,28 +20,19 @@ import           Write.Vertex
 import           Write.WriteMonad
 
 writeModule :: SpecGraph
-            -> NameLocations
             -> FileType
             -> ModuleName
-            -> [String]
+            -> [SourceEntity]
             -> String
-writeModule graph nameLocations boot (ModuleName n) names = moduleString
+writeModule graph boot (ModuleName n) entities = moduleString
   where typeEnv = buildTypeEnvFromSpecGraph graph
         (moduleString, (extraRequiredNames, extensions)) =
           runWrite typeEnv boot moduleWriter
         extensionDocs = getExtensionDoc <$> S.toList extensions
-        getEntity name = let err = error ("exported name missing from spec graph " ++ name)
-                         in M.lookupDefault err name (gNameVertexMap graph)
-        moduleEntities = getEntity <$> names
-        isIncludeName = isIncludeVertex . getEntity
-        requiredNames = extraRequiredNames `S.union`
-                        S.map (nameToRequiredName graph)
-                              (S.filter (not . isIncludeName)
-                                        (allReachable moduleEntities)
-                                        `S.difference` S.fromList names)
-        imports = vcat (getImportDeclarations (ModuleName n) nameLocations requiredNames)
+        requiredNames = extraRequiredNames
+        imports = vcat (getImportDeclarations (ModuleName n) requiredNames)
         moduleWriter = do
-          definitions <- writeVertices (requiredLookup graph <$> names)
+          definitions <- writeVertices entities
           pure [qc|{vcat extensionDocs}
 module {n} where
 
@@ -55,22 +45,22 @@ getExtensionDoc :: String -> Doc
 getExtensionDoc e = let ed = fromString e :: Doc
                        in [qc|\{-# LANGUAGE {ed} #-}|]
 
-nameToRequiredName :: SpecGraph -> String -> RequiredName
-nameToRequiredName graph name =
-  case name of
-    "int32_t"  -> ExternalName (ModuleName "Data.Int")  "Int32"
-    "uint8_t"  -> ExternalName (ModuleName "Data.Word") "Word8"
-    "uint32_t" -> ExternalName (ModuleName "Data.Word") "Word32"
-    "uint64_t" -> ExternalName (ModuleName "Data.Word") "Word64"
-    "size_t"   -> ExternalName (ModuleName "Foreign.C.Types") "CSize(..)"
-    "void"     -> ExternalName (ModuleName "Data.Void") "Void"
-    "float"    -> ExternalName (ModuleName "Foreign.C.Types") "CFloat(..)"
-    _ -> if isTypeConstructor (requiredLookup graph name)
-           then InternalName WildCard name
-           else InternalName NoWildCard name
+-- nameToRequiredName :: SpecGraph -> String -> RequiredName
+-- nameToRequiredName graph name =
+--   case name of
+--     "int32_t"  -> ExternalName (ModuleName "Data.Int")  "Int32"
+--     "uint8_t"  -> ExternalName (ModuleName "Data.Word") "Word8"
+--     "uint32_t" -> ExternalName (ModuleName "Data.Word") "Word32"
+--     "uint64_t" -> ExternalName (ModuleName "Data.Word") "Word64"
+--     "size_t"   -> ExternalName (ModuleName "Foreign.C.Types") "CSize(..)"
+--     "void"     -> ExternalName (ModuleName "Data.Void") "Void"
+--     "float"    -> ExternalName (ModuleName "Foreign.C.Types") "CFloat(..)"
+--     _ -> if isTypeConstructor (requiredLookup graph name)
+--            then InternalName WildCard name
+--            else InternalName NoWildCard name
 
-getImportDeclarations :: ModuleName -> NameLocations -> HashSet RequiredName -> [Doc]
-getImportDeclarations importingModule nameLocations names =
+getImportDeclarations :: ModuleName -> HashSet RequiredName -> [Doc]
+getImportDeclarations importingModule names =
     fmap (writeImport . makeImportSourcy importingModule) .
       mergeImports $ imports
   where imports = catMaybes (getImportDeclaration <$> S.toList names)
@@ -78,18 +68,7 @@ getImportDeclarations importingModule nameLocations names =
           case rn of
             ExternalName moduleName name ->
               Just (Import NotSource moduleName [name])
-            InternalName wildCard name ->
-              if S.member name ignoredNames
-                then Nothing
-                else case M.lookup name nameLocations of
-                       Nothing ->
-                         error ("Imported name not in any module: " ++ name)
-                       Just (moduleName, hsName) ->
-                         case wildCard of
-                           WildCard ->
-                             Just $ Import NotSource moduleName [hsName ++ "(..)"]
-                           NoWildCard ->
-                             Just $ Import NotSource moduleName [hsName]
+            _ -> Nothing
 
 data Import = Import Source ModuleName [String]
 

--- a/generate/src/Write/Module.hs
+++ b/generate/src/Write/Module.hs
@@ -68,7 +68,7 @@ getImportDeclarations importingModule names =
   where imports = catMaybes (getImportDeclaration <$> S.toList names)
         getImportDeclaration rn =
           case rn of
-            ExternalName moduleName name ->
+            ExternalName moduleName name | moduleName /= importingModule ->
               Just (Import NotSource moduleName [name])
             _ -> Nothing
 

--- a/generate/src/Write/Module.hs
+++ b/generate/src/Write/Module.hs
@@ -84,12 +84,12 @@ getImportDeclarations importingModule nameLocations names =
                 else case M.lookup name nameLocations of
                        Nothing ->
                          error ("Imported name not in any module: " ++ name)
-                       Just moduleName ->
+                       Just (moduleName, hsName) ->
                          case wildCard of
                            WildCard ->
-                             Just $ Import NotSource moduleName [name ++ "(..)"]
+                             Just $ Import NotSource moduleName [hsName ++ "(..)"]
                            NoWildCard ->
-                             Just $ Import NotSource moduleName [name]
+                             Just $ Import NotSource moduleName [hsName]
 
 data Import = Import Source ModuleName [String]
 

--- a/generate/src/Write/Spec.hs
+++ b/generate/src/Write/Spec.hs
@@ -24,14 +24,15 @@ import           Write.WriteMonad
 writeSpecModules :: FilePath -> Spec -> IO ()
 writeSpecModules root spec = do
   let graph = getSpecGraph spec
-      partitions = M.toList $ moduleExports (partitionSpec spec)
+      part = partitionSpec spec
+      partitions = M.toList $ moduleExports part
       moduleNames = fst <$> partitions
-      moduleStrings = uncurry (writeModule graph Normal) <$>
+      moduleStrings = uncurry (writeModule graph part Normal) <$>
                       partitions
       modules = zip moduleNames moduleStrings
   traverse_ (createModuleDirectory root) (fst <$> modules)
   mapM_ (uncurry (writeModuleFile root)) modules
-  writeHsBootFiles root graph
+  writeHsBootFiles root graph part
   writeModuleFile root (ModuleName "Graphics.Vulkan")
                        (writeParentModule moduleNames)
 

--- a/generate/src/Write/Type/Base.hs
+++ b/generate/src/Write/Type/Base.hs
@@ -21,14 +21,14 @@ writeBaseType bt = if isTransparentBaseType bt
 writeTransparentBaseType :: BaseType -> Write Doc
 writeTransparentBaseType bt = do
   hsType <- cTypeToHsTypeString (btCType bt)
-  pure [qc|type {btName bt} = {hsType}
+  pure [qc|type {btHsName bt} = {hsType}
 |]
 
 writeNewBaseType :: BaseType -> Write Doc
 writeNewBaseType bt = do
   doesDeriveStorable
   hsType <- cTypeToHsTypeString (btCType bt)
-  pure [qc|newtype {btName bt} = {btName bt} {hsType}
+  pure [qc|newtype {btHsName bt} = {btHsName bt} {hsType}
   deriving (Eq, Storable)
 |]
 

--- a/generate/src/Write/Type/Base.hs
+++ b/generate/src/Write/Type/Base.hs
@@ -29,6 +29,6 @@ writeNewBaseType bt = do
   doesDeriveStorable
   hsType <- cTypeToHsTypeString (btCType bt)
   pure [qc|newtype {btHsName bt} = {btHsName bt} {hsType}
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 |]
 

--- a/generate/src/Write/Type/Bitmask.hs
+++ b/generate/src/Write/Type/Bitmask.hs
@@ -29,7 +29,7 @@ writeOpaqueBitmaskType bmt = do
   pure $ [qc|-- ** {bmtHsName bmt}
 {predocComment "Opaque flag"}
 newtype {bmtHsName bmt} = {bmtHsName bmt} {bmtHsType}
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 |]
 
 writeBitmaskTypeWithBits :: BitmaskType -> Bitmask -> Write Doc
@@ -58,7 +58,7 @@ writeBitmaskTypeWithBits bmt bm = do
   pure [qc|-- ** {bmtHsName bmt}
 {predocComment $ fromMaybe "" (bmComment bm)}
 newtype {bmtHsName bmt} = {bmtHsName bmt} {bmtHsType}
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show {bmtHsName bmt} where
   {indent 0 $ vcat (writeBitPositionShowsPrec <$> bmBitPositions bm)}

--- a/generate/src/Write/Type/Bitmask.hs
+++ b/generate/src/Write/Type/Bitmask.hs
@@ -55,7 +55,7 @@ writeBitmaskTypeWithBits bmt bm = do
     (ExternalName (ModuleName "GHC.Read") <$> [ "expectP"
                                               , "choose"
                                               ])
-  pure [qc|-- ** {bmtName bmt}
+  pure [qc|-- ** {bmtHsName bmt}
 {predocComment $ fromMaybe "" (bmComment bm)}
 newtype {bmtHsName bmt} = {bmtHsName bmt} {bmtHsType}
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/generate/src/Write/Type/Define.hs
+++ b/generate/src/Write/Type/Define.hs
@@ -32,7 +32,7 @@ writeDefine d =
       boundNames = boundVariablesFromDefine header
       (expression, requiredNames) =
         parseCExpressionToHsExpression value
-      hsName = camelCase_ $ dName d
+      hsName = dHsName d
       -- TODO: This assumes the defines are of type uint32_t
       Right uint32_t = C.cIdentifierFromString "uint32_t"
   in do tellRequiredNames (S.toList requiredNames)

--- a/generate/src/Write/Type/Define.hs
+++ b/generate/src/Write/Type/Define.hs
@@ -6,7 +6,9 @@ module Write.Type.Define
   ) where
 
 import           Control.Applicative           ((<|>))
+import           Control.Monad.Reader
 import           Control.Monad.Writer
+import qualified Data.HashMap.Lazy             as M
 import qualified Data.HashSet                  as S
 import           Data.String
 import qualified Language.C.Types              as C
@@ -14,6 +16,7 @@ import           Language.Haskell.Exts.Pretty  (prettyPrint)
 import           Language.Haskell.Exts.Syntax  hiding (Assoc (..), ModuleName)
 import           Prelude                       hiding (exp)
 import           Spec.Type
+import           Spec.TypeEnv
 import           Text.InterpolatedString.Perl6
 import           Text.Parser.Combinators
 import           Text.Parser.Expression
@@ -30,12 +33,12 @@ writeDefine :: Define -> Write Doc
 writeDefine d =
   let (header, value) = head . dSymTab $ d
       boundNames = boundVariablesFromDefine header
-      (expression, requiredNames) =
-        parseCExpressionToHsExpression value
       hsName = dHsName d
       -- TODO: This assumes the defines are of type uint32_t
       Right uint32_t = C.cIdentifierFromString "uint32_t"
-  in do tellRequiredNames (S.toList requiredNames)
+  in do (expression, requiredNames) <-
+          parseCExpressionToHsExpression value
+        tellRequiredNames (S.toList requiredNames)
         hsElemType <- cTypeToHsType (C.TypeSpecifier (C.Specifiers [] [] [])
                                     (C.TypeName uint32_t))
         let hsType = foldr TyFun hsElemType (hsElemType <$ boundNames)
@@ -62,11 +65,12 @@ identifierStyle = IdentifierStyle{ _styleName = "ident"
                                  , _styleReservedHighlight = ReservedIdentifier
                                  }
 
-type ExpressionParser = WriterT (S.HashSet RequiredName) Parser
+type ExpressionParser = ReaderT TypeEnv (WriterT (S.HashSet RequiredName) Parser)
 
-parseCExpressionToHsExpression :: String -> (Exp, S.HashSet RequiredName)
-parseCExpressionToHsExpression s =
-  case parseString (runWriterT (exp <* eof)) mempty s of
+parseCExpressionToHsExpression :: String -> Write (Exp, S.HashSet RequiredName)
+parseCExpressionToHsExpression s = do
+  te <- askTypeEnv
+  return $ case parseString (runWriterT $ runReaderT (exp <* eof) te) mempty s of
     Failure e -> error ("Failed to parse C expression\n" ++ show e)
     Success e -> e
 
@@ -106,13 +110,19 @@ functionCall =
      pure $ foldl App functionName arguments
 
 nameExp :: ExpressionParser Exp
-nameExp = Var . UnQual . Ident . camelCase_ <$> name
+nameExp = do
+  typeMap <- teNameLocations <$> ask
+  cName <- name
+  hsName <- case M.lookup cName typeMap of
+    Just (m, n) -> do
+      tell (S.singleton $ ExternalName m n)
+      pure n
+    Nothing ->
+      pure cName
+  return $ Var $ UnQual $ Ident hsName
 
 litExp :: ExpressionParser Exp
 litExp = Lit . Int <$> natural
 
 castExp :: ExpressionParser Exp
 castExp = parens name *> parens exp
-
-
-

--- a/generate/src/Write/Type/FuncPointer.hs
+++ b/generate/src/Write/Type/FuncPointer.hs
@@ -13,6 +13,6 @@ import           Write.WriteMonad
 writeFuncPointerType :: FuncPointerType -> Write Doc
 writeFuncPointerType fpt = do
   hsType <- cTypeToHsTypeString (fptCType fpt)
-  pure [qc|type {fptName fpt} = {hsType}
+  pure [qc|type {fptHsName fpt} = {hsType}
 |]
 

--- a/generate/src/Write/Type/Handle.hs
+++ b/generate/src/Write/Type/Handle.hs
@@ -27,7 +27,7 @@ writeDispatchableHandleType ht t = do
   tellRequiredName (ExternalName (ModuleName "Foreign.Ptr") "Ptr")
   hsType <- cTypeToHsTypeString t
   pure [qc|data {hsType}
-type {htName ht} = Ptr {hsType}
+type {htHsName ht} = Ptr {hsType}
 |]
 
 writeNonDispatchableHandleType :: HandleType -> CType -> Write Doc
@@ -38,9 +38,9 @@ writeNonDispatchableHandleType ht t = do
   let derivingString :: Doc
       derivingString = if boot
                          then [qc|
-instance Eq {htName ht}
-instance Storable {htName ht}|]
+instance Eq {htHsName ht}
+instance Storable {htHsName ht}|]
                          else fromString "deriving (Eq, Storable)"
-  pure [qc|newtype {htName ht} = {htName ht} {hsType}
+  pure [qc|newtype {htHsName ht} = {htHsName ht} {hsType}
   {derivingString}
 |]

--- a/generate/src/Write/Type/Handle.hs
+++ b/generate/src/Write/Type/Handle.hs
@@ -39,8 +39,9 @@ writeNonDispatchableHandleType ht t = do
       derivingString = if boot
                          then [qc|
 instance Eq {htHsName ht}
+instance Ord {htHsName ht}
 instance Storable {htHsName ht}|]
-                         else fromString "deriving (Eq, Storable)"
+                         else fromString "deriving (Eq, Ord, Storable)"
   pure [qc|newtype {htHsName ht} = {htHsName ht} {hsType}
   {derivingString}
 |]

--- a/generate/src/Write/Type/Struct.hs
+++ b/generate/src/Write/Type/Struct.hs
@@ -35,7 +35,7 @@ data {stHsName st} =
   {stHsName st}\{ {indent (-2) .  vsep $
                  (intercalateRecordCommas structMemberDocs ++
                   [fromString "\}"])}
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 {writeStructStorableInstance env st}
 |]
@@ -55,7 +55,7 @@ writeUnionType ut = do
   pure [qc|{predocComment unionComment}
 data {utHsName ut} = {indent (-2) . vsep $
                     intercalatePrepend (fromString "|") unionMemberDocs}
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 {writeUnionStorableInstance env ut}
 |]

--- a/generate/src/Write/Type/Struct.hs
+++ b/generate/src/Write/Type/Struct.hs
@@ -112,7 +112,7 @@ writeStructStorableInstance env st
   | null (stMembers st) = error "zero member struct...?"
   | otherwise = let memberPacking = calculateMemberPacking env (stMembers st)
                     TypeInfo structSize structAlignment = getTypeInfo env (stName st)
-                in [qc|instance Storable {stName st} where
+                in [qc|instance Storable {stHsName st} where
   sizeOf ~_ = {structSize}
   alignment ~_ = {structAlignment}
   peek ptr = {stHsName st} <$> {indent (-4) . vsep $

--- a/generate/src/Write/TypeConverter.hs
+++ b/generate/src/Write/TypeConverter.hs
@@ -136,7 +136,7 @@ arraySizeToNat s = case s of
                        sizeName <- case Map.lookup sizeId typeMap of
                          Just (m, n) -> do
                            tellRequiredName (ExternalName m n)
-                           pure sizeId
+                           pure n
                          Nothing ->
                            pure sizeId
                        let typeNat = PromotedCon False (UnQual $ Ident sizeName)

--- a/generate/src/Write/Utils.hs
+++ b/generate/src/Write/Utils.hs
@@ -19,7 +19,7 @@ import           Text.PrettyPrint.Leijen.Text hiding (string, (<$>), (</>))
 newtype ModuleName = ModuleName{ unModuleName :: String }
   deriving(Eq, Show, Hashable)
 
-type NameLocations = HashMap String ModuleName
+type NameLocations = HashMap String (ModuleName, String)
 
 comment :: String -> String
 comment "" = ""

--- a/generate/src/Write/Utils.hs
+++ b/generate/src/Write/Utils.hs
@@ -123,9 +123,7 @@ pascalCase_ = concatMap word . splitOn "_"
 -- | Concatenate words separated by underscores in the string and make the
 -- first letter of each one but the first uppercase.
 camelCase_ :: String -> String
-camelCase_ "" = ""
-camelCase_ s = let w:ws = splitOn "_" . fmap toLower $ s
-               in w ++ concatMap upperFirst ws
+camelCase_ = lowerFirst . pascalCase_
 
 getModuleBaseName :: ModuleName -> String
 getModuleBaseName (ModuleName moduleName) =

--- a/generate/src/Write/Utils.hs
+++ b/generate/src/Write/Utils.hs
@@ -116,7 +116,9 @@ pascalCase = concatMap upperFirst . words
 -- | Concatenate words separated by underscores in the string and make the
 -- first letter of each one uppercase.
 pascalCase_ :: String -> String
-pascalCase_ = concatMap upperFirst . splitOn "_"
+pascalCase_ = concatMap word . splitOn "_"
+  where word "" = ""
+        word (x:xs) = toUpper x : (toLower <$> xs)
 
 -- | Concatenate words separated by underscores in the string and make the
 -- first letter of each one but the first uppercase.

--- a/generate/src/Write/Utils.hs
+++ b/generate/src/Write/Utils.hs
@@ -51,6 +51,11 @@ showHex' n = sign ++ "0x" ++ showHex n ""
                  then "-"
                  else ""
 
+-- | Mame the first letter of the word lowercase
+lowerFirst :: String -> String
+lowerFirst "" = ""
+lowerFirst (x:xs) = toLower x : xs
+
 -- | Mame the first letter of the word uppercase
 upperFirst :: String -> String
 upperFirst "" = ""

--- a/generate/src/Write/Vertex.hs
+++ b/generate/src/Write/Vertex.hs
@@ -13,12 +13,12 @@ import           Write.Type.Handle
 import           Write.Type.Struct
 import           Write.WriteMonad
 
-writeVertices :: [Vertex] -> Write Doc
+writeVertices :: [SourceEntity] -> Write Doc
 writeVertices = fmap vcat . traverse writeVertex
 
-writeVertex :: Vertex -> Write Doc
-writeVertex v =
-  case vSourceEntity v of
+writeVertex :: SourceEntity -> Write Doc
+writeVertex se =
+  case se of
     AnInclude _ -> pure empty
     ADefine define -> writeDefine define
     ABaseType baseType -> writeBaseType baseType

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Buffer where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,15 +22,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -40,14 +29,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           , VkSharingMode(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkCreateBuffer
 foreign import ccall "vkCreateBuffer" vkCreateBuffer ::

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Buffer where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -51,9 +51,9 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkCreateBuffer
 foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
-  VkDevice ->
+  Device ->
   Ptr VkBufferCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkBuffer -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Buffer -> IO VkResult
 
 -- ** VkBufferCreateFlags
 
@@ -151,21 +151,21 @@ pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = VkBufferUsageFlagBits 0x100
 
 -- ** vkDestroyBuffer
 foreign import ccall "vkDestroyBuffer" vkDestroyBuffer ::
-  VkDevice -> VkBuffer -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Buffer -> Ptr VkAllocationCallbacks -> IO ()
 
-newtype VkBuffer = VkBuffer Word64
+newtype Buffer = Buffer Word64
   deriving (Eq, Storable)
 
 
 data VkBufferCreateInfo =
-  VkBufferCreateInfo{ vkSType :: VkStructureType 
-                    , vkPNext :: Ptr Void 
-                    , vkFlags :: VkBufferCreateFlags 
-                    , vkSize :: VkDeviceSize 
-                    , vkUsage :: VkBufferUsageFlags 
-                    , vkSharingMode :: VkSharingMode 
-                    , vkQueueFamilyIndexCount :: Word32 
-                    , vkPQueueFamilyIndices :: Ptr Word32 
+  VkBufferCreateInfo{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , flags :: VkBufferCreateFlags 
+                    , size :: VkDeviceSize 
+                    , usage :: VkBufferUsageFlags 
+                    , sharingMode :: VkSharingMode 
+                    , queueFamilyIndexCount :: Word32 
+                    , pQueueFamilyIndices :: Ptr Word32 
                     }
   deriving (Eq)
 
@@ -180,13 +180,13 @@ instance Storable VkBufferCreateInfo where
                                 <*> peek (ptr `plusPtr` 36)
                                 <*> peek (ptr `plusPtr` 40)
                                 <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkSize (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkUsage (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 36) (vkSharingMode (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkQueueFamilyIndexCount (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkPQueueFamilyIndices (poked :: VkBufferCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 24) (size (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 32) (usage (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 36) (sharingMode (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 40) (queueFamilyIndexCount (poked :: VkBufferCreateInfo))
+                *> poke (ptr `plusPtr` 48) (pQueueFamilyIndices (poked :: VkBufferCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -33,57 +33,57 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , SharingMode(..)
+                           , StructureType(..)
+                           , Result(..)
                            , VkDeviceSize(..)
-                           , VkSharingMode(..)
                            )
 
 -- ** vkCreateBuffer
 foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
   Device ->
   Ptr BufferCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Buffer -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Buffer -> IO Result
 
 -- ** VkBufferCreateFlags
 
-newtype VkBufferCreateFlags = VkBufferCreateFlags VkFlags
+newtype BufferCreateFlags = BufferCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkBufferCreateFlags where
+instance Show BufferCreateFlags where
   showsPrec _ VK_BUFFER_CREATE_SPARSE_BINDING_BIT = showString "VK_BUFFER_CREATE_SPARSE_BINDING_BIT"
   showsPrec _ VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT"
   showsPrec _ VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = showString "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT"
   
-  showsPrec p (VkBufferCreateFlags x) = showParen (p >= 11) (showString "VkBufferCreateFlags " . showsPrec 11 x)
+  showsPrec p (BufferCreateFlags x) = showParen (p >= 11) (showString "BufferCreateFlags " . showsPrec 11 x)
 
-instance Read VkBufferCreateFlags where
+instance Read BufferCreateFlags where
   readPrec = parens ( choose [ ("VK_BUFFER_CREATE_SPARSE_BINDING_BIT", pure VK_BUFFER_CREATE_SPARSE_BINDING_BIT)
                              , ("VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT", pure VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT)
                              , ("VK_BUFFER_CREATE_SPARSE_ALIASED_BIT", pure VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBufferCreateFlags")
+                        expectP (Ident "BufferCreateFlags")
                         v <- step readPrec
-                        pure (VkBufferCreateFlags v)
+                        pure (BufferCreateFlags v)
                         )
                     )
 
 -- | Buffer should support sparse backing
-pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = VkBufferCreateFlags 0x1
+pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = BufferCreateFlags 0x1
 -- | Buffer should support sparse backing with partial residency
-pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = VkBufferCreateFlags 0x2
+pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = BufferCreateFlags 0x2
 -- | Buffer should support constent data access to physical memory blocks mapped into multiple locations of sparse buffers
-pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = VkBufferCreateFlags 0x4
+pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = BufferCreateFlags 0x4
 
 
 -- ** VkBufferUsageFlags
 
-newtype VkBufferUsageFlags = VkBufferUsageFlags VkFlags
+newtype BufferUsageFlags = BufferUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkBufferUsageFlags where
+instance Show BufferUsageFlags where
   showsPrec _ VK_BUFFER_USAGE_TRANSFER_SRC_BIT = showString "VK_BUFFER_USAGE_TRANSFER_SRC_BIT"
   showsPrec _ VK_BUFFER_USAGE_TRANSFER_DST_BIT = showString "VK_BUFFER_USAGE_TRANSFER_DST_BIT"
   showsPrec _ VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = showString "VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT"
@@ -94,9 +94,9 @@ instance Show VkBufferUsageFlags where
   showsPrec _ VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = showString "VK_BUFFER_USAGE_VERTEX_BUFFER_BIT"
   showsPrec _ VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = showString "VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT"
   
-  showsPrec p (VkBufferUsageFlags x) = showParen (p >= 11) (showString "VkBufferUsageFlags " . showsPrec 11 x)
+  showsPrec p (BufferUsageFlags x) = showParen (p >= 11) (showString "BufferUsageFlags " . showsPrec 11 x)
 
-instance Read VkBufferUsageFlags where
+instance Read BufferUsageFlags where
   readPrec = parens ( choose [ ("VK_BUFFER_USAGE_TRANSFER_SRC_BIT", pure VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
                              , ("VK_BUFFER_USAGE_TRANSFER_DST_BIT", pure VK_BUFFER_USAGE_TRANSFER_DST_BIT)
                              , ("VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT", pure VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)
@@ -108,30 +108,30 @@ instance Read VkBufferUsageFlags where
                              , ("VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT", pure VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBufferUsageFlags")
+                        expectP (Ident "BufferUsageFlags")
                         v <- step readPrec
-                        pure (VkBufferUsageFlags v)
+                        pure (BufferUsageFlags v)
                         )
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_SRC_BIT = VkBufferUsageFlags 0x1
+pattern VK_BUFFER_USAGE_TRANSFER_SRC_BIT = BufferUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_DST_BIT = VkBufferUsageFlags 0x2
+pattern VK_BUFFER_USAGE_TRANSFER_DST_BIT = BufferUsageFlags 0x2
 -- | Can be used as TBO
-pattern VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = VkBufferUsageFlags 0x4
+pattern VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = BufferUsageFlags 0x4
 -- | Can be used as IBO
-pattern VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = VkBufferUsageFlags 0x8
+pattern VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = BufferUsageFlags 0x8
 -- | Can be used as UBO
-pattern VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = VkBufferUsageFlags 0x10
+pattern VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = BufferUsageFlags 0x10
 -- | Can be used as SSBO
-pattern VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = VkBufferUsageFlags 0x20
+pattern VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = BufferUsageFlags 0x20
 -- | Can be used as source of fixed-function index fetch (index buffer)
-pattern VK_BUFFER_USAGE_INDEX_BUFFER_BIT = VkBufferUsageFlags 0x40
+pattern VK_BUFFER_USAGE_INDEX_BUFFER_BIT = BufferUsageFlags 0x40
 -- | Can be used as source of fixed-function vertex fetch (VBO)
-pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = VkBufferUsageFlags 0x80
+pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = BufferUsageFlags 0x80
 -- | Can be the source of indirect parameters (e.g. indirect buffer, parameter buffer)
-pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = VkBufferUsageFlags 0x100
+pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = BufferUsageFlags 0x100
 
 
 -- ** vkDestroyBuffer
@@ -143,12 +143,12 @@ newtype Buffer = Buffer Word64
 
 
 data BufferCreateInfo =
-  BufferCreateInfo{ sType :: VkStructureType 
+  BufferCreateInfo{ sType :: StructureType 
                   , pNext :: Ptr Void 
-                  , flags :: VkBufferCreateFlags 
+                  , flags :: BufferCreateFlags 
                   , size :: VkDeviceSize 
-                  , usage :: VkBufferUsageFlags 
-                  , sharingMode :: VkSharingMode 
+                  , usage :: BufferUsageFlags 
+                  , sharingMode :: SharingMode 
                   , queueFamilyIndexCount :: Word32 
                   , pQueueFamilyIndices :: Ptr Word32 
                   }

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -46,7 +46,7 @@ foreign import ccall "vkCreateBuffer" createBuffer ::
   Ptr BufferCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Buffer -> IO Result
 
--- ** VkBufferCreateFlags
+-- ** BufferCreateFlags
 
 newtype BufferCreateFlags = BufferCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -78,7 +78,7 @@ pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = BufferCreateFlags 0x2
 pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = BufferCreateFlags 0x4
 
 
--- ** VkBufferUsageFlags
+-- ** BufferUsageFlags
 
 newtype BufferUsageFlags = BufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -52,16 +52,16 @@ newtype BufferCreateFlags = BufferCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show BufferCreateFlags where
-  showsPrec _ VK_BUFFER_CREATE_SPARSE_BINDING_BIT = showString "VK_BUFFER_CREATE_SPARSE_BINDING_BIT"
-  showsPrec _ VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT"
-  showsPrec _ VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = showString "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT"
+  showsPrec _ BufferCreateSparseBindingBit = showString "BufferCreateSparseBindingBit"
+  showsPrec _ BufferCreateSparseResidencyBit = showString "BufferCreateSparseResidencyBit"
+  showsPrec _ BufferCreateSparseAliasedBit = showString "BufferCreateSparseAliasedBit"
   
   showsPrec p (BufferCreateFlags x) = showParen (p >= 11) (showString "BufferCreateFlags " . showsPrec 11 x)
 
 instance Read BufferCreateFlags where
-  readPrec = parens ( choose [ ("VK_BUFFER_CREATE_SPARSE_BINDING_BIT", pure VK_BUFFER_CREATE_SPARSE_BINDING_BIT)
-                             , ("VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT", pure VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT)
-                             , ("VK_BUFFER_CREATE_SPARSE_ALIASED_BIT", pure VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)
+  readPrec = parens ( choose [ ("BufferCreateSparseBindingBit", pure BufferCreateSparseBindingBit)
+                             , ("BufferCreateSparseResidencyBit", pure BufferCreateSparseResidencyBit)
+                             , ("BufferCreateSparseAliasedBit", pure BufferCreateSparseAliasedBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "BufferCreateFlags")
@@ -71,11 +71,11 @@ instance Read BufferCreateFlags where
                     )
 
 -- | Buffer should support sparse backing
-pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = BufferCreateFlags 0x1
+pattern BufferCreateSparseBindingBit = BufferCreateFlags 0x1
 -- | Buffer should support sparse backing with partial residency
-pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = BufferCreateFlags 0x2
+pattern BufferCreateSparseResidencyBit = BufferCreateFlags 0x2
 -- | Buffer should support constent data access to physical memory blocks mapped into multiple locations of sparse buffers
-pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = BufferCreateFlags 0x4
+pattern BufferCreateSparseAliasedBit = BufferCreateFlags 0x4
 
 
 -- ** BufferUsageFlags
@@ -84,28 +84,28 @@ newtype BufferUsageFlags = BufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show BufferUsageFlags where
-  showsPrec _ VK_BUFFER_USAGE_TRANSFER_SRC_BIT = showString "VK_BUFFER_USAGE_TRANSFER_SRC_BIT"
-  showsPrec _ VK_BUFFER_USAGE_TRANSFER_DST_BIT = showString "VK_BUFFER_USAGE_TRANSFER_DST_BIT"
-  showsPrec _ VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = showString "VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = showString "VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = showString "VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = showString "VK_BUFFER_USAGE_STORAGE_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_INDEX_BUFFER_BIT = showString "VK_BUFFER_USAGE_INDEX_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = showString "VK_BUFFER_USAGE_VERTEX_BUFFER_BIT"
-  showsPrec _ VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = showString "VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT"
+  showsPrec _ BufferUsageTransferSrcBit = showString "BufferUsageTransferSrcBit"
+  showsPrec _ BufferUsageTransferDstBit = showString "BufferUsageTransferDstBit"
+  showsPrec _ BufferUsageUniformTexelBufferBit = showString "BufferUsageUniformTexelBufferBit"
+  showsPrec _ BufferUsageStorageTexelBufferBit = showString "BufferUsageStorageTexelBufferBit"
+  showsPrec _ BufferUsageUniformBufferBit = showString "BufferUsageUniformBufferBit"
+  showsPrec _ BufferUsageStorageBufferBit = showString "BufferUsageStorageBufferBit"
+  showsPrec _ BufferUsageIndexBufferBit = showString "BufferUsageIndexBufferBit"
+  showsPrec _ BufferUsageVertexBufferBit = showString "BufferUsageVertexBufferBit"
+  showsPrec _ BufferUsageIndirectBufferBit = showString "BufferUsageIndirectBufferBit"
   
   showsPrec p (BufferUsageFlags x) = showParen (p >= 11) (showString "BufferUsageFlags " . showsPrec 11 x)
 
 instance Read BufferUsageFlags where
-  readPrec = parens ( choose [ ("VK_BUFFER_USAGE_TRANSFER_SRC_BIT", pure VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
-                             , ("VK_BUFFER_USAGE_TRANSFER_DST_BIT", pure VK_BUFFER_USAGE_TRANSFER_DST_BIT)
-                             , ("VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT", pure VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT", pure VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT", pure VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_STORAGE_BUFFER_BIT", pure VK_BUFFER_USAGE_STORAGE_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_INDEX_BUFFER_BIT", pure VK_BUFFER_USAGE_INDEX_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_VERTEX_BUFFER_BIT", pure VK_BUFFER_USAGE_VERTEX_BUFFER_BIT)
-                             , ("VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT", pure VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
+  readPrec = parens ( choose [ ("BufferUsageTransferSrcBit", pure BufferUsageTransferSrcBit)
+                             , ("BufferUsageTransferDstBit", pure BufferUsageTransferDstBit)
+                             , ("BufferUsageUniformTexelBufferBit", pure BufferUsageUniformTexelBufferBit)
+                             , ("BufferUsageStorageTexelBufferBit", pure BufferUsageStorageTexelBufferBit)
+                             , ("BufferUsageUniformBufferBit", pure BufferUsageUniformBufferBit)
+                             , ("BufferUsageStorageBufferBit", pure BufferUsageStorageBufferBit)
+                             , ("BufferUsageIndexBufferBit", pure BufferUsageIndexBufferBit)
+                             , ("BufferUsageVertexBufferBit", pure BufferUsageVertexBufferBit)
+                             , ("BufferUsageIndirectBufferBit", pure BufferUsageIndirectBufferBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "BufferUsageFlags")
@@ -115,23 +115,23 @@ instance Read BufferUsageFlags where
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_SRC_BIT = BufferUsageFlags 0x1
+pattern BufferUsageTransferSrcBit = BufferUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_DST_BIT = BufferUsageFlags 0x2
+pattern BufferUsageTransferDstBit = BufferUsageFlags 0x2
 -- | Can be used as TBO
-pattern VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = BufferUsageFlags 0x4
+pattern BufferUsageUniformTexelBufferBit = BufferUsageFlags 0x4
 -- | Can be used as IBO
-pattern VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = BufferUsageFlags 0x8
+pattern BufferUsageStorageTexelBufferBit = BufferUsageFlags 0x8
 -- | Can be used as UBO
-pattern VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = BufferUsageFlags 0x10
+pattern BufferUsageUniformBufferBit = BufferUsageFlags 0x10
 -- | Can be used as SSBO
-pattern VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = BufferUsageFlags 0x20
+pattern BufferUsageStorageBufferBit = BufferUsageFlags 0x20
 -- | Can be used as source of fixed-function index fetch (index buffer)
-pattern VK_BUFFER_USAGE_INDEX_BUFFER_BIT = BufferUsageFlags 0x40
+pattern BufferUsageIndexBufferBit = BufferUsageFlags 0x40
 -- | Can be used as source of fixed-function vertex fetch (VBO)
-pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = BufferUsageFlags 0x80
+pattern BufferUsageVertexBufferBit = BufferUsageFlags 0x80
 -- | Can be the source of indirect parameters (e.g. indirect buffer, parameter buffer)
-pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = BufferUsageFlags 0x100
+pattern BufferUsageIndirectBufferBit = BufferUsageFlags 0x100
 
 
 -- ** destroyBuffer

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -40,8 +40,8 @@ import Graphics.Vulkan.Core( SharingMode(..)
                            , Flags(..)
                            )
 
--- ** vkCreateBuffer
-foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
+-- ** createBuffer
+foreign import ccall "vkCreateBuffer" createBuffer ::
   Device ->
   Ptr BufferCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Buffer -> IO Result
@@ -134,8 +134,8 @@ pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = BufferUsageFlags 0x80
 pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = BufferUsageFlags 0x100
 
 
--- ** vkDestroyBuffer
-foreign import ccall "vkDestroyBuffer" vkDestroyBuffer ::
+-- ** destroyBuffer
+foreign import ccall "vkDestroyBuffer" destroyBuffer ::
   Device -> Buffer -> Ptr AllocationCallbacks -> IO ()
 
 newtype Buffer = Buffer Word64

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -33,11 +33,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , SharingMode(..)
+import Graphics.Vulkan.Core( SharingMode(..)
                            , StructureType(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 
 -- ** vkCreateBuffer
@@ -48,7 +48,7 @@ foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
 
 -- ** VkBufferCreateFlags
 
-newtype BufferCreateFlags = BufferCreateFlags VkFlags
+newtype BufferCreateFlags = BufferCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show BufferCreateFlags where
@@ -80,7 +80,7 @@ pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = BufferCreateFlags 0x4
 
 -- ** VkBufferUsageFlags
 
-newtype BufferUsageFlags = BufferUsageFlags VkFlags
+newtype BufferUsageFlags = BufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show BufferUsageFlags where
@@ -146,7 +146,7 @@ data BufferCreateInfo =
   BufferCreateInfo{ sType :: StructureType 
                   , pNext :: Ptr Void 
                   , flags :: BufferCreateFlags 
-                  , size :: VkDeviceSize 
+                  , size :: DeviceSize 
                   , usage :: BufferUsageFlags 
                   , sharingMode :: SharingMode 
                   , queueFamilyIndexCount :: Word32 

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -24,7 +24,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -43,8 +43,8 @@ import Graphics.Vulkan.Core( VkStructureType(..)
 -- ** vkCreateBuffer
 foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
   Device ->
-  Ptr VkBufferCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Buffer -> IO VkResult
+  Ptr BufferCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Buffer -> IO VkResult
 
 -- ** VkBufferCreateFlags
 
@@ -136,42 +136,42 @@ pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = VkBufferUsageFlags 0x100
 
 -- ** vkDestroyBuffer
 foreign import ccall "vkDestroyBuffer" vkDestroyBuffer ::
-  Device -> Buffer -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Buffer -> Ptr AllocationCallbacks -> IO ()
 
 newtype Buffer = Buffer Word64
   deriving (Eq, Storable)
 
 
-data VkBufferCreateInfo =
-  VkBufferCreateInfo{ sType :: VkStructureType 
-                    , pNext :: Ptr Void 
-                    , flags :: VkBufferCreateFlags 
-                    , size :: VkDeviceSize 
-                    , usage :: VkBufferUsageFlags 
-                    , sharingMode :: VkSharingMode 
-                    , queueFamilyIndexCount :: Word32 
-                    , pQueueFamilyIndices :: Ptr Word32 
-                    }
+data BufferCreateInfo =
+  BufferCreateInfo{ sType :: VkStructureType 
+                  , pNext :: Ptr Void 
+                  , flags :: VkBufferCreateFlags 
+                  , size :: VkDeviceSize 
+                  , usage :: VkBufferUsageFlags 
+                  , sharingMode :: VkSharingMode 
+                  , queueFamilyIndexCount :: Word32 
+                  , pQueueFamilyIndices :: Ptr Word32 
+                  }
   deriving (Eq)
 
-instance Storable VkBufferCreateInfo where
+instance Storable BufferCreateInfo where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkBufferCreateInfo <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 8)
-                                <*> peek (ptr `plusPtr` 16)
-                                <*> peek (ptr `plusPtr` 24)
-                                <*> peek (ptr `plusPtr` 32)
-                                <*> peek (ptr `plusPtr` 36)
-                                <*> peek (ptr `plusPtr` 40)
-                                <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 24) (size (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 32) (usage (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 36) (sharingMode (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 40) (queueFamilyIndexCount (poked :: VkBufferCreateInfo))
-                *> poke (ptr `plusPtr` 48) (pQueueFamilyIndices (poked :: VkBufferCreateInfo))
+  peek ptr = BufferCreateInfo <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 8)
+                              <*> peek (ptr `plusPtr` 16)
+                              <*> peek (ptr `plusPtr` 24)
+                              <*> peek (ptr `plusPtr` 32)
+                              <*> peek (ptr `plusPtr` 36)
+                              <*> peek (ptr `plusPtr` 40)
+                              <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 24) (size (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 32) (usage (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 36) (sharingMode (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 40) (queueFamilyIndexCount (poked :: BufferCreateInfo))
+                *> poke (ptr `plusPtr` 48) (pQueueFamilyIndices (poked :: BufferCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -49,7 +49,7 @@ foreign import ccall "vkCreateBuffer" createBuffer ::
 -- ** BufferCreateFlags
 
 newtype BufferCreateFlags = BufferCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show BufferCreateFlags where
   showsPrec _ BufferCreateSparseBindingBit = showString "BufferCreateSparseBindingBit"
@@ -81,7 +81,7 @@ pattern BufferCreateSparseAliasedBit = BufferCreateFlags 0x4
 -- ** BufferUsageFlags
 
 newtype BufferUsageFlags = BufferUsageFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show BufferUsageFlags where
   showsPrec _ BufferUsageTransferSrcBit = showString "BufferUsageTransferSrcBit"
@@ -139,7 +139,7 @@ foreign import ccall "vkDestroyBuffer" destroyBuffer ::
   Device -> Buffer -> Ptr AllocationCallbacks -> IO ()
 
 newtype Buffer = Buffer Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data BufferCreateInfo =
@@ -152,7 +152,7 @@ data BufferCreateInfo =
                   , queueFamilyIndexCount :: Word32 
                   , pQueueFamilyIndices :: Ptr Word32 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BufferCreateInfo where
   sizeOf ~_ = 56

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -4,22 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Buffer where
 
-import Graphics.Vulkan.Device( Device
-                             )
-import Graphics.Vulkan.Buffer( Buffer
-                             , VkBufferCreateFlags
-                             , VkBufferUsageFlags
-                             , VkBufferCreateInfo
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Bits( Bits
@@ -27,9 +22,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -38,11 +33,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkStructureType
-                           , VkSharingMode
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
+                           , VkSharingMode(..)
                            )
 
 -- ** vkCreateBuffer
@@ -53,48 +48,42 @@ foreign import ccall "vkCreateBuffer" vkCreateBuffer ::
 
 -- ** VkBufferCreateFlags
 
-newtype VkBufferCreateFlagBits = VkBufferCreateFlagBits VkFlags
+newtype VkBufferCreateFlags = VkBufferCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkBufferCreateFlagBits
-type VkBufferCreateFlags = VkBufferCreateFlagBits
-
-instance Show VkBufferCreateFlagBits where
+instance Show VkBufferCreateFlags where
   showsPrec _ VK_BUFFER_CREATE_SPARSE_BINDING_BIT = showString "VK_BUFFER_CREATE_SPARSE_BINDING_BIT"
   showsPrec _ VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT"
   showsPrec _ VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = showString "VK_BUFFER_CREATE_SPARSE_ALIASED_BIT"
   
-  showsPrec p (VkBufferCreateFlagBits x) = showParen (p >= 11) (showString "VkBufferCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkBufferCreateFlags x) = showParen (p >= 11) (showString "VkBufferCreateFlags " . showsPrec 11 x)
 
-instance Read VkBufferCreateFlagBits where
+instance Read VkBufferCreateFlags where
   readPrec = parens ( choose [ ("VK_BUFFER_CREATE_SPARSE_BINDING_BIT", pure VK_BUFFER_CREATE_SPARSE_BINDING_BIT)
                              , ("VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT", pure VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT)
                              , ("VK_BUFFER_CREATE_SPARSE_ALIASED_BIT", pure VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBufferCreateFlagBits")
+                        expectP (Ident "VkBufferCreateFlags")
                         v <- step readPrec
-                        pure (VkBufferCreateFlagBits v)
+                        pure (VkBufferCreateFlags v)
                         )
                     )
 
 -- | Buffer should support sparse backing
-pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = VkBufferCreateFlagBits 0x1
+pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = VkBufferCreateFlags 0x1
 -- | Buffer should support sparse backing with partial residency
-pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = VkBufferCreateFlagBits 0x2
+pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = VkBufferCreateFlags 0x2
 -- | Buffer should support constent data access to physical memory blocks mapped into multiple locations of sparse buffers
-pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = VkBufferCreateFlagBits 0x4
+pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = VkBufferCreateFlags 0x4
 
 
 -- ** VkBufferUsageFlags
 
-newtype VkBufferUsageFlagBits = VkBufferUsageFlagBits VkFlags
+newtype VkBufferUsageFlags = VkBufferUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkBufferUsageFlagBits
-type VkBufferUsageFlags = VkBufferUsageFlagBits
-
-instance Show VkBufferUsageFlagBits where
+instance Show VkBufferUsageFlags where
   showsPrec _ VK_BUFFER_USAGE_TRANSFER_SRC_BIT = showString "VK_BUFFER_USAGE_TRANSFER_SRC_BIT"
   showsPrec _ VK_BUFFER_USAGE_TRANSFER_DST_BIT = showString "VK_BUFFER_USAGE_TRANSFER_DST_BIT"
   showsPrec _ VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = showString "VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT"
@@ -105,9 +94,9 @@ instance Show VkBufferUsageFlagBits where
   showsPrec _ VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = showString "VK_BUFFER_USAGE_VERTEX_BUFFER_BIT"
   showsPrec _ VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = showString "VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT"
   
-  showsPrec p (VkBufferUsageFlagBits x) = showParen (p >= 11) (showString "VkBufferUsageFlagBits " . showsPrec 11 x)
+  showsPrec p (VkBufferUsageFlags x) = showParen (p >= 11) (showString "VkBufferUsageFlags " . showsPrec 11 x)
 
-instance Read VkBufferUsageFlagBits where
+instance Read VkBufferUsageFlags where
   readPrec = parens ( choose [ ("VK_BUFFER_USAGE_TRANSFER_SRC_BIT", pure VK_BUFFER_USAGE_TRANSFER_SRC_BIT)
                              , ("VK_BUFFER_USAGE_TRANSFER_DST_BIT", pure VK_BUFFER_USAGE_TRANSFER_DST_BIT)
                              , ("VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT", pure VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT)
@@ -119,30 +108,30 @@ instance Read VkBufferUsageFlagBits where
                              , ("VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT", pure VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBufferUsageFlagBits")
+                        expectP (Ident "VkBufferUsageFlags")
                         v <- step readPrec
-                        pure (VkBufferUsageFlagBits v)
+                        pure (VkBufferUsageFlags v)
                         )
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_SRC_BIT = VkBufferUsageFlagBits 0x1
+pattern VK_BUFFER_USAGE_TRANSFER_SRC_BIT = VkBufferUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_BUFFER_USAGE_TRANSFER_DST_BIT = VkBufferUsageFlagBits 0x2
+pattern VK_BUFFER_USAGE_TRANSFER_DST_BIT = VkBufferUsageFlags 0x2
 -- | Can be used as TBO
-pattern VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = VkBufferUsageFlagBits 0x4
+pattern VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT = VkBufferUsageFlags 0x4
 -- | Can be used as IBO
-pattern VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = VkBufferUsageFlagBits 0x8
+pattern VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT = VkBufferUsageFlags 0x8
 -- | Can be used as UBO
-pattern VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = VkBufferUsageFlagBits 0x10
+pattern VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT = VkBufferUsageFlags 0x10
 -- | Can be used as SSBO
-pattern VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = VkBufferUsageFlagBits 0x20
+pattern VK_BUFFER_USAGE_STORAGE_BUFFER_BIT = VkBufferUsageFlags 0x20
 -- | Can be used as source of fixed-function index fetch (index buffer)
-pattern VK_BUFFER_USAGE_INDEX_BUFFER_BIT = VkBufferUsageFlagBits 0x40
+pattern VK_BUFFER_USAGE_INDEX_BUFFER_BIT = VkBufferUsageFlags 0x40
 -- | Can be used as source of fixed-function vertex fetch (VBO)
-pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = VkBufferUsageFlagBits 0x80
+pattern VK_BUFFER_USAGE_VERTEX_BUFFER_BIT = VkBufferUsageFlags 0x80
 -- | Can be the source of indirect parameters (e.g. indirect buffer, parameter buffer)
-pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = VkBufferUsageFlagBits 0x100
+pattern VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT = VkBufferUsageFlags 0x100
 
 
 -- ** vkDestroyBuffer

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -4,6 +4,13 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Buffer where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Buffer( Buffer
+                             , VkBufferCreateFlags
+                             , VkBufferUsageFlags
+                             , VkBufferCreateInfo
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -22,6 +29,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +38,12 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkStructureType
+                           , VkSharingMode
+                           )
 
 -- ** vkCreateBuffer
 foreign import ccall "vkCreateBuffer" vkCreateBuffer ::

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.BufferView where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -37,22 +37,22 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkCreateBufferView
 foreign import ccall "vkCreateBufferView" vkCreateBufferView ::
-  VkDevice ->
+  Device ->
   Ptr VkBufferViewCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkBufferView -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr BufferView -> IO VkResult
 
-newtype VkBufferView = VkBufferView Word64
+newtype BufferView = BufferView Word64
   deriving (Eq, Storable)
 
 
 data VkBufferViewCreateInfo =
-  VkBufferViewCreateInfo{ vkSType :: VkStructureType 
-                        , vkPNext :: Ptr Void 
-                        , vkFlags :: VkBufferViewCreateFlags 
-                        , vkBuffer :: VkBuffer 
-                        , vkFormat :: VkFormat 
-                        , vkOffset :: VkDeviceSize 
-                        , vkRange :: VkDeviceSize 
+  VkBufferViewCreateInfo{ sType :: VkStructureType 
+                        , pNext :: Ptr Void 
+                        , flags :: VkBufferViewCreateFlags 
+                        , buffer :: Buffer 
+                        , format :: VkFormat 
+                        , offset :: VkDeviceSize 
+                        , range :: VkDeviceSize 
                         }
   deriving (Eq)
 
@@ -66,13 +66,13 @@ instance Storable VkBufferViewCreateInfo where
                                     <*> peek (ptr `plusPtr` 32)
                                     <*> peek (ptr `plusPtr` 40)
                                     <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkBuffer (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkFormat (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkOffset (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkRange (poked :: VkBufferViewCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 24) (buffer (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 32) (format (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 40) (offset (poked :: VkBufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 48) (range (poked :: VkBufferViewCreateInfo))
 
 
 -- ** VkBufferViewCreateFlags
@@ -82,5 +82,5 @@ newtype VkBufferViewCreateFlags = VkBufferViewCreateFlags VkFlags
 
 -- ** vkDestroyBufferView
 foreign import ccall "vkDestroyBufferView" vkDestroyBufferView ::
-  VkDevice -> VkBufferView -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> BufferView -> Ptr VkAllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -3,12 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.BufferView where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -17,23 +12,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkCreateBufferView
 foreign import ccall "vkCreateBufferView" vkCreateBufferView ::

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -18,10 +18,10 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Format(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 
@@ -29,18 +29,18 @@ import Graphics.Vulkan.Core( VkStructureType(..)
 foreign import ccall "vkCreateBufferView" vkCreateBufferView ::
   Device ->
   Ptr BufferViewCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr BufferView -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr BufferView -> IO Result
 
 newtype BufferView = BufferView Word64
   deriving (Eq, Storable)
 
 
 data BufferViewCreateInfo =
-  BufferViewCreateInfo{ sType :: VkStructureType 
+  BufferViewCreateInfo{ sType :: StructureType 
                       , pNext :: Ptr Void 
-                      , flags :: VkBufferViewCreateFlags 
+                      , flags :: BufferViewCreateFlags 
                       , buffer :: Buffer 
-                      , format :: VkFormat 
+                      , format :: Format 
                       , offset :: VkDeviceSize 
                       , range :: VkDeviceSize 
                       }
@@ -65,9 +65,9 @@ instance Storable BufferViewCreateInfo where
                 *> poke (ptr `plusPtr` 48) (range (poked :: BufferViewCreateInfo))
 
 
--- ** VkBufferViewCreateFlags
+-- ** BufferViewCreateFlags
 -- | Opaque flag
-newtype VkBufferViewCreateFlags = VkBufferViewCreateFlags VkFlags
+newtype BufferViewCreateFlags = BufferViewCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkDestroyBufferView

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -25,8 +25,8 @@ import Graphics.Vulkan.Core( StructureType(..)
                            , Flags(..)
                            )
 
--- ** vkCreateBufferView
-foreign import ccall "vkCreateBufferView" vkCreateBufferView ::
+-- ** createBufferView
+foreign import ccall "vkCreateBufferView" createBufferView ::
   Device ->
   Ptr BufferViewCreateInfo ->
     Ptr AllocationCallbacks -> Ptr BufferView -> IO Result
@@ -70,7 +70,7 @@ instance Storable BufferViewCreateInfo where
 newtype BufferViewCreateFlags = BufferViewCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkDestroyBufferView
-foreign import ccall "vkDestroyBufferView" vkDestroyBufferView ::
+-- ** destroyBufferView
+foreign import ccall "vkDestroyBufferView" destroyBufferView ::
   Device -> BufferView -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -3,6 +3,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.BufferView where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Buffer( Buffer
+                             )
 import Data.Word( Word64
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +16,18 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.BufferView( VkBufferViewCreateFlags
+                                 , BufferView
+                                 , VkBufferViewCreateInfo
+                                 )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           )
 
 -- ** vkCreateBufferView
 foreign import ccall "vkCreateBufferView" vkCreateBufferView ::

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -18,11 +18,11 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Format(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 
 -- ** vkCreateBufferView
@@ -41,8 +41,8 @@ data BufferViewCreateInfo =
                       , flags :: BufferViewCreateFlags 
                       , buffer :: Buffer 
                       , format :: Format 
-                      , offset :: VkDeviceSize 
-                      , range :: VkDeviceSize 
+                      , offset :: DeviceSize 
+                      , range :: DeviceSize 
                       }
   deriving (Eq)
 
@@ -67,7 +67,7 @@ instance Storable BufferViewCreateInfo where
 
 -- ** BufferViewCreateFlags
 -- | Opaque flag
-newtype BufferViewCreateFlags = BufferViewCreateFlags VkFlags
+newtype BufferViewCreateFlags = BufferViewCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkDestroyBufferView

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -3,30 +3,26 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.BufferView where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.BufferView( VkBufferViewCreateFlags
-                                 , BufferView
-                                 , VkBufferViewCreateInfo
-                                 )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
                            )
 
 -- ** vkCreateBufferView

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -16,7 +16,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
@@ -28,41 +28,41 @@ import Graphics.Vulkan.Core( VkStructureType(..)
 -- ** vkCreateBufferView
 foreign import ccall "vkCreateBufferView" vkCreateBufferView ::
   Device ->
-  Ptr VkBufferViewCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr BufferView -> IO VkResult
+  Ptr BufferViewCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr BufferView -> IO VkResult
 
 newtype BufferView = BufferView Word64
   deriving (Eq, Storable)
 
 
-data VkBufferViewCreateInfo =
-  VkBufferViewCreateInfo{ sType :: VkStructureType 
-                        , pNext :: Ptr Void 
-                        , flags :: VkBufferViewCreateFlags 
-                        , buffer :: Buffer 
-                        , format :: VkFormat 
-                        , offset :: VkDeviceSize 
-                        , range :: VkDeviceSize 
-                        }
+data BufferViewCreateInfo =
+  BufferViewCreateInfo{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , flags :: VkBufferViewCreateFlags 
+                      , buffer :: Buffer 
+                      , format :: VkFormat 
+                      , offset :: VkDeviceSize 
+                      , range :: VkDeviceSize 
+                      }
   deriving (Eq)
 
-instance Storable VkBufferViewCreateInfo where
+instance Storable BufferViewCreateInfo where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkBufferViewCreateInfo <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 40)
-                                    <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 24) (buffer (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 32) (format (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 40) (offset (poked :: VkBufferViewCreateInfo))
-                *> poke (ptr `plusPtr` 48) (range (poked :: VkBufferViewCreateInfo))
+  peek ptr = BufferViewCreateInfo <$> peek (ptr `plusPtr` 0)
+                                  <*> peek (ptr `plusPtr` 8)
+                                  <*> peek (ptr `plusPtr` 16)
+                                  <*> peek (ptr `plusPtr` 24)
+                                  <*> peek (ptr `plusPtr` 32)
+                                  <*> peek (ptr `plusPtr` 40)
+                                  <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 24) (buffer (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 32) (format (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 40) (offset (poked :: BufferViewCreateInfo))
+                *> poke (ptr `plusPtr` 48) (range (poked :: BufferViewCreateInfo))
 
 
 -- ** VkBufferViewCreateFlags
@@ -72,5 +72,5 @@ newtype VkBufferViewCreateFlags = VkBufferViewCreateFlags VkFlags
 
 -- ** vkDestroyBufferView
 foreign import ccall "vkDestroyBufferView" vkDestroyBufferView ::
-  Device -> BufferView -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> BufferView -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/BufferView.hs
+++ b/src/Graphics/Vulkan/BufferView.hs
@@ -32,7 +32,7 @@ foreign import ccall "vkCreateBufferView" createBufferView ::
     Ptr AllocationCallbacks -> Ptr BufferView -> IO Result
 
 newtype BufferView = BufferView Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data BufferViewCreateInfo =
@@ -44,7 +44,7 @@ data BufferViewCreateInfo =
                       , offset :: DeviceSize 
                       , range :: DeviceSize 
                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BufferViewCreateInfo where
   sizeOf ~_ = 56
@@ -68,7 +68,7 @@ instance Storable BufferViewCreateInfo where
 -- ** BufferViewCreateFlags
 -- | Opaque flag
 newtype BufferViewCreateFlags = BufferViewCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroyBufferView
 foreign import ccall "vkDestroyBufferView" destroyBufferView ::

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandBuffer where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Pass( VkFramebuffer(..)
-                           , VkRenderPass(..)
+import Graphics.Vulkan.Pass( Framebuffer(..)
+                           , RenderPass(..)
                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -27,7 +27,7 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.CommandPool( VkCommandPool(..)
+import Graphics.Vulkan.CommandPool( CommandPool(..)
                                   )
 import Data.Void( Void
                 )
@@ -77,17 +77,16 @@ pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = VkCommandBufferLevel 1
 
 -- ** vkAllocateCommandBuffers
 foreign import ccall "vkAllocateCommandBuffers" vkAllocateCommandBuffers ::
-  VkDevice ->
-  Ptr VkCommandBufferAllocateInfo ->
-    Ptr VkCommandBuffer -> IO VkResult
+  Device ->
+  Ptr VkCommandBufferAllocateInfo -> Ptr CommandBuffer -> IO VkResult
 
 -- ** vkResetCommandBuffer
 foreign import ccall "vkResetCommandBuffer" vkResetCommandBuffer ::
-  VkCommandBuffer -> VkCommandBufferResetFlags -> IO VkResult
+  CommandBuffer -> VkCommandBufferResetFlags -> IO VkResult
 
 -- ** vkFreeCommandBuffers
 foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
-  VkDevice -> VkCommandPool -> Word32 -> Ptr VkCommandBuffer -> IO ()
+  Device -> CommandPool -> Word32 -> Ptr CommandBuffer -> IO ()
 
 -- ** VkCommandBufferUsageFlags
 
@@ -126,10 +125,10 @@ pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = VkCommandBufferUsageFlagB
 
 
 data VkCommandBufferBeginInfo =
-  VkCommandBufferBeginInfo{ vkSType :: VkStructureType 
-                          , vkPNext :: Ptr Void 
-                          , vkFlags :: VkCommandBufferUsageFlags 
-                          , vkPInheritanceInfo :: Ptr VkCommandBufferInheritanceInfo 
+  VkCommandBufferBeginInfo{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkCommandBufferUsageFlags 
+                          , pInheritanceInfo :: Ptr VkCommandBufferInheritanceInfo 
                           }
   deriving (Eq)
 
@@ -140,22 +139,22 @@ instance Storable VkCommandBufferBeginInfo where
                                       <*> peek (ptr `plusPtr` 8)
                                       <*> peek (ptr `plusPtr` 16)
                                       <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 24) (vkPInheritanceInfo (poked :: VkCommandBufferBeginInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkCommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 24) (pInheritanceInfo (poked :: VkCommandBufferBeginInfo))
 
 
 
 data VkCommandBufferInheritanceInfo =
-  VkCommandBufferInheritanceInfo{ vkSType :: VkStructureType 
-                                , vkPNext :: Ptr Void 
-                                , vkRenderPass :: VkRenderPass 
-                                , vkSubpass :: Word32 
-                                , vkFramebuffer :: VkFramebuffer 
-                                , vkOcclusionQueryEnable :: VkBool32 
-                                , vkQueryFlags :: VkQueryControlFlags 
-                                , vkPipelineStatistics :: VkQueryPipelineStatisticFlags 
+  VkCommandBufferInheritanceInfo{ sType :: VkStructureType 
+                                , pNext :: Ptr Void 
+                                , renderPass :: RenderPass 
+                                , subpass :: Word32 
+                                , framebuffer :: Framebuffer 
+                                , occlusionQueryEnable :: VkBool32 
+                                , queryFlags :: VkQueryControlFlags 
+                                , pipelineStatistics :: VkQueryPipelineStatisticFlags 
                                 }
   deriving (Eq)
 
@@ -170,18 +169,18 @@ instance Storable VkCommandBufferInheritanceInfo where
                                             <*> peek (ptr `plusPtr` 40)
                                             <*> peek (ptr `plusPtr` 44)
                                             <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 16) (vkRenderPass (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 24) (vkSubpass (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 32) (vkFramebuffer (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 40) (vkOcclusionQueryEnable (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 44) (vkQueryFlags (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 48) (vkPipelineStatistics (poked :: VkCommandBufferInheritanceInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 16) (renderPass (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 24) (subpass (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 32) (framebuffer (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 40) (occlusionQueryEnable (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 44) (queryFlags (poked :: VkCommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 48) (pipelineStatistics (poked :: VkCommandBufferInheritanceInfo))
 
 
 data VkCommandBuffer_T
-type VkCommandBuffer = Ptr VkCommandBuffer_T
+type CommandBuffer = Ptr VkCommandBuffer_T
 
 -- ** VkCommandBufferResetFlags
 
@@ -212,19 +211,19 @@ pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = VkCommandBufferResetFlag
 
 -- ** vkEndCommandBuffer
 foreign import ccall "vkEndCommandBuffer" vkEndCommandBuffer ::
-  VkCommandBuffer -> IO VkResult
+  CommandBuffer -> IO VkResult
 
 -- ** vkBeginCommandBuffer
 foreign import ccall "vkBeginCommandBuffer" vkBeginCommandBuffer ::
-  VkCommandBuffer -> Ptr VkCommandBufferBeginInfo -> IO VkResult
+  CommandBuffer -> Ptr VkCommandBufferBeginInfo -> IO VkResult
 
 
 data VkCommandBufferAllocateInfo =
-  VkCommandBufferAllocateInfo{ vkSType :: VkStructureType 
-                             , vkPNext :: Ptr Void 
-                             , vkCommandPool :: VkCommandPool 
-                             , vkLevel :: VkCommandBufferLevel 
-                             , vkCommandBufferCount :: Word32 
+  VkCommandBufferAllocateInfo{ sType :: VkStructureType 
+                             , pNext :: Ptr Void 
+                             , commandPool :: CommandPool 
+                             , level :: VkCommandBufferLevel 
+                             , commandBufferCount :: Word32 
                              }
   deriving (Eq)
 
@@ -236,10 +235,10 @@ instance Storable VkCommandBufferAllocateInfo where
                                          <*> peek (ptr `plusPtr` 16)
                                          <*> peek (ptr `plusPtr` 24)
                                          <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (vkCommandPool (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (vkLevel (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 28) (vkCommandBufferCount (poked :: VkCommandBufferAllocateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (commandPool (poked :: VkCommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (level (poked :: VkCommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 28) (commandBufferCount (poked :: VkCommandBufferAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -4,18 +4,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandBuffer where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.Pass( Framebuffer(..)
-                           , RenderPass(..)
-                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -27,8 +21,6 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.CommandPool( CommandPool(..)
-                                  )
 import Data.Void( Void
                 )
 import Text.Read( Read(..)
@@ -38,16 +30,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Query( VkQueryPipelineStatisticFlags(..)
-                            , VkQueryControlFlagBits(..)
-                            , VkQueryControlFlags(..)
-                            , VkQueryPipelineStatisticFlagBits(..)
-                            )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 
 -- ** VkCommandBufferLevel
 

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -50,7 +50,7 @@ import Graphics.Vulkan.Core( Bool32(..)
 -- ** CommandBufferLevel
 
 newtype CommandBufferLevel = CommandBufferLevel Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show CommandBufferLevel where
   showsPrec _ CommandBufferLevelPrimary = showString "CommandBufferLevelPrimary"
@@ -89,7 +89,7 @@ foreign import ccall "vkFreeCommandBuffers" freeCommandBuffers ::
 -- ** CommandBufferUsageFlags
 
 newtype CommandBufferUsageFlags = CommandBufferUsageFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferUsageFlags where
   showsPrec _ CommandBufferUsageOneTimeSubmitBit = showString "CommandBufferUsageOneTimeSubmitBit"
@@ -125,7 +125,7 @@ data CommandBufferBeginInfo =
                         , flags :: CommandBufferUsageFlags 
                         , pInheritanceInfo :: Ptr CommandBufferInheritanceInfo 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable CommandBufferBeginInfo where
   sizeOf ~_ = 32
@@ -151,7 +151,7 @@ data CommandBufferInheritanceInfo =
                               , queryFlags :: QueryControlFlags 
                               , pipelineStatistics :: QueryPipelineStatisticFlags 
                               }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable CommandBufferInheritanceInfo where
   sizeOf ~_ = 56
@@ -180,7 +180,7 @@ type CommandBuffer = Ptr VkCommandBuffer_T
 -- ** CommandBufferResetFlags
 
 newtype CommandBufferResetFlags = CommandBufferResetFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferResetFlags where
   showsPrec _ CommandBufferResetReleaseResourcesBit = showString "CommandBufferResetReleaseResourcesBit"
@@ -217,7 +217,7 @@ data CommandBufferAllocateInfo =
                            , level :: CommandBufferLevel 
                            , commandBufferCount :: Word32 
                            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable CommandBufferAllocateInfo where
   sizeOf ~_ = 32

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -53,13 +53,13 @@ newtype CommandBufferLevel = CommandBufferLevel Int32
   deriving (Eq, Storable)
 
 instance Show CommandBufferLevel where
-  showsPrec _ VK_COMMAND_BUFFER_LEVEL_PRIMARY = showString "VK_COMMAND_BUFFER_LEVEL_PRIMARY"
-  showsPrec _ VK_COMMAND_BUFFER_LEVEL_SECONDARY = showString "VK_COMMAND_BUFFER_LEVEL_SECONDARY"
+  showsPrec _ CommandBufferLevelPrimary = showString "CommandBufferLevelPrimary"
+  showsPrec _ CommandBufferLevelSecondary = showString "CommandBufferLevelSecondary"
   showsPrec p (CommandBufferLevel x) = showParen (p >= 11) (showString "CommandBufferLevel " . showsPrec 11 x)
 
 instance Read CommandBufferLevel where
-  readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_LEVEL_PRIMARY", pure VK_COMMAND_BUFFER_LEVEL_PRIMARY)
-                             , ("VK_COMMAND_BUFFER_LEVEL_SECONDARY", pure VK_COMMAND_BUFFER_LEVEL_SECONDARY)
+  readPrec = parens ( choose [ ("CommandBufferLevelPrimary", pure CommandBufferLevelPrimary)
+                             , ("CommandBufferLevelSecondary", pure CommandBufferLevelSecondary)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CommandBufferLevel")
@@ -69,9 +69,9 @@ instance Read CommandBufferLevel where
                     )
 
 
-pattern VK_COMMAND_BUFFER_LEVEL_PRIMARY = CommandBufferLevel 0
+pattern CommandBufferLevelPrimary = CommandBufferLevel 0
 
-pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = CommandBufferLevel 1
+pattern CommandBufferLevelSecondary = CommandBufferLevel 1
 
 -- ** allocateCommandBuffers
 foreign import ccall "vkAllocateCommandBuffers" allocateCommandBuffers ::

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -38,49 +38,49 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Query( VkQueryPipelineStatisticFlags(..)
-                            , VkQueryControlFlags(..)
+import Graphics.Vulkan.Query( QueryPipelineStatisticFlags(..)
+                            , QueryControlFlags(..)
                             )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 
--- ** VkCommandBufferLevel
+-- ** CommandBufferLevel
 
-newtype VkCommandBufferLevel = VkCommandBufferLevel Int32
+newtype CommandBufferLevel = CommandBufferLevel Int32
   deriving (Eq, Storable)
 
-instance Show VkCommandBufferLevel where
+instance Show CommandBufferLevel where
   showsPrec _ VK_COMMAND_BUFFER_LEVEL_PRIMARY = showString "VK_COMMAND_BUFFER_LEVEL_PRIMARY"
   showsPrec _ VK_COMMAND_BUFFER_LEVEL_SECONDARY = showString "VK_COMMAND_BUFFER_LEVEL_SECONDARY"
-  showsPrec p (VkCommandBufferLevel x) = showParen (p >= 11) (showString "VkCommandBufferLevel " . showsPrec 11 x)
+  showsPrec p (CommandBufferLevel x) = showParen (p >= 11) (showString "CommandBufferLevel " . showsPrec 11 x)
 
-instance Read VkCommandBufferLevel where
+instance Read CommandBufferLevel where
   readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_LEVEL_PRIMARY", pure VK_COMMAND_BUFFER_LEVEL_PRIMARY)
                              , ("VK_COMMAND_BUFFER_LEVEL_SECONDARY", pure VK_COMMAND_BUFFER_LEVEL_SECONDARY)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandBufferLevel")
+                        expectP (Ident "CommandBufferLevel")
                         v <- step readPrec
-                        pure (VkCommandBufferLevel v)
+                        pure (CommandBufferLevel v)
                         )
                     )
 
 
-pattern VK_COMMAND_BUFFER_LEVEL_PRIMARY = VkCommandBufferLevel 0
+pattern VK_COMMAND_BUFFER_LEVEL_PRIMARY = CommandBufferLevel 0
 
-pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = VkCommandBufferLevel 1
+pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = CommandBufferLevel 1
 
 -- ** vkAllocateCommandBuffers
 foreign import ccall "vkAllocateCommandBuffers" vkAllocateCommandBuffers ::
   Device ->
-  Ptr CommandBufferAllocateInfo -> Ptr CommandBuffer -> IO VkResult
+  Ptr CommandBufferAllocateInfo -> Ptr CommandBuffer -> IO Result
 
 -- ** vkResetCommandBuffer
 foreign import ccall "vkResetCommandBuffer" vkResetCommandBuffer ::
-  CommandBuffer -> VkCommandBufferResetFlags -> IO VkResult
+  CommandBuffer -> CommandBufferResetFlags -> IO Result
 
 -- ** vkFreeCommandBuffers
 foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
@@ -88,41 +88,41 @@ foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
 
 -- ** VkCommandBufferUsageFlags
 
-newtype VkCommandBufferUsageFlags = VkCommandBufferUsageFlags VkFlags
+newtype CommandBufferUsageFlags = CommandBufferUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCommandBufferUsageFlags where
+instance Show CommandBufferUsageFlags where
   showsPrec _ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = showString "VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT"
   showsPrec _ VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = showString "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT"
   showsPrec _ VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = showString "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT"
   
-  showsPrec p (VkCommandBufferUsageFlags x) = showParen (p >= 11) (showString "VkCommandBufferUsageFlags " . showsPrec 11 x)
+  showsPrec p (CommandBufferUsageFlags x) = showParen (p >= 11) (showString "CommandBufferUsageFlags " . showsPrec 11 x)
 
-instance Read VkCommandBufferUsageFlags where
+instance Read CommandBufferUsageFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT", pure VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT)
                              , ("VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT", pure VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)
                              , ("VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT", pure VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandBufferUsageFlags")
+                        expectP (Ident "CommandBufferUsageFlags")
                         v <- step readPrec
-                        pure (VkCommandBufferUsageFlags v)
+                        pure (CommandBufferUsageFlags v)
                         )
                     )
 
 
-pattern VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = VkCommandBufferUsageFlags 0x1
+pattern VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = CommandBufferUsageFlags 0x1
 
-pattern VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = VkCommandBufferUsageFlags 0x2
+pattern VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = CommandBufferUsageFlags 0x2
 -- | Command buffer may be submitted/executed more than once simultaneously
-pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = VkCommandBufferUsageFlags 0x4
+pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = CommandBufferUsageFlags 0x4
 
 
 
 data CommandBufferBeginInfo =
-  CommandBufferBeginInfo{ sType :: VkStructureType 
+  CommandBufferBeginInfo{ sType :: StructureType 
                         , pNext :: Ptr Void 
-                        , flags :: VkCommandBufferUsageFlags 
+                        , flags :: CommandBufferUsageFlags 
                         , pInheritanceInfo :: Ptr CommandBufferInheritanceInfo 
                         }
   deriving (Eq)
@@ -142,14 +142,14 @@ instance Storable CommandBufferBeginInfo where
 
 
 data CommandBufferInheritanceInfo =
-  CommandBufferInheritanceInfo{ sType :: VkStructureType 
+  CommandBufferInheritanceInfo{ sType :: StructureType 
                               , pNext :: Ptr Void 
                               , renderPass :: RenderPass 
                               , subpass :: Word32 
                               , framebuffer :: Framebuffer 
                               , occlusionQueryEnable :: VkBool32 
-                              , queryFlags :: VkQueryControlFlags 
-                              , pipelineStatistics :: VkQueryPipelineStatisticFlags 
+                              , queryFlags :: QueryControlFlags 
+                              , pipelineStatistics :: QueryPipelineStatisticFlags 
                               }
   deriving (Eq)
 
@@ -179,42 +179,42 @@ type CommandBuffer = Ptr VkCommandBuffer_T
 
 -- ** VkCommandBufferResetFlags
 
-newtype VkCommandBufferResetFlags = VkCommandBufferResetFlags VkFlags
+newtype CommandBufferResetFlags = CommandBufferResetFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCommandBufferResetFlags where
+instance Show CommandBufferResetFlags where
   showsPrec _ VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT"
   
-  showsPrec p (VkCommandBufferResetFlags x) = showParen (p >= 11) (showString "VkCommandBufferResetFlags " . showsPrec 11 x)
+  showsPrec p (CommandBufferResetFlags x) = showParen (p >= 11) (showString "CommandBufferResetFlags " . showsPrec 11 x)
 
-instance Read VkCommandBufferResetFlags where
+instance Read CommandBufferResetFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandBufferResetFlags")
+                        expectP (Ident "CommandBufferResetFlags")
                         v <- step readPrec
-                        pure (VkCommandBufferResetFlags v)
+                        pure (CommandBufferResetFlags v)
                         )
                     )
 
 -- | Release resources owned by the buffer
-pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = VkCommandBufferResetFlags 0x1
+pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = CommandBufferResetFlags 0x1
 
 
 -- ** vkEndCommandBuffer
 foreign import ccall "vkEndCommandBuffer" vkEndCommandBuffer ::
-  CommandBuffer -> IO VkResult
+  CommandBuffer -> IO Result
 
 -- ** vkBeginCommandBuffer
 foreign import ccall "vkBeginCommandBuffer" vkBeginCommandBuffer ::
-  CommandBuffer -> Ptr CommandBufferBeginInfo -> IO VkResult
+  CommandBuffer -> Ptr CommandBufferBeginInfo -> IO Result
 
 
 data CommandBufferAllocateInfo =
-  CommandBufferAllocateInfo{ sType :: VkStructureType 
+  CommandBufferAllocateInfo{ sType :: StructureType 
                            , pNext :: Ptr Void 
                            , commandPool :: CommandPool 
-                           , level :: VkCommandBufferLevel 
+                           , level :: CommandBufferLevel 
                            , commandBufferCount :: Word32 
                            }
   deriving (Eq)

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -92,16 +92,16 @@ newtype CommandBufferUsageFlags = CommandBufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferUsageFlags where
-  showsPrec _ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = showString "VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT"
-  showsPrec _ VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = showString "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT"
-  showsPrec _ VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = showString "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT"
+  showsPrec _ CommandBufferUsageOneTimeSubmitBit = showString "CommandBufferUsageOneTimeSubmitBit"
+  showsPrec _ CommandBufferUsageRenderPassContinueBit = showString "CommandBufferUsageRenderPassContinueBit"
+  showsPrec _ CommandBufferUsageSimultaneousUseBit = showString "CommandBufferUsageSimultaneousUseBit"
   
   showsPrec p (CommandBufferUsageFlags x) = showParen (p >= 11) (showString "CommandBufferUsageFlags " . showsPrec 11 x)
 
 instance Read CommandBufferUsageFlags where
-  readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT", pure VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT)
-                             , ("VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT", pure VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)
-                             , ("VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT", pure VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)
+  readPrec = parens ( choose [ ("CommandBufferUsageOneTimeSubmitBit", pure CommandBufferUsageOneTimeSubmitBit)
+                             , ("CommandBufferUsageRenderPassContinueBit", pure CommandBufferUsageRenderPassContinueBit)
+                             , ("CommandBufferUsageSimultaneousUseBit", pure CommandBufferUsageSimultaneousUseBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CommandBufferUsageFlags")
@@ -111,11 +111,11 @@ instance Read CommandBufferUsageFlags where
                     )
 
 
-pattern VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = CommandBufferUsageFlags 0x1
+pattern CommandBufferUsageOneTimeSubmitBit = CommandBufferUsageFlags 0x1
 
-pattern VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = CommandBufferUsageFlags 0x2
+pattern CommandBufferUsageRenderPassContinueBit = CommandBufferUsageFlags 0x2
 -- | Command buffer may be submitted/executed more than once simultaneously
-pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = CommandBufferUsageFlags 0x4
+pattern CommandBufferUsageSimultaneousUseBit = CommandBufferUsageFlags 0x4
 
 
 
@@ -183,12 +183,12 @@ newtype CommandBufferResetFlags = CommandBufferResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferResetFlags where
-  showsPrec _ VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT"
+  showsPrec _ CommandBufferResetReleaseResourcesBit = showString "CommandBufferResetReleaseResourcesBit"
   
   showsPrec p (CommandBufferResetFlags x) = showParen (p >= 11) (showString "CommandBufferResetFlags " . showsPrec 11 x)
 
 instance Read CommandBufferResetFlags where
-  readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT)
+  readPrec = parens ( choose [ ("CommandBufferResetReleaseResourcesBit", pure CommandBufferResetReleaseResourcesBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CommandBufferResetFlags")
@@ -198,7 +198,7 @@ instance Read CommandBufferResetFlags where
                     )
 
 -- | Release resources owned by the buffer
-pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = CommandBufferResetFlags 0x1
+pattern CommandBufferResetReleaseResourcesBit = CommandBufferResetFlags 0x1
 
 
 -- ** endCommandBuffer

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandBuffer where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Pass( Framebuffer
+                           , RenderPass
+                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -14,6 +19,14 @@ import Data.Word( Word32
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.CommandBuffer( VkCommandBufferLevel
+                                    , VkCommandBufferUsageFlags
+                                    , VkCommandBufferInheritanceInfo
+                                    , CommandBuffer
+                                    , VkCommandBufferAllocateInfo
+                                    , VkCommandBufferResetFlags
+                                    , VkCommandBufferBeginInfo
+                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -21,6 +34,8 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.CommandPool( CommandPool
+                                  )
 import Data.Void( Void
                 )
 import Text.Read( Read(..)
@@ -30,6 +45,14 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Query( VkQueryControlFlags
+                            , VkQueryPipelineStatisticFlags
+                            )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 -- ** VkCommandBufferLevel
 

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -86,7 +86,7 @@ foreign import ccall "vkResetCommandBuffer" resetCommandBuffer ::
 foreign import ccall "vkFreeCommandBuffers" freeCommandBuffers ::
   Device -> CommandPool -> Word32 -> Ptr CommandBuffer -> IO ()
 
--- ** VkCommandBufferUsageFlags
+-- ** CommandBufferUsageFlags
 
 newtype CommandBufferUsageFlags = CommandBufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -177,7 +177,7 @@ instance Storable CommandBufferInheritanceInfo where
 data VkCommandBuffer_T
 type CommandBuffer = Ptr VkCommandBuffer_T
 
--- ** VkCommandBufferResetFlags
+-- ** CommandBufferResetFlags
 
 newtype CommandBufferResetFlags = CommandBufferResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -73,17 +73,17 @@ pattern VK_COMMAND_BUFFER_LEVEL_PRIMARY = CommandBufferLevel 0
 
 pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = CommandBufferLevel 1
 
--- ** vkAllocateCommandBuffers
-foreign import ccall "vkAllocateCommandBuffers" vkAllocateCommandBuffers ::
+-- ** allocateCommandBuffers
+foreign import ccall "vkAllocateCommandBuffers" allocateCommandBuffers ::
   Device ->
   Ptr CommandBufferAllocateInfo -> Ptr CommandBuffer -> IO Result
 
--- ** vkResetCommandBuffer
-foreign import ccall "vkResetCommandBuffer" vkResetCommandBuffer ::
+-- ** resetCommandBuffer
+foreign import ccall "vkResetCommandBuffer" resetCommandBuffer ::
   CommandBuffer -> CommandBufferResetFlags -> IO Result
 
--- ** vkFreeCommandBuffers
-foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
+-- ** freeCommandBuffers
+foreign import ccall "vkFreeCommandBuffers" freeCommandBuffers ::
   Device -> CommandPool -> Word32 -> Ptr CommandBuffer -> IO ()
 
 -- ** VkCommandBufferUsageFlags
@@ -201,12 +201,12 @@ instance Read CommandBufferResetFlags where
 pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = CommandBufferResetFlags 0x1
 
 
--- ** vkEndCommandBuffer
-foreign import ccall "vkEndCommandBuffer" vkEndCommandBuffer ::
+-- ** endCommandBuffer
+foreign import ccall "vkEndCommandBuffer" endCommandBuffer ::
   CommandBuffer -> IO Result
 
--- ** vkBeginCommandBuffer
-foreign import ccall "vkBeginCommandBuffer" vkBeginCommandBuffer ::
+-- ** beginCommandBuffer
+foreign import ccall "vkBeginCommandBuffer" beginCommandBuffer ::
   CommandBuffer -> Ptr CommandBufferBeginInfo -> IO Result
 
 

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -76,7 +76,7 @@ pattern VK_COMMAND_BUFFER_LEVEL_SECONDARY = VkCommandBufferLevel 1
 -- ** vkAllocateCommandBuffers
 foreign import ccall "vkAllocateCommandBuffers" vkAllocateCommandBuffers ::
   Device ->
-  Ptr VkCommandBufferAllocateInfo -> Ptr CommandBuffer -> IO VkResult
+  Ptr CommandBufferAllocateInfo -> Ptr CommandBuffer -> IO VkResult
 
 -- ** vkResetCommandBuffer
 foreign import ccall "vkResetCommandBuffer" vkResetCommandBuffer ::
@@ -119,59 +119,59 @@ pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = VkCommandBufferUsageFlags
 
 
 
-data VkCommandBufferBeginInfo =
-  VkCommandBufferBeginInfo{ sType :: VkStructureType 
-                          , pNext :: Ptr Void 
-                          , flags :: VkCommandBufferUsageFlags 
-                          , pInheritanceInfo :: Ptr VkCommandBufferInheritanceInfo 
-                          }
+data CommandBufferBeginInfo =
+  CommandBufferBeginInfo{ sType :: VkStructureType 
+                        , pNext :: Ptr Void 
+                        , flags :: VkCommandBufferUsageFlags 
+                        , pInheritanceInfo :: Ptr CommandBufferInheritanceInfo 
+                        }
   deriving (Eq)
 
-instance Storable VkCommandBufferBeginInfo where
+instance Storable CommandBufferBeginInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkCommandBufferBeginInfo <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkCommandBufferBeginInfo))
-                *> poke (ptr `plusPtr` 24) (pInheritanceInfo (poked :: VkCommandBufferBeginInfo))
+  peek ptr = CommandBufferBeginInfo <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: CommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: CommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: CommandBufferBeginInfo))
+                *> poke (ptr `plusPtr` 24) (pInheritanceInfo (poked :: CommandBufferBeginInfo))
 
 
 
-data VkCommandBufferInheritanceInfo =
-  VkCommandBufferInheritanceInfo{ sType :: VkStructureType 
-                                , pNext :: Ptr Void 
-                                , renderPass :: RenderPass 
-                                , subpass :: Word32 
-                                , framebuffer :: Framebuffer 
-                                , occlusionQueryEnable :: VkBool32 
-                                , queryFlags :: VkQueryControlFlags 
-                                , pipelineStatistics :: VkQueryPipelineStatisticFlags 
-                                }
+data CommandBufferInheritanceInfo =
+  CommandBufferInheritanceInfo{ sType :: VkStructureType 
+                              , pNext :: Ptr Void 
+                              , renderPass :: RenderPass 
+                              , subpass :: Word32 
+                              , framebuffer :: Framebuffer 
+                              , occlusionQueryEnable :: VkBool32 
+                              , queryFlags :: VkQueryControlFlags 
+                              , pipelineStatistics :: VkQueryPipelineStatisticFlags 
+                              }
   deriving (Eq)
 
-instance Storable VkCommandBufferInheritanceInfo where
+instance Storable CommandBufferInheritanceInfo where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkCommandBufferInheritanceInfo <$> peek (ptr `plusPtr` 0)
-                                            <*> peek (ptr `plusPtr` 8)
-                                            <*> peek (ptr `plusPtr` 16)
-                                            <*> peek (ptr `plusPtr` 24)
-                                            <*> peek (ptr `plusPtr` 32)
-                                            <*> peek (ptr `plusPtr` 40)
-                                            <*> peek (ptr `plusPtr` 44)
-                                            <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 16) (renderPass (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 24) (subpass (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 32) (framebuffer (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 40) (occlusionQueryEnable (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 44) (queryFlags (poked :: VkCommandBufferInheritanceInfo))
-                *> poke (ptr `plusPtr` 48) (pipelineStatistics (poked :: VkCommandBufferInheritanceInfo))
+  peek ptr = CommandBufferInheritanceInfo <$> peek (ptr `plusPtr` 0)
+                                          <*> peek (ptr `plusPtr` 8)
+                                          <*> peek (ptr `plusPtr` 16)
+                                          <*> peek (ptr `plusPtr` 24)
+                                          <*> peek (ptr `plusPtr` 32)
+                                          <*> peek (ptr `plusPtr` 40)
+                                          <*> peek (ptr `plusPtr` 44)
+                                          <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 16) (renderPass (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 24) (subpass (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 32) (framebuffer (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 40) (occlusionQueryEnable (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 44) (queryFlags (poked :: CommandBufferInheritanceInfo))
+                *> poke (ptr `plusPtr` 48) (pipelineStatistics (poked :: CommandBufferInheritanceInfo))
 
 
 data VkCommandBuffer_T
@@ -207,30 +207,30 @@ foreign import ccall "vkEndCommandBuffer" vkEndCommandBuffer ::
 
 -- ** vkBeginCommandBuffer
 foreign import ccall "vkBeginCommandBuffer" vkBeginCommandBuffer ::
-  CommandBuffer -> Ptr VkCommandBufferBeginInfo -> IO VkResult
+  CommandBuffer -> Ptr CommandBufferBeginInfo -> IO VkResult
 
 
-data VkCommandBufferAllocateInfo =
-  VkCommandBufferAllocateInfo{ sType :: VkStructureType 
-                             , pNext :: Ptr Void 
-                             , commandPool :: CommandPool 
-                             , level :: VkCommandBufferLevel 
-                             , commandBufferCount :: Word32 
-                             }
+data CommandBufferAllocateInfo =
+  CommandBufferAllocateInfo{ sType :: VkStructureType 
+                           , pNext :: Ptr Void 
+                           , commandPool :: CommandPool 
+                           , level :: VkCommandBufferLevel 
+                           , commandBufferCount :: Word32 
+                           }
   deriving (Eq)
 
-instance Storable VkCommandBufferAllocateInfo where
+instance Storable CommandBufferAllocateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkCommandBufferAllocateInfo <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-                                         <*> peek (ptr `plusPtr` 16)
-                                         <*> peek (ptr `plusPtr` 24)
-                                         <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (commandPool (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (level (poked :: VkCommandBufferAllocateInfo))
-                *> poke (ptr `plusPtr` 28) (commandBufferCount (poked :: VkCommandBufferAllocateInfo))
+  peek ptr = CommandBufferAllocateInfo <$> peek (ptr `plusPtr` 0)
+                                       <*> peek (ptr `plusPtr` 8)
+                                       <*> peek (ptr `plusPtr` 16)
+                                       <*> peek (ptr `plusPtr` 24)
+                                       <*> peek (ptr `plusPtr` 28)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: CommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: CommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (commandPool (poked :: CommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (level (poked :: CommandBufferAllocateInfo))
+                *> poke (ptr `plusPtr` 28) (commandBufferCount (poked :: CommandBufferAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -41,10 +41,10 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Query( QueryPipelineStatisticFlags(..)
                             , QueryControlFlags(..)
                             )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 -- ** CommandBufferLevel
@@ -88,7 +88,7 @@ foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
 
 -- ** VkCommandBufferUsageFlags
 
-newtype CommandBufferUsageFlags = CommandBufferUsageFlags VkFlags
+newtype CommandBufferUsageFlags = CommandBufferUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferUsageFlags where
@@ -147,7 +147,7 @@ data CommandBufferInheritanceInfo =
                               , renderPass :: RenderPass 
                               , subpass :: Word32 
                               , framebuffer :: Framebuffer 
-                              , occlusionQueryEnable :: VkBool32 
+                              , occlusionQueryEnable :: Bool32 
                               , queryFlags :: QueryControlFlags 
                               , pipelineStatistics :: QueryPipelineStatisticFlags 
                               }
@@ -179,7 +179,7 @@ type CommandBuffer = Ptr VkCommandBuffer_T
 
 -- ** VkCommandBufferResetFlags
 
-newtype CommandBufferResetFlags = CommandBufferResetFlags VkFlags
+newtype CommandBufferResetFlags = CommandBufferResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandBufferResetFlags where

--- a/src/Graphics/Vulkan/CommandBuffer.hs
+++ b/src/Graphics/Vulkan/CommandBuffer.hs
@@ -4,29 +4,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandBuffer where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Pass( Framebuffer
-                           , RenderPass
+import Graphics.Vulkan.Pass( RenderPass(..)
+                           , Framebuffer(..)
                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
+                  , Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.CommandBuffer( VkCommandBufferLevel
-                                    , VkCommandBufferUsageFlags
-                                    , VkCommandBufferInheritanceInfo
-                                    , CommandBuffer
-                                    , VkCommandBufferAllocateInfo
-                                    , VkCommandBufferResetFlags
-                                    , VkCommandBufferBeginInfo
-                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -34,9 +27,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.CommandPool( CommandPool
+import Graphics.Vulkan.CommandPool( CommandPool(..)
                                   )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
 import Text.Read( Read(..)
                 , parens
@@ -45,13 +38,13 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Query( VkQueryControlFlags
-                            , VkQueryPipelineStatisticFlags
+import Graphics.Vulkan.Query( VkQueryPipelineStatisticFlags(..)
+                            , VkQueryControlFlags(..)
                             )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
 
 -- ** VkCommandBufferLevel
@@ -95,37 +88,34 @@ foreign import ccall "vkFreeCommandBuffers" vkFreeCommandBuffers ::
 
 -- ** VkCommandBufferUsageFlags
 
-newtype VkCommandBufferUsageFlagBits = VkCommandBufferUsageFlagBits VkFlags
+newtype VkCommandBufferUsageFlags = VkCommandBufferUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCommandBufferUsageFlagBits
-type VkCommandBufferUsageFlags = VkCommandBufferUsageFlagBits
-
-instance Show VkCommandBufferUsageFlagBits where
+instance Show VkCommandBufferUsageFlags where
   showsPrec _ VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = showString "VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT"
   showsPrec _ VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = showString "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT"
   showsPrec _ VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = showString "VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT"
   
-  showsPrec p (VkCommandBufferUsageFlagBits x) = showParen (p >= 11) (showString "VkCommandBufferUsageFlagBits " . showsPrec 11 x)
+  showsPrec p (VkCommandBufferUsageFlags x) = showParen (p >= 11) (showString "VkCommandBufferUsageFlags " . showsPrec 11 x)
 
-instance Read VkCommandBufferUsageFlagBits where
+instance Read VkCommandBufferUsageFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT", pure VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT)
                              , ("VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT", pure VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)
                              , ("VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT", pure VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandBufferUsageFlagBits")
+                        expectP (Ident "VkCommandBufferUsageFlags")
                         v <- step readPrec
-                        pure (VkCommandBufferUsageFlagBits v)
+                        pure (VkCommandBufferUsageFlags v)
                         )
                     )
 
 
-pattern VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = VkCommandBufferUsageFlagBits 0x1
+pattern VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT = VkCommandBufferUsageFlags 0x1
 
-pattern VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = VkCommandBufferUsageFlagBits 0x2
+pattern VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT = VkCommandBufferUsageFlags 0x2
 -- | Command buffer may be submitted/executed more than once simultaneously
-pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = VkCommandBufferUsageFlagBits 0x4
+pattern VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT = VkCommandBufferUsageFlags 0x4
 
 
 
@@ -189,29 +179,26 @@ type CommandBuffer = Ptr VkCommandBuffer_T
 
 -- ** VkCommandBufferResetFlags
 
-newtype VkCommandBufferResetFlagBits = VkCommandBufferResetFlagBits VkFlags
+newtype VkCommandBufferResetFlags = VkCommandBufferResetFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCommandBufferResetFlagBits
-type VkCommandBufferResetFlags = VkCommandBufferResetFlagBits
-
-instance Show VkCommandBufferResetFlagBits where
+instance Show VkCommandBufferResetFlags where
   showsPrec _ VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT"
   
-  showsPrec p (VkCommandBufferResetFlagBits x) = showParen (p >= 11) (showString "VkCommandBufferResetFlagBits " . showsPrec 11 x)
+  showsPrec p (VkCommandBufferResetFlags x) = showParen (p >= 11) (showString "VkCommandBufferResetFlags " . showsPrec 11 x)
 
-instance Read VkCommandBufferResetFlagBits where
+instance Read VkCommandBufferResetFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandBufferResetFlagBits")
+                        expectP (Ident "VkCommandBufferResetFlags")
                         v <- step readPrec
-                        pure (VkCommandBufferResetFlagBits v)
+                        pure (VkCommandBufferResetFlags v)
                         )
                     )
 
 -- | Release resources owned by the buffer
-pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = VkCommandBufferResetFlagBits 0x1
+pattern VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT = VkCommandBufferResetFlags 0x1
 
 
 -- ** vkEndCommandBuffer

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -7,38 +7,17 @@ module Graphics.Vulkan.CommandBufferBuilding where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
-import Graphics.Vulkan.Pass( VkDependencyFlagBits(..)
-                           , Framebuffer(..)
-                           , RenderPass(..)
-                           , VkAccessFlags(..)
-                           , VkDependencyFlags(..)
-                           , VkAccessFlagBits(..)
-                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
-import Graphics.Vulkan.Event( Event(..)
-                            )
 import GHC.Read( expectP
                , choose
                )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits(..)
-                               , VkPipelineStageFlags(..)
-                               , Pipeline(..)
-                               , VkPipelineBindPoint(..)
-                               )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , castPtr
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( DescriptorSet(..)
-                                    )
-import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
-                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -48,8 +27,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
-                                     )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -57,39 +34,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
-                             , VkShaderStageFlags(..)
-                             )
-import Graphics.Vulkan.Sampler( VkFilter(..)
-                              )
-import Graphics.Vulkan.Image( Image(..)
-                            , VkImageLayout(..)
-                            , VkImageAspectFlagBits(..)
-                            , VkImageSubresourceRange(..)
-                            , VkImageAspectFlags(..)
-                            )
-import Graphics.Vulkan.Query( VkQueryResultFlagBits(..)
-                            , VkQueryControlFlagBits(..)
-                            , VkQueryControlFlags(..)
-                            , QueryPool(..)
-                            , VkQueryResultFlags(..)
-                            )
-import Graphics.Vulkan.OtherTypes( VkImageMemoryBarrier(..)
-                                 , VkMemoryBarrier(..)
-                                 , VkBufferMemoryBarrier(..)
-                                 )
-import Graphics.Vulkan.Core( VkExtent3D(..)
-                           , VkDeviceSize(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkOffset2D(..)
-                           , VkOffset3D(..)
-                           , VkRect2D(..)
-                           , VkViewport(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CFloat
-                      , CFloat(..)
                       )
 
 -- ** vkCmdPushConstants

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -71,12 +71,12 @@ import Graphics.Vulkan.OtherTypes( BufferMemoryBarrier(..)
                                  , MemoryBarrier(..)
                                  )
 import Graphics.Vulkan.Core( Offset3D(..)
-                           , VkFlags(..)
                            , StructureType(..)
                            , Viewport(..)
                            , Rect2D(..)
                            , Extent3D(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       )
@@ -93,7 +93,7 @@ foreign import ccall "vkCmdSetStencilWriteMask" vkCmdSetStencilWriteMask ::
 
 -- ** vkCmdBindIndexBuffer
 foreign import ccall "vkCmdBindIndexBuffer" vkCmdBindIndexBuffer ::
-  CommandBuffer -> Buffer -> VkDeviceSize -> IndexType -> IO ()
+  CommandBuffer -> Buffer -> DeviceSize -> IndexType -> IO ()
 
 -- ** vkCmdResetQueryPool
 foreign import ccall "vkCmdResetQueryPool" vkCmdResetQueryPool ::
@@ -113,7 +113,7 @@ foreign import ccall "vkCmdBindPipeline" vkCmdBindPipeline ::
 -- ** vkCmdBindVertexBuffers
 foreign import ccall "vkCmdBindVertexBuffers" vkCmdBindVertexBuffers ::
   CommandBuffer ->
-  Word32 -> Word32 -> Ptr Buffer -> Ptr VkDeviceSize -> IO ()
+  Word32 -> Word32 -> Ptr Buffer -> Ptr DeviceSize -> IO ()
 
 -- ** vkCmdDraw
 foreign import ccall "vkCmdDraw" vkCmdDraw ::
@@ -168,7 +168,7 @@ foreign import ccall "vkCmdCopyImageToBuffer" vkCmdCopyImageToBuffer ::
 
 -- ** vkCmdDispatchIndirect
 foreign import ccall "vkCmdDispatchIndirect" vkCmdDispatchIndirect ::
-  CommandBuffer -> Buffer -> VkDeviceSize -> IO ()
+  CommandBuffer -> Buffer -> DeviceSize -> IO ()
 
 -- ** vkCmdBeginQuery
 foreign import ccall "vkCmdBeginQuery" vkCmdBeginQuery ::
@@ -181,7 +181,7 @@ foreign import ccall "vkCmdEndRenderPass" vkCmdEndRenderPass ::
 -- ** vkCmdFillBuffer
 foreign import ccall "vkCmdFillBuffer" vkCmdFillBuffer ::
   CommandBuffer ->
-  Buffer -> VkDeviceSize -> VkDeviceSize -> Word32 -> IO ()
+  Buffer -> DeviceSize -> DeviceSize -> Word32 -> IO ()
 
 
 data ClearRect =
@@ -250,7 +250,7 @@ pattern VK_INDEX_TYPE_UINT32 = IndexType 1
 
 
 data BufferImageCopy =
-  BufferImageCopy{ bufferOffset :: VkDeviceSize 
+  BufferImageCopy{ bufferOffset :: DeviceSize 
                  , bufferRowLength :: Word32 
                  , bufferImageHeight :: Word32 
                  , imageSubresource :: ImageSubresourceLayers 
@@ -288,13 +288,12 @@ foreign import ccall "vkCmdCopyBufferToImage" vkCmdCopyBufferToImage ::
 
 -- ** vkCmdDrawIndexedIndirect
 foreign import ccall "vkCmdDrawIndexedIndirect" vkCmdDrawIndexedIndirect ::
-  CommandBuffer ->
-  Buffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
+  CommandBuffer -> Buffer -> DeviceSize -> Word32 -> Word32 -> IO ()
 
 -- ** vkCmdUpdateBuffer
 foreign import ccall "vkCmdUpdateBuffer" vkCmdUpdateBuffer ::
   CommandBuffer ->
-  Buffer -> VkDeviceSize -> VkDeviceSize -> Ptr Word32 -> IO ()
+  Buffer -> DeviceSize -> DeviceSize -> Ptr Word32 -> IO ()
 
 -- ** vkCmdCopyImage
 foreign import ccall "vkCmdCopyImage" vkCmdCopyImage ::
@@ -340,8 +339,7 @@ foreign import ccall "vkCmdSetDepthBias" vkCmdSetDepthBias ::
 
 -- ** vkCmdDrawIndirect
 foreign import ccall "vkCmdDrawIndirect" vkCmdDrawIndirect ::
-  CommandBuffer ->
-  Buffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
+  CommandBuffer -> Buffer -> DeviceSize -> Word32 -> Word32 -> IO ()
 
 
 data ClearDepthStencilValue =
@@ -361,9 +359,9 @@ instance Storable ClearDepthStencilValue where
 
 
 data BufferCopy =
-  BufferCopy{ srcOffset :: VkDeviceSize 
-            , dstOffset :: VkDeviceSize 
-            , size :: VkDeviceSize 
+  BufferCopy{ srcOffset :: DeviceSize 
+            , dstOffset :: DeviceSize 
+            , size :: DeviceSize 
             }
   deriving (Eq)
 
@@ -501,7 +499,7 @@ instance Storable ClearValue where
 
 -- ** VkStencilFaceFlags
 
-newtype StencilFaceFlags = StencilFaceFlags VkFlags
+newtype StencilFaceFlags = StencilFaceFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show StencilFaceFlags where
@@ -578,7 +576,7 @@ foreign import ccall "vkCmdCopyQueryPoolResults" vkCmdCopyQueryPoolResults ::
   QueryPool ->
     Word32 ->
       Word32 ->
-        Buffer -> VkDeviceSize -> VkDeviceSize -> QueryResultFlags -> IO ()
+        Buffer -> DeviceSize -> DeviceSize -> QueryResultFlags -> IO ()
 
 -- ** vkCmdBlitImage
 foreign import ccall "vkCmdBlitImage" vkCmdBlitImage ::

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -228,13 +228,13 @@ newtype IndexType = IndexType Int32
   deriving (Eq, Storable)
 
 instance Show IndexType where
-  showsPrec _ VK_INDEX_TYPE_UINT16 = showString "VK_INDEX_TYPE_UINT16"
-  showsPrec _ VK_INDEX_TYPE_UINT32 = showString "VK_INDEX_TYPE_UINT32"
+  showsPrec _ IndexTypeUint16 = showString "IndexTypeUint16"
+  showsPrec _ IndexTypeUint32 = showString "IndexTypeUint32"
   showsPrec p (IndexType x) = showParen (p >= 11) (showString "IndexType " . showsPrec 11 x)
 
 instance Read IndexType where
-  readPrec = parens ( choose [ ("VK_INDEX_TYPE_UINT16", pure VK_INDEX_TYPE_UINT16)
-                             , ("VK_INDEX_TYPE_UINT32", pure VK_INDEX_TYPE_UINT32)
+  readPrec = parens ( choose [ ("IndexTypeUint16", pure IndexTypeUint16)
+                             , ("IndexTypeUint32", pure IndexTypeUint32)
                              ] +++
                       prec 10 (do
                         expectP (Ident "IndexType")
@@ -244,9 +244,9 @@ instance Read IndexType where
                     )
 
 
-pattern VK_INDEX_TYPE_UINT16 = IndexType 0
+pattern IndexTypeUint16 = IndexType 0
 
-pattern VK_INDEX_TYPE_UINT32 = IndexType 1
+pattern IndexTypeUint32 = IndexType 1
 
 
 data BufferImageCopy =
@@ -550,13 +550,13 @@ newtype SubpassContents = SubpassContents Int32
   deriving (Eq, Storable)
 
 instance Show SubpassContents where
-  showsPrec _ VK_SUBPASS_CONTENTS_INLINE = showString "VK_SUBPASS_CONTENTS_INLINE"
-  showsPrec _ VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = showString "VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS"
+  showsPrec _ SubpassContentsInline = showString "SubpassContentsInline"
+  showsPrec _ SubpassContentsSecondaryCommandBuffers = showString "SubpassContentsSecondaryCommandBuffers"
   showsPrec p (SubpassContents x) = showParen (p >= 11) (showString "SubpassContents " . showsPrec 11 x)
 
 instance Read SubpassContents where
-  readPrec = parens ( choose [ ("VK_SUBPASS_CONTENTS_INLINE", pure VK_SUBPASS_CONTENTS_INLINE)
-                             , ("VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS", pure VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS)
+  readPrec = parens ( choose [ ("SubpassContentsInline", pure SubpassContentsInline)
+                             , ("SubpassContentsSecondaryCommandBuffers", pure SubpassContentsSecondaryCommandBuffers)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SubpassContents")
@@ -566,9 +566,9 @@ instance Read SubpassContents where
                     )
 
 
-pattern VK_SUBPASS_CONTENTS_INLINE = SubpassContents 0
+pattern SubpassContentsInline = SubpassContents 0
 
-pattern VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = SubpassContents 1
+pattern SubpassContentsSecondaryCommandBuffers = SubpassContents 1
 
 -- ** cmdCopyQueryPoolResults
 foreign import ccall "vkCmdCopyQueryPoolResults" cmdCopyQueryPoolResults ::

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -81,42 +81,42 @@ import Graphics.Vulkan.Core( Offset3D(..)
 import Foreign.C.Types( CFloat(..)
                       )
 
--- ** vkCmdPushConstants
-foreign import ccall "vkCmdPushConstants" vkCmdPushConstants ::
+-- ** cmdPushConstants
+foreign import ccall "vkCmdPushConstants" cmdPushConstants ::
   CommandBuffer ->
   PipelineLayout ->
     ShaderStageFlags -> Word32 -> Word32 -> Ptr Void -> IO ()
 
--- ** vkCmdSetStencilWriteMask
-foreign import ccall "vkCmdSetStencilWriteMask" vkCmdSetStencilWriteMask ::
+-- ** cmdSetStencilWriteMask
+foreign import ccall "vkCmdSetStencilWriteMask" cmdSetStencilWriteMask ::
   CommandBuffer -> StencilFaceFlags -> Word32 -> IO ()
 
--- ** vkCmdBindIndexBuffer
-foreign import ccall "vkCmdBindIndexBuffer" vkCmdBindIndexBuffer ::
+-- ** cmdBindIndexBuffer
+foreign import ccall "vkCmdBindIndexBuffer" cmdBindIndexBuffer ::
   CommandBuffer -> Buffer -> DeviceSize -> IndexType -> IO ()
 
--- ** vkCmdResetQueryPool
-foreign import ccall "vkCmdResetQueryPool" vkCmdResetQueryPool ::
+-- ** cmdResetQueryPool
+foreign import ccall "vkCmdResetQueryPool" cmdResetQueryPool ::
   CommandBuffer -> QueryPool -> Word32 -> Word32 -> IO ()
 
--- ** vkCmdResolveImage
-foreign import ccall "vkCmdResolveImage" vkCmdResolveImage ::
+-- ** cmdResolveImage
+foreign import ccall "vkCmdResolveImage" cmdResolveImage ::
   CommandBuffer ->
   Image ->
     ImageLayout ->
       Image -> ImageLayout -> Word32 -> Ptr ImageResolve -> IO ()
 
--- ** vkCmdBindPipeline
-foreign import ccall "vkCmdBindPipeline" vkCmdBindPipeline ::
+-- ** cmdBindPipeline
+foreign import ccall "vkCmdBindPipeline" cmdBindPipeline ::
   CommandBuffer -> PipelineBindPoint -> Pipeline -> IO ()
 
--- ** vkCmdBindVertexBuffers
-foreign import ccall "vkCmdBindVertexBuffers" vkCmdBindVertexBuffers ::
+-- ** cmdBindVertexBuffers
+foreign import ccall "vkCmdBindVertexBuffers" cmdBindVertexBuffers ::
   CommandBuffer ->
   Word32 -> Word32 -> Ptr Buffer -> Ptr DeviceSize -> IO ()
 
--- ** vkCmdDraw
-foreign import ccall "vkCmdDraw" vkCmdDraw ::
+-- ** cmdDraw
+foreign import ccall "vkCmdDraw" cmdDraw ::
   CommandBuffer -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 
 
@@ -144,42 +144,42 @@ instance Storable ImageCopy where
                 *> poke (ptr `plusPtr` 56) (extent (poked :: ImageCopy))
 
 
--- ** vkCmdNextSubpass
-foreign import ccall "vkCmdNextSubpass" vkCmdNextSubpass ::
+-- ** cmdNextSubpass
+foreign import ccall "vkCmdNextSubpass" cmdNextSubpass ::
   CommandBuffer -> SubpassContents -> IO ()
 
--- ** vkCmdEndQuery
-foreign import ccall "vkCmdEndQuery" vkCmdEndQuery ::
+-- ** cmdEndQuery
+foreign import ccall "vkCmdEndQuery" cmdEndQuery ::
   CommandBuffer -> QueryPool -> Word32 -> IO ()
 
--- ** vkCmdSetScissor
-foreign import ccall "vkCmdSetScissor" vkCmdSetScissor ::
+-- ** cmdSetScissor
+foreign import ccall "vkCmdSetScissor" cmdSetScissor ::
   CommandBuffer -> Word32 -> Word32 -> Ptr Rect2D -> IO ()
 
--- ** vkCmdSetEvent
-foreign import ccall "vkCmdSetEvent" vkCmdSetEvent ::
+-- ** cmdSetEvent
+foreign import ccall "vkCmdSetEvent" cmdSetEvent ::
   CommandBuffer -> Event -> PipelineStageFlags -> IO ()
 
--- ** vkCmdCopyImageToBuffer
-foreign import ccall "vkCmdCopyImageToBuffer" vkCmdCopyImageToBuffer ::
+-- ** cmdCopyImageToBuffer
+foreign import ccall "vkCmdCopyImageToBuffer" cmdCopyImageToBuffer ::
   CommandBuffer ->
   Image ->
     ImageLayout -> Buffer -> Word32 -> Ptr BufferImageCopy -> IO ()
 
--- ** vkCmdDispatchIndirect
-foreign import ccall "vkCmdDispatchIndirect" vkCmdDispatchIndirect ::
+-- ** cmdDispatchIndirect
+foreign import ccall "vkCmdDispatchIndirect" cmdDispatchIndirect ::
   CommandBuffer -> Buffer -> DeviceSize -> IO ()
 
--- ** vkCmdBeginQuery
-foreign import ccall "vkCmdBeginQuery" vkCmdBeginQuery ::
+-- ** cmdBeginQuery
+foreign import ccall "vkCmdBeginQuery" cmdBeginQuery ::
   CommandBuffer -> QueryPool -> Word32 -> QueryControlFlags -> IO ()
 
--- ** vkCmdEndRenderPass
-foreign import ccall "vkCmdEndRenderPass" vkCmdEndRenderPass ::
+-- ** cmdEndRenderPass
+foreign import ccall "vkCmdEndRenderPass" cmdEndRenderPass ::
   CommandBuffer -> IO ()
 
--- ** vkCmdFillBuffer
-foreign import ccall "vkCmdFillBuffer" vkCmdFillBuffer ::
+-- ** cmdFillBuffer
+foreign import ccall "vkCmdFillBuffer" cmdFillBuffer ::
   CommandBuffer ->
   Buffer -> DeviceSize -> DeviceSize -> Word32 -> IO ()
 
@@ -202,8 +202,8 @@ instance Storable ClearRect where
                 *> poke (ptr `plusPtr` 20) (layerCount (poked :: ClearRect))
 
 
--- ** vkCmdWaitEvents
-foreign import ccall "vkCmdWaitEvents" vkCmdWaitEvents ::
+-- ** cmdWaitEvents
+foreign import ccall "vkCmdWaitEvents" cmdWaitEvents ::
   CommandBuffer ->
   Word32 ->
     Ptr Event ->
@@ -215,8 +215,8 @@ foreign import ccall "vkCmdWaitEvents" vkCmdWaitEvents ::
                 Ptr BufferMemoryBarrier ->
                   Word32 -> Ptr ImageMemoryBarrier -> IO ()
 
--- ** vkCmdClearColorImage
-foreign import ccall "vkCmdClearColorImage" vkCmdClearColorImage ::
+-- ** cmdClearColorImage
+foreign import ccall "vkCmdClearColorImage" cmdClearColorImage ::
   CommandBuffer ->
   Image ->
     ImageLayout ->
@@ -276,34 +276,34 @@ instance Storable BufferImageCopy where
                 *> poke (ptr `plusPtr` 44) (imageExtent (poked :: BufferImageCopy))
 
 
--- ** vkCmdSetDepthBounds
-foreign import ccall "vkCmdSetDepthBounds" vkCmdSetDepthBounds ::
+-- ** cmdSetDepthBounds
+foreign import ccall "vkCmdSetDepthBounds" cmdSetDepthBounds ::
   CommandBuffer -> CFloat -> CFloat -> IO ()
 
--- ** vkCmdCopyBufferToImage
-foreign import ccall "vkCmdCopyBufferToImage" vkCmdCopyBufferToImage ::
+-- ** cmdCopyBufferToImage
+foreign import ccall "vkCmdCopyBufferToImage" cmdCopyBufferToImage ::
   CommandBuffer ->
   Buffer ->
     Image -> ImageLayout -> Word32 -> Ptr BufferImageCopy -> IO ()
 
--- ** vkCmdDrawIndexedIndirect
-foreign import ccall "vkCmdDrawIndexedIndirect" vkCmdDrawIndexedIndirect ::
+-- ** cmdDrawIndexedIndirect
+foreign import ccall "vkCmdDrawIndexedIndirect" cmdDrawIndexedIndirect ::
   CommandBuffer -> Buffer -> DeviceSize -> Word32 -> Word32 -> IO ()
 
--- ** vkCmdUpdateBuffer
-foreign import ccall "vkCmdUpdateBuffer" vkCmdUpdateBuffer ::
+-- ** cmdUpdateBuffer
+foreign import ccall "vkCmdUpdateBuffer" cmdUpdateBuffer ::
   CommandBuffer ->
   Buffer -> DeviceSize -> DeviceSize -> Ptr Word32 -> IO ()
 
--- ** vkCmdCopyImage
-foreign import ccall "vkCmdCopyImage" vkCmdCopyImage ::
+-- ** cmdCopyImage
+foreign import ccall "vkCmdCopyImage" cmdCopyImage ::
   CommandBuffer ->
   Image ->
     ImageLayout ->
       Image -> ImageLayout -> Word32 -> Ptr ImageCopy -> IO ()
 
--- ** vkCmdWriteTimestamp
-foreign import ccall "vkCmdWriteTimestamp" vkCmdWriteTimestamp ::
+-- ** cmdWriteTimestamp
+foreign import ccall "vkCmdWriteTimestamp" cmdWriteTimestamp ::
   CommandBuffer -> PipelineStageFlags -> QueryPool -> Word32 -> IO ()
 
 
@@ -328,17 +328,17 @@ instance Storable ImageSubresourceLayers where
                 *> poke (ptr `plusPtr` 12) (layerCount (poked :: ImageSubresourceLayers))
 
 
--- ** vkCmdDrawIndexed
-foreign import ccall "vkCmdDrawIndexed" vkCmdDrawIndexed ::
+-- ** cmdDrawIndexed
+foreign import ccall "vkCmdDrawIndexed" cmdDrawIndexed ::
   CommandBuffer ->
   Word32 -> Word32 -> Word32 -> Int32 -> Word32 -> IO ()
 
--- ** vkCmdSetDepthBias
-foreign import ccall "vkCmdSetDepthBias" vkCmdSetDepthBias ::
+-- ** cmdSetDepthBias
+foreign import ccall "vkCmdSetDepthBias" cmdSetDepthBias ::
   CommandBuffer -> CFloat -> CFloat -> CFloat -> IO ()
 
--- ** vkCmdDrawIndirect
-foreign import ccall "vkCmdDrawIndirect" vkCmdDrawIndirect ::
+-- ** cmdDrawIndirect
+foreign import ccall "vkCmdDrawIndirect" cmdDrawIndirect ::
   CommandBuffer -> Buffer -> DeviceSize -> Word32 -> Word32 -> IO ()
 
 
@@ -376,34 +376,34 @@ instance Storable BufferCopy where
                 *> poke (ptr `plusPtr` 16) (size (poked :: BufferCopy))
 
 
--- ** vkCmdClearAttachments
-foreign import ccall "vkCmdClearAttachments" vkCmdClearAttachments ::
+-- ** cmdClearAttachments
+foreign import ccall "vkCmdClearAttachments" cmdClearAttachments ::
   CommandBuffer ->
   Word32 -> Ptr ClearAttachment -> Word32 -> Ptr ClearRect -> IO ()
 
--- ** vkCmdSetViewport
-foreign import ccall "vkCmdSetViewport" vkCmdSetViewport ::
+-- ** cmdSetViewport
+foreign import ccall "vkCmdSetViewport" cmdSetViewport ::
   CommandBuffer -> Word32 -> Word32 -> Ptr Viewport -> IO ()
 
--- ** vkCmdCopyBuffer
-foreign import ccall "vkCmdCopyBuffer" vkCmdCopyBuffer ::
+-- ** cmdCopyBuffer
+foreign import ccall "vkCmdCopyBuffer" cmdCopyBuffer ::
   CommandBuffer ->
   Buffer -> Buffer -> Word32 -> Ptr BufferCopy -> IO ()
 
--- ** vkCmdBindDescriptorSets
-foreign import ccall "vkCmdBindDescriptorSets" vkCmdBindDescriptorSets ::
+-- ** cmdBindDescriptorSets
+foreign import ccall "vkCmdBindDescriptorSets" cmdBindDescriptorSets ::
   CommandBuffer ->
   PipelineBindPoint ->
     PipelineLayout ->
       Word32 ->
         Word32 -> Ptr DescriptorSet -> Word32 -> Ptr Word32 -> IO ()
 
--- ** vkCmdSetLineWidth
-foreign import ccall "vkCmdSetLineWidth" vkCmdSetLineWidth ::
+-- ** cmdSetLineWidth
+foreign import ccall "vkCmdSetLineWidth" cmdSetLineWidth ::
   CommandBuffer -> CFloat -> IO ()
 
--- ** vkCmdExecuteCommands
-foreign import ccall "vkCmdExecuteCommands" vkCmdExecuteCommands ::
+-- ** cmdExecuteCommands
+foreign import ccall "vkCmdExecuteCommands" cmdExecuteCommands ::
   CommandBuffer -> Word32 -> Ptr CommandBuffer -> IO ()
 
 
@@ -437,8 +437,8 @@ instance Storable RenderPassBeginInfo where
                 *> poke (ptr `plusPtr` 56) (pClearValues (poked :: RenderPassBeginInfo))
 
 
--- ** vkCmdSetStencilCompareMask
-foreign import ccall "vkCmdSetStencilCompareMask" vkCmdSetStencilCompareMask ::
+-- ** cmdSetStencilCompareMask
+foreign import ccall "vkCmdSetStencilCompareMask" cmdSetStencilCompareMask ::
   CommandBuffer -> StencilFaceFlags -> Word32 -> IO ()
 
 
@@ -570,27 +570,27 @@ pattern VK_SUBPASS_CONTENTS_INLINE = SubpassContents 0
 
 pattern VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = SubpassContents 1
 
--- ** vkCmdCopyQueryPoolResults
-foreign import ccall "vkCmdCopyQueryPoolResults" vkCmdCopyQueryPoolResults ::
+-- ** cmdCopyQueryPoolResults
+foreign import ccall "vkCmdCopyQueryPoolResults" cmdCopyQueryPoolResults ::
   CommandBuffer ->
   QueryPool ->
     Word32 ->
       Word32 ->
         Buffer -> DeviceSize -> DeviceSize -> QueryResultFlags -> IO ()
 
--- ** vkCmdBlitImage
-foreign import ccall "vkCmdBlitImage" vkCmdBlitImage ::
+-- ** cmdBlitImage
+foreign import ccall "vkCmdBlitImage" cmdBlitImage ::
   CommandBuffer ->
   Image ->
     ImageLayout ->
       Image -> ImageLayout -> Word32 -> Ptr ImageBlit -> Filter -> IO ()
 
--- ** vkCmdSetBlendConstants
-foreign import ccall "vkCmdSetBlendConstants" vkCmdSetBlendConstants ::
+-- ** cmdSetBlendConstants
+foreign import ccall "vkCmdSetBlendConstants" cmdSetBlendConstants ::
   CommandBuffer -> Ptr CFloat -> IO ()
 
--- ** vkCmdClearDepthStencilImage
-foreign import ccall "vkCmdClearDepthStencilImage" vkCmdClearDepthStencilImage ::
+-- ** cmdClearDepthStencilImage
+foreign import ccall "vkCmdClearDepthStencilImage" cmdClearDepthStencilImage ::
   CommandBuffer ->
   Image ->
     ImageLayout ->
@@ -622,16 +622,16 @@ instance Storable ImageResolve where
                 *> poke (ptr `plusPtr` 56) (extent (poked :: ImageResolve))
 
 
--- ** vkCmdDispatch
-foreign import ccall "vkCmdDispatch" vkCmdDispatch ::
+-- ** cmdDispatch
+foreign import ccall "vkCmdDispatch" cmdDispatch ::
   CommandBuffer -> Word32 -> Word32 -> Word32 -> IO ()
 
--- ** vkCmdSetStencilReference
-foreign import ccall "vkCmdSetStencilReference" vkCmdSetStencilReference ::
+-- ** cmdSetStencilReference
+foreign import ccall "vkCmdSetStencilReference" cmdSetStencilReference ::
   CommandBuffer -> StencilFaceFlags -> Word32 -> IO ()
 
--- ** vkCmdPipelineBarrier
-foreign import ccall "vkCmdPipelineBarrier" vkCmdPipelineBarrier ::
+-- ** cmdPipelineBarrier
+foreign import ccall "vkCmdPipelineBarrier" cmdPipelineBarrier ::
   CommandBuffer ->
   PipelineStageFlags ->
     PipelineStageFlags ->
@@ -642,12 +642,12 @@ foreign import ccall "vkCmdPipelineBarrier" vkCmdPipelineBarrier ::
               Ptr BufferMemoryBarrier ->
                 Word32 -> Ptr ImageMemoryBarrier -> IO ()
 
--- ** vkCmdBeginRenderPass
-foreign import ccall "vkCmdBeginRenderPass" vkCmdBeginRenderPass ::
+-- ** cmdBeginRenderPass
+foreign import ccall "vkCmdBeginRenderPass" cmdBeginRenderPass ::
   CommandBuffer ->
   Ptr RenderPassBeginInfo -> SubpassContents -> IO ()
 
--- ** vkCmdResetEvent
-foreign import ccall "vkCmdResetEvent" vkCmdResetEvent ::
+-- ** cmdResetEvent
+foreign import ccall "vkCmdResetEvent" cmdResetEvent ::
   CommandBuffer -> Event -> PipelineStageFlags -> IO ()
 

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -497,7 +497,7 @@ instance Storable ClearValue where
                      DepthStencil e -> poke (castPtr ptr) e
 
 
--- ** VkStencilFaceFlags
+-- ** StencilFaceFlags
 
 newtype StencilFaceFlags = StencilFaceFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -7,17 +7,34 @@ module Graphics.Vulkan.CommandBufferBuilding where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
+import Graphics.Vulkan.Buffer( Buffer
+                             )
+import Graphics.Vulkan.Pass( Framebuffer
+                           , VkDependencyFlags
+                           , RenderPass
+                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
+import Graphics.Vulkan.Event( Event
+                            )
 import GHC.Read( expectP
                , choose
                )
+import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits
+                               , VkPipelineStageFlags
+                               , VkPipelineBindPoint
+                               , Pipeline
+                               )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , castPtr
                   , plusPtr
                   )
+import Graphics.Vulkan.DescriptorSet( DescriptorSet
+                                    )
+import Graphics.Vulkan.CommandBuffer( CommandBuffer
+                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -27,6 +44,24 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.CommandBufferBuilding( VkRenderPassBeginInfo
+                                            , VkClearValue
+                                            , VkStencilFaceFlags
+                                            , VkImageSubresourceLayers
+                                            , VkImageResolve
+                                            , VkClearRect
+                                            , VkClearColorValue
+                                            , VkSubpassContents
+                                            , VkImageBlit
+                                            , VkIndexType
+                                            , VkClearDepthStencilValue
+                                            , VkClearAttachment
+                                            , VkBufferCopy
+                                            , VkImageCopy
+                                            , VkBufferImageCopy
+                                            )
+import Graphics.Vulkan.PipelineLayout( PipelineLayout
+                                     )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -34,6 +69,31 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Shader( VkShaderStageFlags
+                             )
+import Graphics.Vulkan.Sampler( VkFilter
+                              )
+import Graphics.Vulkan.Image( VkImageAspectFlags
+                            , VkImageSubresourceRange
+                            , VkImageLayout
+                            , Image
+                            )
+import Graphics.Vulkan.Query( VkQueryResultFlags
+                            , QueryPool
+                            , VkQueryControlFlags
+                            )
+import Graphics.Vulkan.OtherTypes( VkMemoryBarrier
+                                 , VkBufferMemoryBarrier
+                                 , VkImageMemoryBarrier
+                                 )
+import Graphics.Vulkan.Core( VkExtent3D
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkOffset3D
+                           , VkViewport
+                           , VkRect2D
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CFloat
                       )
 

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -7,25 +7,25 @@ module Graphics.Vulkan.CommandBufferBuilding where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Graphics.Vulkan.Pass( VkDependencyFlagBits(..)
-                           , VkFramebuffer(..)
-                           , VkRenderPass(..)
+                           , Framebuffer(..)
+                           , RenderPass(..)
                            , VkAccessFlags(..)
                            , VkDependencyFlags(..)
                            , VkAccessFlagBits(..)
                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
-import Graphics.Vulkan.Event( VkEvent(..)
+import Graphics.Vulkan.Event( Event(..)
                             )
 import GHC.Read( expectP
                , choose
                )
 import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits(..)
                                , VkPipelineStageFlags(..)
-                               , VkPipeline(..)
+                               , Pipeline(..)
                                , VkPipelineBindPoint(..)
                                )
 import Data.Word( Word64
@@ -35,9 +35,9 @@ import Foreign.Ptr( Ptr
                   , castPtr
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( VkDescriptorSet(..)
+import Graphics.Vulkan.DescriptorSet( DescriptorSet(..)
                                     )
-import Graphics.Vulkan.CommandBuffer( VkCommandBuffer(..)
+import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
                                     )
 import Data.Int( Int32
                )
@@ -48,7 +48,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.PipelineLayout( VkPipelineLayout(..)
+import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
                                      )
 import Text.Read( Read(..)
                 , parens
@@ -62,7 +62,7 @@ import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
                              )
 import Graphics.Vulkan.Sampler( VkFilter(..)
                               )
-import Graphics.Vulkan.Image( VkImage(..)
+import Graphics.Vulkan.Image( Image(..)
                             , VkImageLayout(..)
                             , VkImageAspectFlagBits(..)
                             , VkImageSubresourceRange(..)
@@ -71,7 +71,7 @@ import Graphics.Vulkan.Image( VkImage(..)
 import Graphics.Vulkan.Query( VkQueryResultFlagBits(..)
                             , VkQueryControlFlagBits(..)
                             , VkQueryControlFlags(..)
-                            , VkQueryPool(..)
+                            , QueryPool(..)
                             , VkQueryResultFlags(..)
                             )
 import Graphics.Vulkan.OtherTypes( VkImageMemoryBarrier(..)
@@ -94,49 +94,49 @@ import Foreign.C.Types( CFloat
 
 -- ** vkCmdPushConstants
 foreign import ccall "vkCmdPushConstants" vkCmdPushConstants ::
-  VkCommandBuffer ->
-  VkPipelineLayout ->
+  CommandBuffer ->
+  PipelineLayout ->
     VkShaderStageFlags -> Word32 -> Word32 -> Ptr Void -> IO ()
 
 -- ** vkCmdSetStencilWriteMask
 foreign import ccall "vkCmdSetStencilWriteMask" vkCmdSetStencilWriteMask ::
-  VkCommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
+  CommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
 
 -- ** vkCmdBindIndexBuffer
 foreign import ccall "vkCmdBindIndexBuffer" vkCmdBindIndexBuffer ::
-  VkCommandBuffer -> VkBuffer -> VkDeviceSize -> VkIndexType -> IO ()
+  CommandBuffer -> Buffer -> VkDeviceSize -> VkIndexType -> IO ()
 
 -- ** vkCmdResetQueryPool
 foreign import ccall "vkCmdResetQueryPool" vkCmdResetQueryPool ::
-  VkCommandBuffer -> VkQueryPool -> Word32 -> Word32 -> IO ()
+  CommandBuffer -> QueryPool -> Word32 -> Word32 -> IO ()
 
 -- ** vkCmdResolveImage
 foreign import ccall "vkCmdResolveImage" vkCmdResolveImage ::
-  VkCommandBuffer ->
-  VkImage ->
+  CommandBuffer ->
+  Image ->
     VkImageLayout ->
-      VkImage -> VkImageLayout -> Word32 -> Ptr VkImageResolve -> IO ()
+      Image -> VkImageLayout -> Word32 -> Ptr VkImageResolve -> IO ()
 
 -- ** vkCmdBindPipeline
 foreign import ccall "vkCmdBindPipeline" vkCmdBindPipeline ::
-  VkCommandBuffer -> VkPipelineBindPoint -> VkPipeline -> IO ()
+  CommandBuffer -> VkPipelineBindPoint -> Pipeline -> IO ()
 
 -- ** vkCmdBindVertexBuffers
 foreign import ccall "vkCmdBindVertexBuffers" vkCmdBindVertexBuffers ::
-  VkCommandBuffer ->
-  Word32 -> Word32 -> Ptr VkBuffer -> Ptr VkDeviceSize -> IO ()
+  CommandBuffer ->
+  Word32 -> Word32 -> Ptr Buffer -> Ptr VkDeviceSize -> IO ()
 
 -- ** vkCmdDraw
 foreign import ccall "vkCmdDraw" vkCmdDraw ::
-  VkCommandBuffer -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 
 
 data VkImageCopy =
-  VkImageCopy{ vkSrcSubresource :: VkImageSubresourceLayers 
-             , vkSrcOffset :: VkOffset3D 
-             , vkDstSubresource :: VkImageSubresourceLayers 
-             , vkDstOffset :: VkOffset3D 
-             , vkExtent :: VkExtent3D 
+  VkImageCopy{ srcSubresource :: VkImageSubresourceLayers 
+             , srcOffset :: VkOffset3D 
+             , dstSubresource :: VkImageSubresourceLayers 
+             , dstOffset :: VkOffset3D 
+             , extent :: VkExtent3D 
              }
   deriving (Eq)
 
@@ -148,59 +148,58 @@ instance Storable VkImageCopy where
                          <*> peek (ptr `plusPtr` 28)
                          <*> peek (ptr `plusPtr` 44)
                          <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSrcSubresource (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 16) (vkSrcOffset (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 28) (vkDstSubresource (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 44) (vkDstOffset (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 56) (vkExtent (poked :: VkImageCopy))
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageCopy))
+                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: VkImageCopy))
+                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: VkImageCopy))
+                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: VkImageCopy))
+                *> poke (ptr `plusPtr` 56) (extent (poked :: VkImageCopy))
 
 
 -- ** vkCmdNextSubpass
 foreign import ccall "vkCmdNextSubpass" vkCmdNextSubpass ::
-  VkCommandBuffer -> VkSubpassContents -> IO ()
+  CommandBuffer -> VkSubpassContents -> IO ()
 
 -- ** vkCmdEndQuery
 foreign import ccall "vkCmdEndQuery" vkCmdEndQuery ::
-  VkCommandBuffer -> VkQueryPool -> Word32 -> IO ()
+  CommandBuffer -> QueryPool -> Word32 -> IO ()
 
 -- ** vkCmdSetScissor
 foreign import ccall "vkCmdSetScissor" vkCmdSetScissor ::
-  VkCommandBuffer -> Word32 -> Word32 -> Ptr VkRect2D -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Ptr VkRect2D -> IO ()
 
 -- ** vkCmdSetEvent
 foreign import ccall "vkCmdSetEvent" vkCmdSetEvent ::
-  VkCommandBuffer -> VkEvent -> VkPipelineStageFlags -> IO ()
+  CommandBuffer -> Event -> VkPipelineStageFlags -> IO ()
 
 -- ** vkCmdCopyImageToBuffer
 foreign import ccall "vkCmdCopyImageToBuffer" vkCmdCopyImageToBuffer ::
-  VkCommandBuffer ->
-  VkImage ->
-    VkImageLayout ->
-      VkBuffer -> Word32 -> Ptr VkBufferImageCopy -> IO ()
+  CommandBuffer ->
+  Image ->
+    VkImageLayout -> Buffer -> Word32 -> Ptr VkBufferImageCopy -> IO ()
 
 -- ** vkCmdDispatchIndirect
 foreign import ccall "vkCmdDispatchIndirect" vkCmdDispatchIndirect ::
-  VkCommandBuffer -> VkBuffer -> VkDeviceSize -> IO ()
+  CommandBuffer -> Buffer -> VkDeviceSize -> IO ()
 
 -- ** vkCmdBeginQuery
 foreign import ccall "vkCmdBeginQuery" vkCmdBeginQuery ::
-  VkCommandBuffer ->
-  VkQueryPool -> Word32 -> VkQueryControlFlags -> IO ()
+  CommandBuffer ->
+  QueryPool -> Word32 -> VkQueryControlFlags -> IO ()
 
 -- ** vkCmdEndRenderPass
 foreign import ccall "vkCmdEndRenderPass" vkCmdEndRenderPass ::
-  VkCommandBuffer -> IO ()
+  CommandBuffer -> IO ()
 
 -- ** vkCmdFillBuffer
 foreign import ccall "vkCmdFillBuffer" vkCmdFillBuffer ::
-  VkCommandBuffer ->
-  VkBuffer -> VkDeviceSize -> VkDeviceSize -> Word32 -> IO ()
+  CommandBuffer ->
+  Buffer -> VkDeviceSize -> VkDeviceSize -> Word32 -> IO ()
 
 
 data VkClearRect =
-  VkClearRect{ vkRect :: VkRect2D 
-             , vkBaseArrayLayer :: Word32 
-             , vkLayerCount :: Word32 
+  VkClearRect{ rect :: VkRect2D 
+             , baseArrayLayer :: Word32 
+             , layerCount :: Word32 
              }
   deriving (Eq)
 
@@ -210,16 +209,16 @@ instance Storable VkClearRect where
   peek ptr = VkClearRect <$> peek (ptr `plusPtr` 0)
                          <*> peek (ptr `plusPtr` 16)
                          <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkRect (poked :: VkClearRect))
-                *> poke (ptr `plusPtr` 16) (vkBaseArrayLayer (poked :: VkClearRect))
-                *> poke (ptr `plusPtr` 20) (vkLayerCount (poked :: VkClearRect))
+  poke ptr poked = poke (ptr `plusPtr` 0) (rect (poked :: VkClearRect))
+                *> poke (ptr `plusPtr` 16) (baseArrayLayer (poked :: VkClearRect))
+                *> poke (ptr `plusPtr` 20) (layerCount (poked :: VkClearRect))
 
 
 -- ** vkCmdWaitEvents
 foreign import ccall "vkCmdWaitEvents" vkCmdWaitEvents ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   Word32 ->
-    Ptr VkEvent ->
+    Ptr Event ->
       VkPipelineStageFlags ->
         VkPipelineStageFlags ->
           Word32 ->
@@ -230,8 +229,8 @@ foreign import ccall "vkCmdWaitEvents" vkCmdWaitEvents ::
 
 -- ** vkCmdClearColorImage
 foreign import ccall "vkCmdClearColorImage" vkCmdClearColorImage ::
-  VkCommandBuffer ->
-  VkImage ->
+  CommandBuffer ->
+  Image ->
     VkImageLayout ->
       Ptr VkClearColorValue ->
         Word32 -> Ptr VkImageSubresourceRange -> IO ()
@@ -264,12 +263,12 @@ pattern VK_INDEX_TYPE_UINT32 = VkIndexType 1
 
 
 data VkBufferImageCopy =
-  VkBufferImageCopy{ vkBufferOffset :: VkDeviceSize 
-                   , vkBufferRowLength :: Word32 
-                   , vkBufferImageHeight :: Word32 
-                   , vkImageSubresource :: VkImageSubresourceLayers 
-                   , vkImageOffset :: VkOffset3D 
-                   , vkImageExtent :: VkExtent3D 
+  VkBufferImageCopy{ bufferOffset :: VkDeviceSize 
+                   , bufferRowLength :: Word32 
+                   , bufferImageHeight :: Word32 
+                   , imageSubresource :: VkImageSubresourceLayers 
+                   , imageOffset :: VkOffset3D 
+                   , imageExtent :: VkExtent3D 
                    }
   deriving (Eq)
 
@@ -282,53 +281,52 @@ instance Storable VkBufferImageCopy where
                                <*> peek (ptr `plusPtr` 16)
                                <*> peek (ptr `plusPtr` 32)
                                <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBufferOffset (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 8) (vkBufferRowLength (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 12) (vkBufferImageHeight (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 16) (vkImageSubresource (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 32) (vkImageOffset (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 44) (vkImageExtent (poked :: VkBufferImageCopy))
+  poke ptr poked = poke (ptr `plusPtr` 0) (bufferOffset (poked :: VkBufferImageCopy))
+                *> poke (ptr `plusPtr` 8) (bufferRowLength (poked :: VkBufferImageCopy))
+                *> poke (ptr `plusPtr` 12) (bufferImageHeight (poked :: VkBufferImageCopy))
+                *> poke (ptr `plusPtr` 16) (imageSubresource (poked :: VkBufferImageCopy))
+                *> poke (ptr `plusPtr` 32) (imageOffset (poked :: VkBufferImageCopy))
+                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: VkBufferImageCopy))
 
 
 -- ** vkCmdSetDepthBounds
 foreign import ccall "vkCmdSetDepthBounds" vkCmdSetDepthBounds ::
-  VkCommandBuffer -> CFloat -> CFloat -> IO ()
+  CommandBuffer -> CFloat -> CFloat -> IO ()
 
 -- ** vkCmdCopyBufferToImage
 foreign import ccall "vkCmdCopyBufferToImage" vkCmdCopyBufferToImage ::
-  VkCommandBuffer ->
-  VkBuffer ->
-    VkImage ->
-      VkImageLayout -> Word32 -> Ptr VkBufferImageCopy -> IO ()
+  CommandBuffer ->
+  Buffer ->
+    Image -> VkImageLayout -> Word32 -> Ptr VkBufferImageCopy -> IO ()
 
 -- ** vkCmdDrawIndexedIndirect
 foreign import ccall "vkCmdDrawIndexedIndirect" vkCmdDrawIndexedIndirect ::
-  VkCommandBuffer ->
-  VkBuffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
+  CommandBuffer ->
+  Buffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
 
 -- ** vkCmdUpdateBuffer
 foreign import ccall "vkCmdUpdateBuffer" vkCmdUpdateBuffer ::
-  VkCommandBuffer ->
-  VkBuffer -> VkDeviceSize -> VkDeviceSize -> Ptr Word32 -> IO ()
+  CommandBuffer ->
+  Buffer -> VkDeviceSize -> VkDeviceSize -> Ptr Word32 -> IO ()
 
 -- ** vkCmdCopyImage
 foreign import ccall "vkCmdCopyImage" vkCmdCopyImage ::
-  VkCommandBuffer ->
-  VkImage ->
+  CommandBuffer ->
+  Image ->
     VkImageLayout ->
-      VkImage -> VkImageLayout -> Word32 -> Ptr VkImageCopy -> IO ()
+      Image -> VkImageLayout -> Word32 -> Ptr VkImageCopy -> IO ()
 
 -- ** vkCmdWriteTimestamp
 foreign import ccall "vkCmdWriteTimestamp" vkCmdWriteTimestamp ::
-  VkCommandBuffer ->
-  VkPipelineStageFlagBits -> VkQueryPool -> Word32 -> IO ()
+  CommandBuffer ->
+  VkPipelineStageFlagBits -> QueryPool -> Word32 -> IO ()
 
 
 data VkImageSubresourceLayers =
-  VkImageSubresourceLayers{ vkAspectMask :: VkImageAspectFlags 
-                          , vkMipLevel :: Word32 
-                          , vkBaseArrayLayer :: Word32 
-                          , vkLayerCount :: Word32 
+  VkImageSubresourceLayers{ aspectMask :: VkImageAspectFlags 
+                          , mipLevel :: Word32 
+                          , baseArrayLayer :: Word32 
+                          , layerCount :: Word32 
                           }
   deriving (Eq)
 
@@ -339,30 +337,30 @@ instance Storable VkImageSubresourceLayers where
                                       <*> peek (ptr `plusPtr` 4)
                                       <*> peek (ptr `plusPtr` 8)
                                       <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAspectMask (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 4) (vkMipLevel (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 8) (vkBaseArrayLayer (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 12) (vkLayerCount (poked :: VkImageSubresourceLayers))
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: VkImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 8) (baseArrayLayer (poked :: VkImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 12) (layerCount (poked :: VkImageSubresourceLayers))
 
 
 -- ** vkCmdDrawIndexed
 foreign import ccall "vkCmdDrawIndexed" vkCmdDrawIndexed ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   Word32 -> Word32 -> Word32 -> Int32 -> Word32 -> IO ()
 
 -- ** vkCmdSetDepthBias
 foreign import ccall "vkCmdSetDepthBias" vkCmdSetDepthBias ::
-  VkCommandBuffer -> CFloat -> CFloat -> CFloat -> IO ()
+  CommandBuffer -> CFloat -> CFloat -> CFloat -> IO ()
 
 -- ** vkCmdDrawIndirect
 foreign import ccall "vkCmdDrawIndirect" vkCmdDrawIndirect ::
-  VkCommandBuffer ->
-  VkBuffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
+  CommandBuffer ->
+  Buffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
 
 
 data VkClearDepthStencilValue =
-  VkClearDepthStencilValue{ vkDepth :: CFloat 
-                          , vkStencil :: Word32 
+  VkClearDepthStencilValue{ depth :: CFloat 
+                          , stencil :: Word32 
                           }
   deriving (Eq)
 
@@ -371,15 +369,15 @@ instance Storable VkClearDepthStencilValue where
   alignment ~_ = 4
   peek ptr = VkClearDepthStencilValue <$> peek (ptr `plusPtr` 0)
                                       <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkDepth (poked :: VkClearDepthStencilValue))
-                *> poke (ptr `plusPtr` 4) (vkStencil (poked :: VkClearDepthStencilValue))
+  poke ptr poked = poke (ptr `plusPtr` 0) (depth (poked :: VkClearDepthStencilValue))
+                *> poke (ptr `plusPtr` 4) (stencil (poked :: VkClearDepthStencilValue))
 
 
 
 data VkBufferCopy =
-  VkBufferCopy{ vkSrcOffset :: VkDeviceSize 
-              , vkDstOffset :: VkDeviceSize 
-              , vkSize :: VkDeviceSize 
+  VkBufferCopy{ srcOffset :: VkDeviceSize 
+              , dstOffset :: VkDeviceSize 
+              , size :: VkDeviceSize 
               }
   deriving (Eq)
 
@@ -389,51 +387,51 @@ instance Storable VkBufferCopy where
   peek ptr = VkBufferCopy <$> peek (ptr `plusPtr` 0)
                           <*> peek (ptr `plusPtr` 8)
                           <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSrcOffset (poked :: VkBufferCopy))
-                *> poke (ptr `plusPtr` 8) (vkDstOffset (poked :: VkBufferCopy))
-                *> poke (ptr `plusPtr` 16) (vkSize (poked :: VkBufferCopy))
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcOffset (poked :: VkBufferCopy))
+                *> poke (ptr `plusPtr` 8) (dstOffset (poked :: VkBufferCopy))
+                *> poke (ptr `plusPtr` 16) (size (poked :: VkBufferCopy))
 
 
 -- ** vkCmdClearAttachments
 foreign import ccall "vkCmdClearAttachments" vkCmdClearAttachments ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   Word32 ->
     Ptr VkClearAttachment -> Word32 -> Ptr VkClearRect -> IO ()
 
 -- ** vkCmdSetViewport
 foreign import ccall "vkCmdSetViewport" vkCmdSetViewport ::
-  VkCommandBuffer -> Word32 -> Word32 -> Ptr VkViewport -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Ptr VkViewport -> IO ()
 
 -- ** vkCmdCopyBuffer
 foreign import ccall "vkCmdCopyBuffer" vkCmdCopyBuffer ::
-  VkCommandBuffer ->
-  VkBuffer -> VkBuffer -> Word32 -> Ptr VkBufferCopy -> IO ()
+  CommandBuffer ->
+  Buffer -> Buffer -> Word32 -> Ptr VkBufferCopy -> IO ()
 
 -- ** vkCmdBindDescriptorSets
 foreign import ccall "vkCmdBindDescriptorSets" vkCmdBindDescriptorSets ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   VkPipelineBindPoint ->
-    VkPipelineLayout ->
+    PipelineLayout ->
       Word32 ->
-        Word32 -> Ptr VkDescriptorSet -> Word32 -> Ptr Word32 -> IO ()
+        Word32 -> Ptr DescriptorSet -> Word32 -> Ptr Word32 -> IO ()
 
 -- ** vkCmdSetLineWidth
 foreign import ccall "vkCmdSetLineWidth" vkCmdSetLineWidth ::
-  VkCommandBuffer -> CFloat -> IO ()
+  CommandBuffer -> CFloat -> IO ()
 
 -- ** vkCmdExecuteCommands
 foreign import ccall "vkCmdExecuteCommands" vkCmdExecuteCommands ::
-  VkCommandBuffer -> Word32 -> Ptr VkCommandBuffer -> IO ()
+  CommandBuffer -> Word32 -> Ptr CommandBuffer -> IO ()
 
 
 data VkRenderPassBeginInfo =
-  VkRenderPassBeginInfo{ vkSType :: VkStructureType 
-                       , vkPNext :: Ptr Void 
-                       , vkRenderPass :: VkRenderPass 
-                       , vkFramebuffer :: VkFramebuffer 
-                       , vkRenderArea :: VkRect2D 
-                       , vkClearValueCount :: Word32 
-                       , vkPClearValues :: Ptr VkClearValue 
+  VkRenderPassBeginInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , renderPass :: RenderPass 
+                       , framebuffer :: Framebuffer 
+                       , renderArea :: VkRect2D 
+                       , clearValueCount :: Word32 
+                       , pClearValues :: Ptr VkClearValue 
                        }
   deriving (Eq)
 
@@ -447,25 +445,25 @@ instance Storable VkRenderPassBeginInfo where
                                    <*> peek (ptr `plusPtr` 32)
                                    <*> peek (ptr `plusPtr` 48)
                                    <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 16) (vkRenderPass (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 24) (vkFramebuffer (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 32) (vkRenderArea (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 48) (vkClearValueCount (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 56) (vkPClearValues (poked :: VkRenderPassBeginInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 16) (renderPass (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 24) (framebuffer (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 32) (renderArea (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 48) (clearValueCount (poked :: VkRenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 56) (pClearValues (poked :: VkRenderPassBeginInfo))
 
 
 -- ** vkCmdSetStencilCompareMask
 foreign import ccall "vkCmdSetStencilCompareMask" vkCmdSetStencilCompareMask ::
-  VkCommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
+  CommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
 
 
 data VkImageBlit =
-  VkImageBlit{ vkSrcSubresource :: VkImageSubresourceLayers 
-             , vkSrcOffsets :: Vector 2 VkOffset3D 
-             , vkDstSubresource :: VkImageSubresourceLayers 
-             , vkDstOffsets :: Vector 2 VkOffset3D 
+  VkImageBlit{ srcSubresource :: VkImageSubresourceLayers 
+             , srcOffsets :: Vector 2 VkOffset3D 
+             , dstSubresource :: VkImageSubresourceLayers 
+             , dstOffsets :: Vector 2 VkOffset3D 
              }
   deriving (Eq)
 
@@ -476,17 +474,17 @@ instance Storable VkImageBlit where
                          <*> peek (ptr `plusPtr` 16)
                          <*> peek (ptr `plusPtr` 40)
                          <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSrcSubresource (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 16) (vkSrcOffsets (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 40) (vkDstSubresource (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 56) (vkDstOffsets (poked :: VkImageBlit))
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageBlit))
+                *> poke (ptr `plusPtr` 16) (srcOffsets (poked :: VkImageBlit))
+                *> poke (ptr `plusPtr` 40) (dstSubresource (poked :: VkImageBlit))
+                *> poke (ptr `plusPtr` 56) (dstOffsets (poked :: VkImageBlit))
 
 
 
 data VkClearAttachment =
-  VkClearAttachment{ vkAspectMask :: VkImageAspectFlags 
-                   , vkColorAttachment :: Word32 
-                   , vkClearValue :: VkClearValue 
+  VkClearAttachment{ aspectMask :: VkImageAspectFlags 
+                   , colorAttachment :: Word32 
+                   , clearValue :: VkClearValue 
                    }
   deriving (Eq)
 
@@ -496,14 +494,14 @@ instance Storable VkClearAttachment where
   peek ptr = VkClearAttachment <$> peek (ptr `plusPtr` 0)
                                <*> peek (ptr `plusPtr` 4)
                                <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAspectMask (poked :: VkClearAttachment))
-                *> poke (ptr `plusPtr` 4) (vkColorAttachment (poked :: VkClearAttachment))
-                *> poke (ptr `plusPtr` 8) (vkClearValue (poked :: VkClearAttachment))
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkClearAttachment))
+                *> poke (ptr `plusPtr` 4) (colorAttachment (poked :: VkClearAttachment))
+                *> poke (ptr `plusPtr` 8) (clearValue (poked :: VkClearAttachment))
 
 
 -- | // Union allowing specification of color or depth and stencil values. Actual value selected is based on attachment being cleared.
-data VkClearValue = VkColor VkClearColorValue 
-                  | VkDepthStencil VkClearDepthStencilValue 
+data VkClearValue = Color VkClearColorValue 
+                  | DepthStencil VkClearDepthStencilValue 
   deriving (Eq)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
@@ -512,8 +510,8 @@ instance Storable VkClearValue where
   alignment ~_ = 4
   peek ~_ = error "peek@VkClearValue"
   poke ptr poked = case poked of
-                     VkColor e -> poke (castPtr ptr) e
-                     VkDepthStencil e -> poke (castPtr ptr) e
+                     Color e -> poke (castPtr ptr) e
+                     DepthStencil e -> poke (castPtr ptr) e
 
 
 -- ** VkStencilFaceFlags
@@ -550,9 +548,9 @@ pattern VK_STENCIL_FACE_BACK_BIT = VkStencilFaceFlagBits 0x2
 pattern VK_STENCIL_FRONT_AND_BACK = VkStencilFaceFlagBits 0x3
 
 -- | // Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.
-data VkClearColorValue = VkFloat32 (Vector 4 CFloat) 
-                       | VkInt32 (Vector 4 Int32) 
-                       | VkUint32 (Vector 4 Word32) 
+data VkClearColorValue = Float32 (Vector 4 CFloat) 
+                       | Int32 (Vector 4 Int32) 
+                       | Uint32 (Vector 4 Word32) 
   deriving (Eq)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
@@ -561,9 +559,9 @@ instance Storable VkClearColorValue where
   alignment ~_ = 4
   peek ~_ = error "peek@VkClearColorValue"
   poke ptr poked = case poked of
-                     VkFloat32 e -> poke (castPtr ptr) e
-                     VkInt32 e -> poke (castPtr ptr) e
-                     VkUint32 e -> poke (castPtr ptr) e
+                     Float32 e -> poke (castPtr ptr) e
+                     Int32 e -> poke (castPtr ptr) e
+                     Uint32 e -> poke (castPtr ptr) e
 
 
 -- ** VkSubpassContents
@@ -594,40 +592,40 @@ pattern VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS = VkSubpassContents 1
 
 -- ** vkCmdCopyQueryPoolResults
 foreign import ccall "vkCmdCopyQueryPoolResults" vkCmdCopyQueryPoolResults ::
-  VkCommandBuffer ->
-  VkQueryPool ->
+  CommandBuffer ->
+  QueryPool ->
     Word32 ->
       Word32 ->
-        VkBuffer ->
+        Buffer ->
           VkDeviceSize -> VkDeviceSize -> VkQueryResultFlags -> IO ()
 
 -- ** vkCmdBlitImage
 foreign import ccall "vkCmdBlitImage" vkCmdBlitImage ::
-  VkCommandBuffer ->
-  VkImage ->
+  CommandBuffer ->
+  Image ->
     VkImageLayout ->
-      VkImage ->
+      Image ->
         VkImageLayout -> Word32 -> Ptr VkImageBlit -> VkFilter -> IO ()
 
 -- ** vkCmdSetBlendConstants
 foreign import ccall "vkCmdSetBlendConstants" vkCmdSetBlendConstants ::
-  VkCommandBuffer -> Ptr CFloat -> IO ()
+  CommandBuffer -> Ptr CFloat -> IO ()
 
 -- ** vkCmdClearDepthStencilImage
 foreign import ccall "vkCmdClearDepthStencilImage" vkCmdClearDepthStencilImage ::
-  VkCommandBuffer ->
-  VkImage ->
+  CommandBuffer ->
+  Image ->
     VkImageLayout ->
       Ptr VkClearDepthStencilValue ->
         Word32 -> Ptr VkImageSubresourceRange -> IO ()
 
 
 data VkImageResolve =
-  VkImageResolve{ vkSrcSubresource :: VkImageSubresourceLayers 
-                , vkSrcOffset :: VkOffset3D 
-                , vkDstSubresource :: VkImageSubresourceLayers 
-                , vkDstOffset :: VkOffset3D 
-                , vkExtent :: VkExtent3D 
+  VkImageResolve{ srcSubresource :: VkImageSubresourceLayers 
+                , srcOffset :: VkOffset3D 
+                , dstSubresource :: VkImageSubresourceLayers 
+                , dstOffset :: VkOffset3D 
+                , extent :: VkExtent3D 
                 }
   deriving (Eq)
 
@@ -639,24 +637,24 @@ instance Storable VkImageResolve where
                             <*> peek (ptr `plusPtr` 28)
                             <*> peek (ptr `plusPtr` 44)
                             <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSrcSubresource (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 16) (vkSrcOffset (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 28) (vkDstSubresource (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 44) (vkDstOffset (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 56) (vkExtent (poked :: VkImageResolve))
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageResolve))
+                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: VkImageResolve))
+                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: VkImageResolve))
+                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: VkImageResolve))
+                *> poke (ptr `plusPtr` 56) (extent (poked :: VkImageResolve))
 
 
 -- ** vkCmdDispatch
 foreign import ccall "vkCmdDispatch" vkCmdDispatch ::
-  VkCommandBuffer -> Word32 -> Word32 -> Word32 -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Word32 -> IO ()
 
 -- ** vkCmdSetStencilReference
 foreign import ccall "vkCmdSetStencilReference" vkCmdSetStencilReference ::
-  VkCommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
+  CommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
 
 -- ** vkCmdPipelineBarrier
 foreign import ccall "vkCmdPipelineBarrier" vkCmdPipelineBarrier ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   VkPipelineStageFlags ->
     VkPipelineStageFlags ->
       VkDependencyFlags ->
@@ -668,10 +666,10 @@ foreign import ccall "vkCmdPipelineBarrier" vkCmdPipelineBarrier ::
 
 -- ** vkCmdBeginRenderPass
 foreign import ccall "vkCmdBeginRenderPass" vkCmdBeginRenderPass ::
-  VkCommandBuffer ->
+  CommandBuffer ->
   Ptr VkRenderPassBeginInfo -> VkSubpassContents -> IO ()
 
 -- ** vkCmdResetEvent
 foreign import ccall "vkCmdResetEvent" vkCmdResetEvent ::
-  VkCommandBuffer -> VkEvent -> VkPipelineStageFlags -> IO ()
+  CommandBuffer -> Event -> VkPipelineStageFlags -> IO ()
 

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -503,15 +503,15 @@ newtype StencilFaceFlags = StencilFaceFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show StencilFaceFlags where
-  showsPrec _ VK_STENCIL_FACE_FRONT_BIT = showString "VK_STENCIL_FACE_FRONT_BIT"
-  showsPrec _ VK_STENCIL_FACE_BACK_BIT = showString "VK_STENCIL_FACE_BACK_BIT"
-  showsPrec _ VK_STENCIL_FRONT_AND_BACK = showString "VK_STENCIL_FRONT_AND_BACK"
+  showsPrec _ StencilFaceFrontBit = showString "StencilFaceFrontBit"
+  showsPrec _ StencilFaceBackBit = showString "StencilFaceBackBit"
+  showsPrec _ StencilFrontAndBack = showString "StencilFrontAndBack"
   showsPrec p (StencilFaceFlags x) = showParen (p >= 11) (showString "StencilFaceFlags " . showsPrec 11 x)
 
 instance Read StencilFaceFlags where
-  readPrec = parens ( choose [ ("VK_STENCIL_FACE_FRONT_BIT", pure VK_STENCIL_FACE_FRONT_BIT)
-                             , ("VK_STENCIL_FACE_BACK_BIT", pure VK_STENCIL_FACE_BACK_BIT)
-                             , ("VK_STENCIL_FRONT_AND_BACK", pure VK_STENCIL_FRONT_AND_BACK)
+  readPrec = parens ( choose [ ("StencilFaceFrontBit", pure StencilFaceFrontBit)
+                             , ("StencilFaceBackBit", pure StencilFaceBackBit)
+                             , ("StencilFrontAndBack", pure StencilFrontAndBack)
                              ] +++
                       prec 10 (do
                         expectP (Ident "StencilFaceFlags")
@@ -521,11 +521,11 @@ instance Read StencilFaceFlags where
                     )
 
 -- | Front face
-pattern VK_STENCIL_FACE_FRONT_BIT = StencilFaceFlags 0x1
+pattern StencilFaceFrontBit = StencilFaceFlags 0x1
 -- | Back face
-pattern VK_STENCIL_FACE_BACK_BIT = StencilFaceFlags 0x2
+pattern StencilFaceBackBit = StencilFaceFlags 0x2
 -- | Front and back faces
-pattern VK_STENCIL_FRONT_AND_BACK = StencilFaceFlags 0x3
+pattern StencilFrontAndBack = StencilFaceFlags 0x3
 
 -- | // Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.
 data ClearColorValue = Float32 (Vector 4 CFloat) 

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -59,24 +59,24 @@ import Graphics.Vulkan.Sampler( VkFilter(..)
                               )
 import Graphics.Vulkan.Image( Image(..)
                             , VkImageAspectFlags(..)
-                            , VkImageSubresourceRange(..)
+                            , ImageSubresourceRange(..)
                             , VkImageLayout(..)
                             )
 import Graphics.Vulkan.Query( VkQueryResultFlags(..)
                             , QueryPool(..)
                             , VkQueryControlFlags(..)
                             )
-import Graphics.Vulkan.OtherTypes( VkMemoryBarrier(..)
-                                 , VkBufferMemoryBarrier(..)
-                                 , VkImageMemoryBarrier(..)
+import Graphics.Vulkan.OtherTypes( BufferMemoryBarrier(..)
+                                 , ImageMemoryBarrier(..)
+                                 , MemoryBarrier(..)
                                  )
 import Graphics.Vulkan.Core( VkStructureType(..)
+                           , Offset3D(..)
                            , VkFlags(..)
-                           , VkRect2D(..)
-                           , VkOffset3D(..)
-                           , VkViewport(..)
+                           , Viewport(..)
+                           , Rect2D(..)
+                           , Extent3D(..)
                            , VkDeviceSize(..)
-                           , VkExtent3D(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       )
@@ -104,7 +104,7 @@ foreign import ccall "vkCmdResolveImage" vkCmdResolveImage ::
   CommandBuffer ->
   Image ->
     VkImageLayout ->
-      Image -> VkImageLayout -> Word32 -> Ptr VkImageResolve -> IO ()
+      Image -> VkImageLayout -> Word32 -> Ptr ImageResolve -> IO ()
 
 -- ** vkCmdBindPipeline
 foreign import ccall "vkCmdBindPipeline" vkCmdBindPipeline ::
@@ -120,28 +120,28 @@ foreign import ccall "vkCmdDraw" vkCmdDraw ::
   CommandBuffer -> Word32 -> Word32 -> Word32 -> Word32 -> IO ()
 
 
-data VkImageCopy =
-  VkImageCopy{ srcSubresource :: VkImageSubresourceLayers 
-             , srcOffset :: VkOffset3D 
-             , dstSubresource :: VkImageSubresourceLayers 
-             , dstOffset :: VkOffset3D 
-             , extent :: VkExtent3D 
-             }
+data ImageCopy =
+  ImageCopy{ srcSubresource :: ImageSubresourceLayers 
+           , srcOffset :: Offset3D 
+           , dstSubresource :: ImageSubresourceLayers 
+           , dstOffset :: Offset3D 
+           , extent :: Extent3D 
+           }
   deriving (Eq)
 
-instance Storable VkImageCopy where
+instance Storable ImageCopy where
   sizeOf ~_ = 68
   alignment ~_ = 4
-  peek ptr = VkImageCopy <$> peek (ptr `plusPtr` 0)
-                         <*> peek (ptr `plusPtr` 16)
-                         <*> peek (ptr `plusPtr` 28)
-                         <*> peek (ptr `plusPtr` 44)
-                         <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: VkImageCopy))
-                *> poke (ptr `plusPtr` 56) (extent (poked :: VkImageCopy))
+  peek ptr = ImageCopy <$> peek (ptr `plusPtr` 0)
+                       <*> peek (ptr `plusPtr` 16)
+                       <*> peek (ptr `plusPtr` 28)
+                       <*> peek (ptr `plusPtr` 44)
+                       <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: ImageCopy))
+                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: ImageCopy))
+                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: ImageCopy))
+                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: ImageCopy))
+                *> poke (ptr `plusPtr` 56) (extent (poked :: ImageCopy))
 
 
 -- ** vkCmdNextSubpass
@@ -154,7 +154,7 @@ foreign import ccall "vkCmdEndQuery" vkCmdEndQuery ::
 
 -- ** vkCmdSetScissor
 foreign import ccall "vkCmdSetScissor" vkCmdSetScissor ::
-  CommandBuffer -> Word32 -> Word32 -> Ptr VkRect2D -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Ptr Rect2D -> IO ()
 
 -- ** vkCmdSetEvent
 foreign import ccall "vkCmdSetEvent" vkCmdSetEvent ::
@@ -164,7 +164,7 @@ foreign import ccall "vkCmdSetEvent" vkCmdSetEvent ::
 foreign import ccall "vkCmdCopyImageToBuffer" vkCmdCopyImageToBuffer ::
   CommandBuffer ->
   Image ->
-    VkImageLayout -> Buffer -> Word32 -> Ptr VkBufferImageCopy -> IO ()
+    VkImageLayout -> Buffer -> Word32 -> Ptr BufferImageCopy -> IO ()
 
 -- ** vkCmdDispatchIndirect
 foreign import ccall "vkCmdDispatchIndirect" vkCmdDispatchIndirect ::
@@ -185,22 +185,22 @@ foreign import ccall "vkCmdFillBuffer" vkCmdFillBuffer ::
   Buffer -> VkDeviceSize -> VkDeviceSize -> Word32 -> IO ()
 
 
-data VkClearRect =
-  VkClearRect{ rect :: VkRect2D 
-             , baseArrayLayer :: Word32 
-             , layerCount :: Word32 
-             }
+data ClearRect =
+  ClearRect{ rect :: Rect2D 
+           , baseArrayLayer :: Word32 
+           , layerCount :: Word32 
+           }
   deriving (Eq)
 
-instance Storable VkClearRect where
+instance Storable ClearRect where
   sizeOf ~_ = 24
   alignment ~_ = 4
-  peek ptr = VkClearRect <$> peek (ptr `plusPtr` 0)
-                         <*> peek (ptr `plusPtr` 16)
-                         <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (rect (poked :: VkClearRect))
-                *> poke (ptr `plusPtr` 16) (baseArrayLayer (poked :: VkClearRect))
-                *> poke (ptr `plusPtr` 20) (layerCount (poked :: VkClearRect))
+  peek ptr = ClearRect <$> peek (ptr `plusPtr` 0)
+                       <*> peek (ptr `plusPtr` 16)
+                       <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (rect (poked :: ClearRect))
+                *> poke (ptr `plusPtr` 16) (baseArrayLayer (poked :: ClearRect))
+                *> poke (ptr `plusPtr` 20) (layerCount (poked :: ClearRect))
 
 
 -- ** vkCmdWaitEvents
@@ -211,18 +211,17 @@ foreign import ccall "vkCmdWaitEvents" vkCmdWaitEvents ::
       VkPipelineStageFlags ->
         VkPipelineStageFlags ->
           Word32 ->
-            Ptr VkMemoryBarrier ->
+            Ptr MemoryBarrier ->
               Word32 ->
-                Ptr VkBufferMemoryBarrier ->
-                  Word32 -> Ptr VkImageMemoryBarrier -> IO ()
+                Ptr BufferMemoryBarrier ->
+                  Word32 -> Ptr ImageMemoryBarrier -> IO ()
 
 -- ** vkCmdClearColorImage
 foreign import ccall "vkCmdClearColorImage" vkCmdClearColorImage ::
   CommandBuffer ->
   Image ->
     VkImageLayout ->
-      Ptr VkClearColorValue ->
-        Word32 -> Ptr VkImageSubresourceRange -> IO ()
+      Ptr ClearColorValue -> Word32 -> Ptr ImageSubresourceRange -> IO ()
 
 -- ** VkIndexType
 
@@ -251,31 +250,31 @@ pattern VK_INDEX_TYPE_UINT16 = VkIndexType 0
 pattern VK_INDEX_TYPE_UINT32 = VkIndexType 1
 
 
-data VkBufferImageCopy =
-  VkBufferImageCopy{ bufferOffset :: VkDeviceSize 
-                   , bufferRowLength :: Word32 
-                   , bufferImageHeight :: Word32 
-                   , imageSubresource :: VkImageSubresourceLayers 
-                   , imageOffset :: VkOffset3D 
-                   , imageExtent :: VkExtent3D 
-                   }
+data BufferImageCopy =
+  BufferImageCopy{ bufferOffset :: VkDeviceSize 
+                 , bufferRowLength :: Word32 
+                 , bufferImageHeight :: Word32 
+                 , imageSubresource :: ImageSubresourceLayers 
+                 , imageOffset :: Offset3D 
+                 , imageExtent :: Extent3D 
+                 }
   deriving (Eq)
 
-instance Storable VkBufferImageCopy where
+instance Storable BufferImageCopy where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkBufferImageCopy <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 8)
-                               <*> peek (ptr `plusPtr` 12)
-                               <*> peek (ptr `plusPtr` 16)
-                               <*> peek (ptr `plusPtr` 32)
-                               <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (bufferOffset (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 8) (bufferRowLength (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 12) (bufferImageHeight (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 16) (imageSubresource (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 32) (imageOffset (poked :: VkBufferImageCopy))
-                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: VkBufferImageCopy))
+  peek ptr = BufferImageCopy <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 8)
+                             <*> peek (ptr `plusPtr` 12)
+                             <*> peek (ptr `plusPtr` 16)
+                             <*> peek (ptr `plusPtr` 32)
+                             <*> peek (ptr `plusPtr` 44)
+  poke ptr poked = poke (ptr `plusPtr` 0) (bufferOffset (poked :: BufferImageCopy))
+                *> poke (ptr `plusPtr` 8) (bufferRowLength (poked :: BufferImageCopy))
+                *> poke (ptr `plusPtr` 12) (bufferImageHeight (poked :: BufferImageCopy))
+                *> poke (ptr `plusPtr` 16) (imageSubresource (poked :: BufferImageCopy))
+                *> poke (ptr `plusPtr` 32) (imageOffset (poked :: BufferImageCopy))
+                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: BufferImageCopy))
 
 
 -- ** vkCmdSetDepthBounds
@@ -286,7 +285,7 @@ foreign import ccall "vkCmdSetDepthBounds" vkCmdSetDepthBounds ::
 foreign import ccall "vkCmdCopyBufferToImage" vkCmdCopyBufferToImage ::
   CommandBuffer ->
   Buffer ->
-    Image -> VkImageLayout -> Word32 -> Ptr VkBufferImageCopy -> IO ()
+    Image -> VkImageLayout -> Word32 -> Ptr BufferImageCopy -> IO ()
 
 -- ** vkCmdDrawIndexedIndirect
 foreign import ccall "vkCmdDrawIndexedIndirect" vkCmdDrawIndexedIndirect ::
@@ -303,7 +302,7 @@ foreign import ccall "vkCmdCopyImage" vkCmdCopyImage ::
   CommandBuffer ->
   Image ->
     VkImageLayout ->
-      Image -> VkImageLayout -> Word32 -> Ptr VkImageCopy -> IO ()
+      Image -> VkImageLayout -> Word32 -> Ptr ImageCopy -> IO ()
 
 -- ** vkCmdWriteTimestamp
 foreign import ccall "vkCmdWriteTimestamp" vkCmdWriteTimestamp ::
@@ -311,25 +310,25 @@ foreign import ccall "vkCmdWriteTimestamp" vkCmdWriteTimestamp ::
   VkPipelineStageFlags -> QueryPool -> Word32 -> IO ()
 
 
-data VkImageSubresourceLayers =
-  VkImageSubresourceLayers{ aspectMask :: VkImageAspectFlags 
-                          , mipLevel :: Word32 
-                          , baseArrayLayer :: Word32 
-                          , layerCount :: Word32 
-                          }
+data ImageSubresourceLayers =
+  ImageSubresourceLayers{ aspectMask :: VkImageAspectFlags 
+                        , mipLevel :: Word32 
+                        , baseArrayLayer :: Word32 
+                        , layerCount :: Word32 
+                        }
   deriving (Eq)
 
-instance Storable VkImageSubresourceLayers where
+instance Storable ImageSubresourceLayers where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ptr = VkImageSubresourceLayers <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 4)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 8) (baseArrayLayer (poked :: VkImageSubresourceLayers))
-                *> poke (ptr `plusPtr` 12) (layerCount (poked :: VkImageSubresourceLayers))
+  peek ptr = ImageSubresourceLayers <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 4)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: ImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: ImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 8) (baseArrayLayer (poked :: ImageSubresourceLayers))
+                *> poke (ptr `plusPtr` 12) (layerCount (poked :: ImageSubresourceLayers))
 
 
 -- ** vkCmdDrawIndexed
@@ -347,54 +346,53 @@ foreign import ccall "vkCmdDrawIndirect" vkCmdDrawIndirect ::
   Buffer -> VkDeviceSize -> Word32 -> Word32 -> IO ()
 
 
-data VkClearDepthStencilValue =
-  VkClearDepthStencilValue{ depth :: CFloat 
-                          , stencil :: Word32 
-                          }
+data ClearDepthStencilValue =
+  ClearDepthStencilValue{ depth :: CFloat 
+                        , stencil :: Word32 
+                        }
   deriving (Eq)
 
-instance Storable VkClearDepthStencilValue where
+instance Storable ClearDepthStencilValue where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkClearDepthStencilValue <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (depth (poked :: VkClearDepthStencilValue))
-                *> poke (ptr `plusPtr` 4) (stencil (poked :: VkClearDepthStencilValue))
+  peek ptr = ClearDepthStencilValue <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (depth (poked :: ClearDepthStencilValue))
+                *> poke (ptr `plusPtr` 4) (stencil (poked :: ClearDepthStencilValue))
 
 
 
-data VkBufferCopy =
-  VkBufferCopy{ srcOffset :: VkDeviceSize 
-              , dstOffset :: VkDeviceSize 
-              , size :: VkDeviceSize 
-              }
+data BufferCopy =
+  BufferCopy{ srcOffset :: VkDeviceSize 
+            , dstOffset :: VkDeviceSize 
+            , size :: VkDeviceSize 
+            }
   deriving (Eq)
 
-instance Storable VkBufferCopy where
+instance Storable BufferCopy where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkBufferCopy <$> peek (ptr `plusPtr` 0)
-                          <*> peek (ptr `plusPtr` 8)
-                          <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (srcOffset (poked :: VkBufferCopy))
-                *> poke (ptr `plusPtr` 8) (dstOffset (poked :: VkBufferCopy))
-                *> poke (ptr `plusPtr` 16) (size (poked :: VkBufferCopy))
+  peek ptr = BufferCopy <$> peek (ptr `plusPtr` 0)
+                        <*> peek (ptr `plusPtr` 8)
+                        <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcOffset (poked :: BufferCopy))
+                *> poke (ptr `plusPtr` 8) (dstOffset (poked :: BufferCopy))
+                *> poke (ptr `plusPtr` 16) (size (poked :: BufferCopy))
 
 
 -- ** vkCmdClearAttachments
 foreign import ccall "vkCmdClearAttachments" vkCmdClearAttachments ::
   CommandBuffer ->
-  Word32 ->
-    Ptr VkClearAttachment -> Word32 -> Ptr VkClearRect -> IO ()
+  Word32 -> Ptr ClearAttachment -> Word32 -> Ptr ClearRect -> IO ()
 
 -- ** vkCmdSetViewport
 foreign import ccall "vkCmdSetViewport" vkCmdSetViewport ::
-  CommandBuffer -> Word32 -> Word32 -> Ptr VkViewport -> IO ()
+  CommandBuffer -> Word32 -> Word32 -> Ptr Viewport -> IO ()
 
 -- ** vkCmdCopyBuffer
 foreign import ccall "vkCmdCopyBuffer" vkCmdCopyBuffer ::
   CommandBuffer ->
-  Buffer -> Buffer -> Word32 -> Ptr VkBufferCopy -> IO ()
+  Buffer -> Buffer -> Word32 -> Ptr BufferCopy -> IO ()
 
 -- ** vkCmdBindDescriptorSets
 foreign import ccall "vkCmdBindDescriptorSets" vkCmdBindDescriptorSets ::
@@ -413,34 +411,34 @@ foreign import ccall "vkCmdExecuteCommands" vkCmdExecuteCommands ::
   CommandBuffer -> Word32 -> Ptr CommandBuffer -> IO ()
 
 
-data VkRenderPassBeginInfo =
-  VkRenderPassBeginInfo{ sType :: VkStructureType 
-                       , pNext :: Ptr Void 
-                       , renderPass :: RenderPass 
-                       , framebuffer :: Framebuffer 
-                       , renderArea :: VkRect2D 
-                       , clearValueCount :: Word32 
-                       , pClearValues :: Ptr VkClearValue 
-                       }
+data RenderPassBeginInfo =
+  RenderPassBeginInfo{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , renderPass :: RenderPass 
+                     , framebuffer :: Framebuffer 
+                     , renderArea :: Rect2D 
+                     , clearValueCount :: Word32 
+                     , pClearValues :: Ptr ClearValue 
+                     }
   deriving (Eq)
 
-instance Storable VkRenderPassBeginInfo where
+instance Storable RenderPassBeginInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkRenderPassBeginInfo <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 24)
-                                   <*> peek (ptr `plusPtr` 32)
-                                   <*> peek (ptr `plusPtr` 48)
-                                   <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 16) (renderPass (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 24) (framebuffer (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 32) (renderArea (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 48) (clearValueCount (poked :: VkRenderPassBeginInfo))
-                *> poke (ptr `plusPtr` 56) (pClearValues (poked :: VkRenderPassBeginInfo))
+  peek ptr = RenderPassBeginInfo <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 48)
+                                 <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 16) (renderPass (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 24) (framebuffer (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 32) (renderArea (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 48) (clearValueCount (poked :: RenderPassBeginInfo))
+                *> poke (ptr `plusPtr` 56) (pClearValues (poked :: RenderPassBeginInfo))
 
 
 -- ** vkCmdSetStencilCompareMask
@@ -448,56 +446,56 @@ foreign import ccall "vkCmdSetStencilCompareMask" vkCmdSetStencilCompareMask ::
   CommandBuffer -> VkStencilFaceFlags -> Word32 -> IO ()
 
 
-data VkImageBlit =
-  VkImageBlit{ srcSubresource :: VkImageSubresourceLayers 
-             , srcOffsets :: Vector 2 VkOffset3D 
-             , dstSubresource :: VkImageSubresourceLayers 
-             , dstOffsets :: Vector 2 VkOffset3D 
-             }
+data ImageBlit =
+  ImageBlit{ srcSubresource :: ImageSubresourceLayers 
+           , srcOffsets :: Vector 2 Offset3D 
+           , dstSubresource :: ImageSubresourceLayers 
+           , dstOffsets :: Vector 2 Offset3D 
+           }
   deriving (Eq)
 
-instance Storable VkImageBlit where
+instance Storable ImageBlit where
   sizeOf ~_ = 80
   alignment ~_ = 4
-  peek ptr = VkImageBlit <$> peek (ptr `plusPtr` 0)
-                         <*> peek (ptr `plusPtr` 16)
-                         <*> peek (ptr `plusPtr` 40)
-                         <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 16) (srcOffsets (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 40) (dstSubresource (poked :: VkImageBlit))
-                *> poke (ptr `plusPtr` 56) (dstOffsets (poked :: VkImageBlit))
+  peek ptr = ImageBlit <$> peek (ptr `plusPtr` 0)
+                       <*> peek (ptr `plusPtr` 16)
+                       <*> peek (ptr `plusPtr` 40)
+                       <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: ImageBlit))
+                *> poke (ptr `plusPtr` 16) (srcOffsets (poked :: ImageBlit))
+                *> poke (ptr `plusPtr` 40) (dstSubresource (poked :: ImageBlit))
+                *> poke (ptr `plusPtr` 56) (dstOffsets (poked :: ImageBlit))
 
 
 
-data VkClearAttachment =
-  VkClearAttachment{ aspectMask :: VkImageAspectFlags 
-                   , colorAttachment :: Word32 
-                   , clearValue :: VkClearValue 
-                   }
+data ClearAttachment =
+  ClearAttachment{ aspectMask :: VkImageAspectFlags 
+                 , colorAttachment :: Word32 
+                 , clearValue :: ClearValue 
+                 }
   deriving (Eq)
 
-instance Storable VkClearAttachment where
+instance Storable ClearAttachment where
   sizeOf ~_ = 24
   alignment ~_ = 4
-  peek ptr = VkClearAttachment <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 4)
-                               <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkClearAttachment))
-                *> poke (ptr `plusPtr` 4) (colorAttachment (poked :: VkClearAttachment))
-                *> poke (ptr `plusPtr` 8) (clearValue (poked :: VkClearAttachment))
+  peek ptr = ClearAttachment <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 4)
+                             <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: ClearAttachment))
+                *> poke (ptr `plusPtr` 4) (colorAttachment (poked :: ClearAttachment))
+                *> poke (ptr `plusPtr` 8) (clearValue (poked :: ClearAttachment))
 
 
 -- | // Union allowing specification of color or depth and stencil values. Actual value selected is based on attachment being cleared.
-data VkClearValue = Color VkClearColorValue 
-                  | DepthStencil VkClearDepthStencilValue 
+data ClearValue = Color ClearColorValue 
+                | DepthStencil ClearDepthStencilValue 
   deriving (Eq)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
-instance Storable VkClearValue where
+instance Storable ClearValue where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ~_ = error "peek@VkClearValue"
+  peek ~_ = error "peek@ClearValue"
   poke ptr poked = case poked of
                      Color e -> poke (castPtr ptr) e
                      DepthStencil e -> poke (castPtr ptr) e
@@ -534,16 +532,16 @@ pattern VK_STENCIL_FACE_BACK_BIT = VkStencilFaceFlags 0x2
 pattern VK_STENCIL_FRONT_AND_BACK = VkStencilFaceFlags 0x3
 
 -- | // Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.
-data VkClearColorValue = Float32 (Vector 4 CFloat) 
-                       | Int32 (Vector 4 Int32) 
-                       | Uint32 (Vector 4 Word32) 
+data ClearColorValue = Float32 (Vector 4 CFloat) 
+                     | Int32 (Vector 4 Int32) 
+                     | Uint32 (Vector 4 Word32) 
   deriving (Eq)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
-instance Storable VkClearColorValue where
+instance Storable ClearColorValue where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ~_ = error "peek@VkClearColorValue"
+  peek ~_ = error "peek@ClearColorValue"
   poke ptr poked = case poked of
                      Float32 e -> poke (castPtr ptr) e
                      Int32 e -> poke (castPtr ptr) e
@@ -591,7 +589,7 @@ foreign import ccall "vkCmdBlitImage" vkCmdBlitImage ::
   Image ->
     VkImageLayout ->
       Image ->
-        VkImageLayout -> Word32 -> Ptr VkImageBlit -> VkFilter -> IO ()
+        VkImageLayout -> Word32 -> Ptr ImageBlit -> VkFilter -> IO ()
 
 -- ** vkCmdSetBlendConstants
 foreign import ccall "vkCmdSetBlendConstants" vkCmdSetBlendConstants ::
@@ -602,32 +600,32 @@ foreign import ccall "vkCmdClearDepthStencilImage" vkCmdClearDepthStencilImage :
   CommandBuffer ->
   Image ->
     VkImageLayout ->
-      Ptr VkClearDepthStencilValue ->
-        Word32 -> Ptr VkImageSubresourceRange -> IO ()
+      Ptr ClearDepthStencilValue ->
+        Word32 -> Ptr ImageSubresourceRange -> IO ()
 
 
-data VkImageResolve =
-  VkImageResolve{ srcSubresource :: VkImageSubresourceLayers 
-                , srcOffset :: VkOffset3D 
-                , dstSubresource :: VkImageSubresourceLayers 
-                , dstOffset :: VkOffset3D 
-                , extent :: VkExtent3D 
-                }
+data ImageResolve =
+  ImageResolve{ srcSubresource :: ImageSubresourceLayers 
+              , srcOffset :: Offset3D 
+              , dstSubresource :: ImageSubresourceLayers 
+              , dstOffset :: Offset3D 
+              , extent :: Extent3D 
+              }
   deriving (Eq)
 
-instance Storable VkImageResolve where
+instance Storable ImageResolve where
   sizeOf ~_ = 68
   alignment ~_ = 4
-  peek ptr = VkImageResolve <$> peek (ptr `plusPtr` 0)
-                            <*> peek (ptr `plusPtr` 16)
-                            <*> peek (ptr `plusPtr` 28)
-                            <*> peek (ptr `plusPtr` 44)
-                            <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: VkImageResolve))
-                *> poke (ptr `plusPtr` 56) (extent (poked :: VkImageResolve))
+  peek ptr = ImageResolve <$> peek (ptr `plusPtr` 0)
+                          <*> peek (ptr `plusPtr` 16)
+                          <*> peek (ptr `plusPtr` 28)
+                          <*> peek (ptr `plusPtr` 44)
+                          <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubresource (poked :: ImageResolve))
+                *> poke (ptr `plusPtr` 16) (srcOffset (poked :: ImageResolve))
+                *> poke (ptr `plusPtr` 28) (dstSubresource (poked :: ImageResolve))
+                *> poke (ptr `plusPtr` 44) (dstOffset (poked :: ImageResolve))
+                *> poke (ptr `plusPtr` 56) (extent (poked :: ImageResolve))
 
 
 -- ** vkCmdDispatch
@@ -645,15 +643,15 @@ foreign import ccall "vkCmdPipelineBarrier" vkCmdPipelineBarrier ::
     VkPipelineStageFlags ->
       VkDependencyFlags ->
         Word32 ->
-          Ptr VkMemoryBarrier ->
+          Ptr MemoryBarrier ->
             Word32 ->
-              Ptr VkBufferMemoryBarrier ->
-                Word32 -> Ptr VkImageMemoryBarrier -> IO ()
+              Ptr BufferMemoryBarrier ->
+                Word32 -> Ptr ImageMemoryBarrier -> IO ()
 
 -- ** vkCmdBeginRenderPass
 foreign import ccall "vkCmdBeginRenderPass" vkCmdBeginRenderPass ::
   CommandBuffer ->
-  Ptr VkRenderPassBeginInfo -> VkSubpassContents -> IO ()
+  Ptr RenderPassBeginInfo -> VkSubpassContents -> IO ()
 
 -- ** vkCmdResetEvent
 foreign import ccall "vkCmdResetEvent" vkCmdResetEvent ::

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -127,7 +127,7 @@ data ImageCopy =
            , dstOffset :: Offset3D 
            , extent :: Extent3D 
            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageCopy where
   sizeOf ~_ = 68
@@ -189,7 +189,7 @@ data ClearRect =
            , baseArrayLayer :: Word32 
            , layerCount :: Word32 
            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ClearRect where
   sizeOf ~_ = 24
@@ -225,7 +225,7 @@ foreign import ccall "vkCmdClearColorImage" cmdClearColorImage ::
 -- ** IndexType
 
 newtype IndexType = IndexType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show IndexType where
   showsPrec _ IndexTypeUint16 = showString "IndexTypeUint16"
@@ -257,7 +257,7 @@ data BufferImageCopy =
                  , imageOffset :: Offset3D 
                  , imageExtent :: Extent3D 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BufferImageCopy where
   sizeOf ~_ = 56
@@ -313,7 +313,7 @@ data ImageSubresourceLayers =
                         , baseArrayLayer :: Word32 
                         , layerCount :: Word32 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageSubresourceLayers where
   sizeOf ~_ = 16
@@ -346,7 +346,7 @@ data ClearDepthStencilValue =
   ClearDepthStencilValue{ depth :: CFloat 
                         , stencil :: Word32 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ClearDepthStencilValue where
   sizeOf ~_ = 8
@@ -363,7 +363,7 @@ data BufferCopy =
             , dstOffset :: DeviceSize 
             , size :: DeviceSize 
             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BufferCopy where
   sizeOf ~_ = 24
@@ -416,7 +416,7 @@ data RenderPassBeginInfo =
                      , clearValueCount :: Word32 
                      , pClearValues :: Ptr ClearValue 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable RenderPassBeginInfo where
   sizeOf ~_ = 64
@@ -448,7 +448,7 @@ data ImageBlit =
            , dstSubresource :: ImageSubresourceLayers 
            , dstOffsets :: Vector 2 Offset3D 
            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageBlit where
   sizeOf ~_ = 80
@@ -469,7 +469,7 @@ data ClearAttachment =
                  , colorAttachment :: Word32 
                  , clearValue :: ClearValue 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ClearAttachment where
   sizeOf ~_ = 24
@@ -485,7 +485,7 @@ instance Storable ClearAttachment where
 -- | // Union allowing specification of color or depth and stencil values. Actual value selected is based on attachment being cleared.
 data ClearValue = Color ClearColorValue 
                 | DepthStencil ClearDepthStencilValue 
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
 instance Storable ClearValue where
@@ -500,7 +500,7 @@ instance Storable ClearValue where
 -- ** StencilFaceFlags
 
 newtype StencilFaceFlags = StencilFaceFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show StencilFaceFlags where
   showsPrec _ StencilFaceFrontBit = showString "StencilFaceFrontBit"
@@ -531,7 +531,7 @@ pattern StencilFrontAndBack = StencilFaceFlags 0x3
 data ClearColorValue = Float32 (Vector 4 CFloat) 
                      | Int32 (Vector 4 Int32) 
                      | Uint32 (Vector 4 Word32) 
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 -- | _Note_: peek is undefined as we wouldn't know which constructor to use
 instance Storable ClearColorValue where
@@ -547,7 +547,7 @@ instance Storable ClearColorValue where
 -- ** SubpassContents
 
 newtype SubpassContents = SubpassContents Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show SubpassContents where
   showsPrec _ SubpassContentsInline = showString "SubpassContentsInline"
@@ -605,7 +605,7 @@ data ImageResolve =
               , dstOffset :: Offset3D 
               , extent :: Extent3D 
               }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageResolve where
   sizeOf ~_ = 68

--- a/src/Graphics/Vulkan/CommandBufferBuilding.hs
+++ b/src/Graphics/Vulkan/CommandBufferBuilding.hs
@@ -5,62 +5,46 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandBufferBuilding where
 
-import Data.Vector.Storable.Sized( Vector
+import Data.Vector.Storable.Sized( Vector(..)
                                  )
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
-import Graphics.Vulkan.Pass( Framebuffer
-                           , VkDependencyFlags
-                           , RenderPass
+import Graphics.Vulkan.Pass( RenderPass(..)
+                           , Framebuffer(..)
+                           , VkDependencyFlags(..)
                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
-import Graphics.Vulkan.Event( Event
+import Graphics.Vulkan.Event( Event(..)
                             )
 import GHC.Read( expectP
                , choose
                )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits
-                               , VkPipelineStageFlags
-                               , VkPipelineBindPoint
-                               , Pipeline
+import Graphics.Vulkan.Pipeline( Pipeline(..)
+                               , VkPipelineBindPoint(..)
+                               , VkPipelineStageFlags(..)
                                )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , castPtr
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( DescriptorSet
+import Graphics.Vulkan.DescriptorSet( DescriptorSet(..)
                                     )
-import Graphics.Vulkan.CommandBuffer( CommandBuffer
+import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
                                     )
-import Data.Int( Int32
+import Data.Int( Int32(..)
+               , Int32
                )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.CommandBufferBuilding( VkRenderPassBeginInfo
-                                            , VkClearValue
-                                            , VkStencilFaceFlags
-                                            , VkImageSubresourceLayers
-                                            , VkImageResolve
-                                            , VkClearRect
-                                            , VkClearColorValue
-                                            , VkSubpassContents
-                                            , VkImageBlit
-                                            , VkIndexType
-                                            , VkClearDepthStencilValue
-                                            , VkClearAttachment
-                                            , VkBufferCopy
-                                            , VkImageCopy
-                                            , VkBufferImageCopy
-                                            )
-import Graphics.Vulkan.PipelineLayout( PipelineLayout
+import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
                                      )
 import Text.Read( Read(..)
                 , parens
@@ -69,32 +53,32 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlags
+import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Sampler( VkFilter
+import Graphics.Vulkan.Sampler( VkFilter(..)
                               )
-import Graphics.Vulkan.Image( VkImageAspectFlags
-                            , VkImageSubresourceRange
-                            , VkImageLayout
-                            , Image
+import Graphics.Vulkan.Image( Image(..)
+                            , VkImageAspectFlags(..)
+                            , VkImageSubresourceRange(..)
+                            , VkImageLayout(..)
                             )
-import Graphics.Vulkan.Query( VkQueryResultFlags
-                            , QueryPool
-                            , VkQueryControlFlags
+import Graphics.Vulkan.Query( VkQueryResultFlags(..)
+                            , QueryPool(..)
+                            , VkQueryControlFlags(..)
                             )
-import Graphics.Vulkan.OtherTypes( VkMemoryBarrier
-                                 , VkBufferMemoryBarrier
-                                 , VkImageMemoryBarrier
+import Graphics.Vulkan.OtherTypes( VkMemoryBarrier(..)
+                                 , VkBufferMemoryBarrier(..)
+                                 , VkImageMemoryBarrier(..)
                                  )
-import Graphics.Vulkan.Core( VkExtent3D
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkOffset3D
-                           , VkViewport
-                           , VkRect2D
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkRect2D(..)
+                           , VkOffset3D(..)
+                           , VkViewport(..)
+                           , VkDeviceSize(..)
+                           , VkExtent3D(..)
                            )
-import Foreign.C.Types( CFloat
+import Foreign.C.Types( CFloat(..)
                       )
 
 -- ** vkCmdPushConstants
@@ -324,7 +308,7 @@ foreign import ccall "vkCmdCopyImage" vkCmdCopyImage ::
 -- ** vkCmdWriteTimestamp
 foreign import ccall "vkCmdWriteTimestamp" vkCmdWriteTimestamp ::
   CommandBuffer ->
-  VkPipelineStageFlagBits -> QueryPool -> Word32 -> IO ()
+  VkPipelineStageFlags -> QueryPool -> Word32 -> IO ()
 
 
 data VkImageSubresourceLayers =
@@ -521,36 +505,33 @@ instance Storable VkClearValue where
 
 -- ** VkStencilFaceFlags
 
-newtype VkStencilFaceFlagBits = VkStencilFaceFlagBits VkFlags
+newtype VkStencilFaceFlags = VkStencilFaceFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkStencilFaceFlagBits
-type VkStencilFaceFlags = VkStencilFaceFlagBits
-
-instance Show VkStencilFaceFlagBits where
+instance Show VkStencilFaceFlags where
   showsPrec _ VK_STENCIL_FACE_FRONT_BIT = showString "VK_STENCIL_FACE_FRONT_BIT"
   showsPrec _ VK_STENCIL_FACE_BACK_BIT = showString "VK_STENCIL_FACE_BACK_BIT"
   showsPrec _ VK_STENCIL_FRONT_AND_BACK = showString "VK_STENCIL_FRONT_AND_BACK"
-  showsPrec p (VkStencilFaceFlagBits x) = showParen (p >= 11) (showString "VkStencilFaceFlagBits " . showsPrec 11 x)
+  showsPrec p (VkStencilFaceFlags x) = showParen (p >= 11) (showString "VkStencilFaceFlags " . showsPrec 11 x)
 
-instance Read VkStencilFaceFlagBits where
+instance Read VkStencilFaceFlags where
   readPrec = parens ( choose [ ("VK_STENCIL_FACE_FRONT_BIT", pure VK_STENCIL_FACE_FRONT_BIT)
                              , ("VK_STENCIL_FACE_BACK_BIT", pure VK_STENCIL_FACE_BACK_BIT)
                              , ("VK_STENCIL_FRONT_AND_BACK", pure VK_STENCIL_FRONT_AND_BACK)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkStencilFaceFlagBits")
+                        expectP (Ident "VkStencilFaceFlags")
                         v <- step readPrec
-                        pure (VkStencilFaceFlagBits v)
+                        pure (VkStencilFaceFlags v)
                         )
                     )
 
 -- | Front face
-pattern VK_STENCIL_FACE_FRONT_BIT = VkStencilFaceFlagBits 0x1
+pattern VK_STENCIL_FACE_FRONT_BIT = VkStencilFaceFlags 0x1
 -- | Back face
-pattern VK_STENCIL_FACE_BACK_BIT = VkStencilFaceFlagBits 0x2
+pattern VK_STENCIL_FACE_BACK_BIT = VkStencilFaceFlags 0x2
 -- | Front and back faces
-pattern VK_STENCIL_FRONT_AND_BACK = VkStencilFaceFlagBits 0x3
+pattern VK_STENCIL_FRONT_AND_BACK = VkStencilFaceFlags 0x3
 
 -- | // Union allowing specification of floating point, integer, or unsigned integer color data. Actual value selected is based on image/attachment being cleared.
 data VkClearColorValue = Float32 (Vector 4 CFloat) 

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandPool where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,15 +22,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -40,12 +29,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkCommandPoolCreateInfo =

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandPool where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -49,10 +49,10 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkCommandPoolCreateInfo =
-  VkCommandPoolCreateInfo{ vkSType :: VkStructureType 
-                         , vkPNext :: Ptr Void 
-                         , vkFlags :: VkCommandPoolCreateFlags 
-                         , vkQueueFamilyIndex :: Word32 
+  VkCommandPoolCreateInfo{ sType :: VkStructureType 
+                         , pNext :: Ptr Void 
+                         , flags :: VkCommandPoolCreateFlags 
+                         , queueFamilyIndex :: Word32 
                          }
   deriving (Eq)
 
@@ -63,19 +63,19 @@ instance Storable VkCommandPoolCreateInfo where
                                      <*> peek (ptr `plusPtr` 8)
                                      <*> peek (ptr `plusPtr` 16)
                                      <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkQueueFamilyIndex (poked :: VkCommandPoolCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkCommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: VkCommandPoolCreateInfo))
 
 
 -- ** vkDestroyCommandPool
 foreign import ccall "vkDestroyCommandPool" vkDestroyCommandPool ::
-  VkDevice -> VkCommandPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> CommandPool -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** vkResetCommandPool
 foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
-  VkDevice -> VkCommandPool -> VkCommandPoolResetFlags -> IO VkResult
+  Device -> CommandPool -> VkCommandPoolResetFlags -> IO VkResult
 
 -- ** VkCommandPoolCreateFlags
 
@@ -110,9 +110,9 @@ pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = VkCommandPoolCreateFla
 
 -- ** vkCreateCommandPool
 foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
-  VkDevice ->
+  Device ->
   Ptr VkCommandPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkCommandPool -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr CommandPool -> IO VkResult
 
 -- ** VkCommandPoolResetFlags
 
@@ -141,6 +141,6 @@ instance Read VkCommandPoolResetFlagBits where
 pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = VkCommandPoolResetFlagBits 0x1
 
 
-newtype VkCommandPool = VkCommandPool Word64
+newtype CommandPool = CommandPool Word64
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -24,7 +24,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -39,30 +39,30 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            )
 
 
-data VkCommandPoolCreateInfo =
-  VkCommandPoolCreateInfo{ sType :: VkStructureType 
-                         , pNext :: Ptr Void 
-                         , flags :: VkCommandPoolCreateFlags 
-                         , queueFamilyIndex :: Word32 
-                         }
+data CommandPoolCreateInfo =
+  CommandPoolCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkCommandPoolCreateFlags 
+                       , queueFamilyIndex :: Word32 
+                       }
   deriving (Eq)
 
-instance Storable VkCommandPoolCreateInfo where
+instance Storable CommandPoolCreateInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkCommandPoolCreateInfo <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkCommandPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: VkCommandPoolCreateInfo))
+  peek ptr = CommandPoolCreateInfo <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: CommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: CommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: CommandPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: CommandPoolCreateInfo))
 
 
 -- ** vkDestroyCommandPool
 foreign import ccall "vkDestroyCommandPool" vkDestroyCommandPool ::
-  Device -> CommandPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> CommandPool -> Ptr AllocationCallbacks -> IO ()
 
 -- ** vkResetCommandPool
 foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
@@ -99,8 +99,8 @@ pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = VkCommandPoolCreateFla
 -- ** vkCreateCommandPool
 foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
   Device ->
-  Ptr VkCommandPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr CommandPool -> IO VkResult
+  Ptr CommandPoolCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr CommandPool -> IO VkResult
 
 -- ** VkCommandPoolResetFlags
 

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandPool where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -20,8 +22,15 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.CommandPool( VkCommandPoolResetFlags
+                                  , VkCommandPoolCreateFlags
+                                  , CommandPool
+                                  , VkCommandPoolCreateInfo
+                                  )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +38,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 
 data VkCommandPoolCreateInfo =

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -68,7 +68,7 @@ foreign import ccall "vkDestroyCommandPool" destroyCommandPool ::
 foreign import ccall "vkResetCommandPool" resetCommandPool ::
   Device -> CommandPool -> CommandPoolResetFlags -> IO Result
 
--- ** VkCommandPoolCreateFlags
+-- ** CommandPoolCreateFlags
 
 newtype CommandPoolCreateFlags = CommandPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -102,7 +102,7 @@ foreign import ccall "vkCreateCommandPool" createCommandPool ::
   Ptr CommandPoolCreateInfo ->
     Ptr AllocationCallbacks -> Ptr CommandPool -> IO Result
 
--- ** VkCommandPoolResetFlags
+-- ** CommandPoolResetFlags
 
 newtype CommandPoolResetFlags = CommandPoolResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -60,12 +60,12 @@ instance Storable CommandPoolCreateInfo where
                 *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: CommandPoolCreateInfo))
 
 
--- ** vkDestroyCommandPool
-foreign import ccall "vkDestroyCommandPool" vkDestroyCommandPool ::
+-- ** destroyCommandPool
+foreign import ccall "vkDestroyCommandPool" destroyCommandPool ::
   Device -> CommandPool -> Ptr AllocationCallbacks -> IO ()
 
--- ** vkResetCommandPool
-foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
+-- ** resetCommandPool
+foreign import ccall "vkResetCommandPool" resetCommandPool ::
   Device -> CommandPool -> CommandPoolResetFlags -> IO Result
 
 -- ** VkCommandPoolCreateFlags
@@ -96,8 +96,8 @@ pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = CommandPoolCreateFlags 0x1
 pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = CommandPoolCreateFlags 0x2
 
 
--- ** vkCreateCommandPool
-foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
+-- ** createCommandPool
+foreign import ccall "vkCreateCommandPool" createCommandPool ::
   Device ->
   Ptr CommandPoolCreateInfo ->
     Ptr AllocationCallbacks -> Ptr CommandPool -> IO Result

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -33,9 +33,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 
@@ -70,7 +70,7 @@ foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
 
 -- ** VkCommandPoolCreateFlags
 
-newtype CommandPoolCreateFlags = CommandPoolCreateFlags VkFlags
+newtype CommandPoolCreateFlags = CommandPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolCreateFlags where
@@ -104,7 +104,7 @@ foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
 
 -- ** VkCommandPoolResetFlags
 
-newtype CommandPoolResetFlags = CommandPoolResetFlags VkFlags
+newtype CommandPoolResetFlags = CommandPoolResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolResetFlags where

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -74,14 +74,14 @@ newtype CommandPoolCreateFlags = CommandPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolCreateFlags where
-  showsPrec _ VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = showString "VK_COMMAND_POOL_CREATE_TRANSIENT_BIT"
-  showsPrec _ VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = showString "VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT"
+  showsPrec _ CommandPoolCreateTransientBit = showString "CommandPoolCreateTransientBit"
+  showsPrec _ CommandPoolCreateResetCommandBufferBit = showString "CommandPoolCreateResetCommandBufferBit"
   
   showsPrec p (CommandPoolCreateFlags x) = showParen (p >= 11) (showString "CommandPoolCreateFlags " . showsPrec 11 x)
 
 instance Read CommandPoolCreateFlags where
-  readPrec = parens ( choose [ ("VK_COMMAND_POOL_CREATE_TRANSIENT_BIT", pure VK_COMMAND_POOL_CREATE_TRANSIENT_BIT)
-                             , ("VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT", pure VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
+  readPrec = parens ( choose [ ("CommandPoolCreateTransientBit", pure CommandPoolCreateTransientBit)
+                             , ("CommandPoolCreateResetCommandBufferBit", pure CommandPoolCreateResetCommandBufferBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CommandPoolCreateFlags")
@@ -91,9 +91,9 @@ instance Read CommandPoolCreateFlags where
                     )
 
 -- | Command buffers have a short lifetime
-pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = CommandPoolCreateFlags 0x1
+pattern CommandPoolCreateTransientBit = CommandPoolCreateFlags 0x1
 -- | Command buffers may release their memory individually
-pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = CommandPoolCreateFlags 0x2
+pattern CommandPoolCreateResetCommandBufferBit = CommandPoolCreateFlags 0x2
 
 
 -- ** createCommandPool
@@ -108,12 +108,12 @@ newtype CommandPoolResetFlags = CommandPoolResetFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolResetFlags where
-  showsPrec _ VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT"
+  showsPrec _ CommandPoolResetReleaseResourcesBit = showString "CommandPoolResetReleaseResourcesBit"
   
   showsPrec p (CommandPoolResetFlags x) = showParen (p >= 11) (showString "CommandPoolResetFlags " . showsPrec 11 x)
 
 instance Read CommandPoolResetFlags where
-  readPrec = parens ( choose [ ("VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT)
+  readPrec = parens ( choose [ ("CommandPoolResetReleaseResourcesBit", pure CommandPoolResetReleaseResourcesBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CommandPoolResetFlags")
@@ -123,7 +123,7 @@ instance Read CommandPoolResetFlags where
                     )
 
 -- | Release resources owned by the pool
-pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = CommandPoolResetFlags 0x1
+pattern CommandPoolResetReleaseResourcesBit = CommandPoolResetFlags 0x1
 
 
 newtype CommandPool = CommandPool Word64

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -45,7 +45,7 @@ data CommandPoolCreateInfo =
                        , flags :: CommandPoolCreateFlags 
                        , queueFamilyIndex :: Word32 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable CommandPoolCreateInfo where
   sizeOf ~_ = 24
@@ -71,7 +71,7 @@ foreign import ccall "vkResetCommandPool" resetCommandPool ::
 -- ** CommandPoolCreateFlags
 
 newtype CommandPoolCreateFlags = CommandPoolCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolCreateFlags where
   showsPrec _ CommandPoolCreateTransientBit = showString "CommandPoolCreateTransientBit"
@@ -105,7 +105,7 @@ foreign import ccall "vkCreateCommandPool" createCommandPool ::
 -- ** CommandPoolResetFlags
 
 newtype CommandPoolResetFlags = CommandPoolResetFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CommandPoolResetFlags where
   showsPrec _ CommandPoolResetReleaseResourcesBit = showString "CommandPoolResetReleaseResourcesBit"
@@ -127,5 +127,5 @@ pattern CommandPoolResetReleaseResourcesBit = CommandPoolResetFlags 0x1
 
 
 newtype CommandPool = CommandPool Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.CommandPool where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Bits( Bits
@@ -22,14 +22,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.CommandPool( VkCommandPoolResetFlags
-                                  , VkCommandPoolCreateFlags
-                                  , CommandPool
-                                  , VkCommandPoolCreateInfo
-                                  )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -38,9 +33,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
 
 
@@ -75,33 +70,30 @@ foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
 
 -- ** VkCommandPoolCreateFlags
 
-newtype VkCommandPoolCreateFlagBits = VkCommandPoolCreateFlagBits VkFlags
+newtype VkCommandPoolCreateFlags = VkCommandPoolCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCommandPoolCreateFlagBits
-type VkCommandPoolCreateFlags = VkCommandPoolCreateFlagBits
-
-instance Show VkCommandPoolCreateFlagBits where
+instance Show VkCommandPoolCreateFlags where
   showsPrec _ VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = showString "VK_COMMAND_POOL_CREATE_TRANSIENT_BIT"
   showsPrec _ VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = showString "VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT"
   
-  showsPrec p (VkCommandPoolCreateFlagBits x) = showParen (p >= 11) (showString "VkCommandPoolCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkCommandPoolCreateFlags x) = showParen (p >= 11) (showString "VkCommandPoolCreateFlags " . showsPrec 11 x)
 
-instance Read VkCommandPoolCreateFlagBits where
+instance Read VkCommandPoolCreateFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_POOL_CREATE_TRANSIENT_BIT", pure VK_COMMAND_POOL_CREATE_TRANSIENT_BIT)
                              , ("VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT", pure VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandPoolCreateFlagBits")
+                        expectP (Ident "VkCommandPoolCreateFlags")
                         v <- step readPrec
-                        pure (VkCommandPoolCreateFlagBits v)
+                        pure (VkCommandPoolCreateFlags v)
                         )
                     )
 
 -- | Command buffers have a short lifetime
-pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = VkCommandPoolCreateFlagBits 0x1
+pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = VkCommandPoolCreateFlags 0x1
 -- | Command buffers may release their memory individually
-pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = VkCommandPoolCreateFlagBits 0x2
+pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = VkCommandPoolCreateFlags 0x2
 
 
 -- ** vkCreateCommandPool
@@ -112,29 +104,26 @@ foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
 
 -- ** VkCommandPoolResetFlags
 
-newtype VkCommandPoolResetFlagBits = VkCommandPoolResetFlagBits VkFlags
+newtype VkCommandPoolResetFlags = VkCommandPoolResetFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCommandPoolResetFlagBits
-type VkCommandPoolResetFlags = VkCommandPoolResetFlagBits
-
-instance Show VkCommandPoolResetFlagBits where
+instance Show VkCommandPoolResetFlags where
   showsPrec _ VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT"
   
-  showsPrec p (VkCommandPoolResetFlagBits x) = showParen (p >= 11) (showString "VkCommandPoolResetFlagBits " . showsPrec 11 x)
+  showsPrec p (VkCommandPoolResetFlags x) = showParen (p >= 11) (showString "VkCommandPoolResetFlags " . showsPrec 11 x)
 
-instance Read VkCommandPoolResetFlagBits where
+instance Read VkCommandPoolResetFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandPoolResetFlagBits")
+                        expectP (Ident "VkCommandPoolResetFlags")
                         v <- step readPrec
-                        pure (VkCommandPoolResetFlagBits v)
+                        pure (VkCommandPoolResetFlags v)
                         )
                     )
 
 -- | Release resources owned by the pool
-pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = VkCommandPoolResetFlagBits 0x1
+pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = VkCommandPoolResetFlags 0x1
 
 
 newtype CommandPool = CommandPool Word64

--- a/src/Graphics/Vulkan/CommandPool.hs
+++ b/src/Graphics/Vulkan/CommandPool.hs
@@ -33,16 +33,16 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 
 
 data CommandPoolCreateInfo =
-  CommandPoolCreateInfo{ sType :: VkStructureType 
+  CommandPoolCreateInfo{ sType :: StructureType 
                        , pNext :: Ptr Void 
-                       , flags :: VkCommandPoolCreateFlags 
+                       , flags :: CommandPoolCreateFlags 
                        , queueFamilyIndex :: Word32 
                        }
   deriving (Eq)
@@ -66,64 +66,64 @@ foreign import ccall "vkDestroyCommandPool" vkDestroyCommandPool ::
 
 -- ** vkResetCommandPool
 foreign import ccall "vkResetCommandPool" vkResetCommandPool ::
-  Device -> CommandPool -> VkCommandPoolResetFlags -> IO VkResult
+  Device -> CommandPool -> CommandPoolResetFlags -> IO Result
 
 -- ** VkCommandPoolCreateFlags
 
-newtype VkCommandPoolCreateFlags = VkCommandPoolCreateFlags VkFlags
+newtype CommandPoolCreateFlags = CommandPoolCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCommandPoolCreateFlags where
+instance Show CommandPoolCreateFlags where
   showsPrec _ VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = showString "VK_COMMAND_POOL_CREATE_TRANSIENT_BIT"
   showsPrec _ VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = showString "VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT"
   
-  showsPrec p (VkCommandPoolCreateFlags x) = showParen (p >= 11) (showString "VkCommandPoolCreateFlags " . showsPrec 11 x)
+  showsPrec p (CommandPoolCreateFlags x) = showParen (p >= 11) (showString "CommandPoolCreateFlags " . showsPrec 11 x)
 
-instance Read VkCommandPoolCreateFlags where
+instance Read CommandPoolCreateFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_POOL_CREATE_TRANSIENT_BIT", pure VK_COMMAND_POOL_CREATE_TRANSIENT_BIT)
                              , ("VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT", pure VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandPoolCreateFlags")
+                        expectP (Ident "CommandPoolCreateFlags")
                         v <- step readPrec
-                        pure (VkCommandPoolCreateFlags v)
+                        pure (CommandPoolCreateFlags v)
                         )
                     )
 
 -- | Command buffers have a short lifetime
-pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = VkCommandPoolCreateFlags 0x1
+pattern VK_COMMAND_POOL_CREATE_TRANSIENT_BIT = CommandPoolCreateFlags 0x1
 -- | Command buffers may release their memory individually
-pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = VkCommandPoolCreateFlags 0x2
+pattern VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT = CommandPoolCreateFlags 0x2
 
 
 -- ** vkCreateCommandPool
 foreign import ccall "vkCreateCommandPool" vkCreateCommandPool ::
   Device ->
   Ptr CommandPoolCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr CommandPool -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr CommandPool -> IO Result
 
 -- ** VkCommandPoolResetFlags
 
-newtype VkCommandPoolResetFlags = VkCommandPoolResetFlags VkFlags
+newtype CommandPoolResetFlags = CommandPoolResetFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCommandPoolResetFlags where
+instance Show CommandPoolResetFlags where
   showsPrec _ VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = showString "VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT"
   
-  showsPrec p (VkCommandPoolResetFlags x) = showParen (p >= 11) (showString "VkCommandPoolResetFlags " . showsPrec 11 x)
+  showsPrec p (CommandPoolResetFlags x) = showParen (p >= 11) (showString "CommandPoolResetFlags " . showsPrec 11 x)
 
-instance Read VkCommandPoolResetFlags where
+instance Read CommandPoolResetFlags where
   readPrec = parens ( choose [ ("VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT", pure VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCommandPoolResetFlags")
+                        expectP (Ident "CommandPoolResetFlags")
                         v <- step readPrec
-                        pure (VkCommandPoolResetFlags v)
+                        pure (CommandPoolResetFlags v)
                         )
                     )
 
 -- | Release resources owned by the pool
-pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = VkCommandPoolResetFlags 0x1
+pattern VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT = CommandPoolResetFlags 0x1
 
 
 newtype CommandPool = CommandPool Word64

--- a/src/Graphics/Vulkan/Constants.hs
+++ b/src/Graphics/Vulkan/Constants.hs
@@ -52,27 +52,27 @@ type VK_MAX_MEMORY_HEAPS = 16
 
 pattern VK_FALSE = 0
 type VK_FALSE = 0
--- ** VkPipelineCacheHeaderVersion
+-- ** PipelineCacheHeaderVersion
 
-newtype VkPipelineCacheHeaderVersion = VkPipelineCacheHeaderVersion Int32
+newtype PipelineCacheHeaderVersion = PipelineCacheHeaderVersion Int32
   deriving (Eq, Storable)
 
-instance Show VkPipelineCacheHeaderVersion where
+instance Show PipelineCacheHeaderVersion where
   showsPrec _ VK_PIPELINE_CACHE_HEADER_VERSION_ONE = showString "VK_PIPELINE_CACHE_HEADER_VERSION_ONE"
-  showsPrec p (VkPipelineCacheHeaderVersion x) = showParen (p >= 11) (showString "VkPipelineCacheHeaderVersion " . showsPrec 11 x)
+  showsPrec p (PipelineCacheHeaderVersion x) = showParen (p >= 11) (showString "PipelineCacheHeaderVersion " . showsPrec 11 x)
 
-instance Read VkPipelineCacheHeaderVersion where
+instance Read PipelineCacheHeaderVersion where
   readPrec = parens ( choose [ ("VK_PIPELINE_CACHE_HEADER_VERSION_ONE", pure VK_PIPELINE_CACHE_HEADER_VERSION_ONE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineCacheHeaderVersion")
+                        expectP (Ident "PipelineCacheHeaderVersion")
                         v <- step readPrec
-                        pure (VkPipelineCacheHeaderVersion v)
+                        pure (PipelineCacheHeaderVersion v)
                         )
                     )
 
 
-pattern VK_PIPELINE_CACHE_HEADER_VERSION_ONE = VkPipelineCacheHeaderVersion 1
+pattern VK_PIPELINE_CACHE_HEADER_VERSION_ONE = PipelineCacheHeaderVersion 1
 
 
 pattern VK_MAX_EXTENSION_NAME_SIZE = 256

--- a/src/Graphics/Vulkan/Constants.hs
+++ b/src/Graphics/Vulkan/Constants.hs
@@ -58,11 +58,11 @@ newtype PipelineCacheHeaderVersion = PipelineCacheHeaderVersion Int32
   deriving (Eq, Storable)
 
 instance Show PipelineCacheHeaderVersion where
-  showsPrec _ VK_PIPELINE_CACHE_HEADER_VERSION_ONE = showString "VK_PIPELINE_CACHE_HEADER_VERSION_ONE"
+  showsPrec _ PipelineCacheHeaderVersionOne = showString "PipelineCacheHeaderVersionOne"
   showsPrec p (PipelineCacheHeaderVersion x) = showParen (p >= 11) (showString "PipelineCacheHeaderVersion " . showsPrec 11 x)
 
 instance Read PipelineCacheHeaderVersion where
-  readPrec = parens ( choose [ ("VK_PIPELINE_CACHE_HEADER_VERSION_ONE", pure VK_PIPELINE_CACHE_HEADER_VERSION_ONE)
+  readPrec = parens ( choose [ ("PipelineCacheHeaderVersionOne", pure PipelineCacheHeaderVersionOne)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PipelineCacheHeaderVersion")
@@ -72,7 +72,7 @@ instance Read PipelineCacheHeaderVersion where
                     )
 
 
-pattern VK_PIPELINE_CACHE_HEADER_VERSION_ONE = PipelineCacheHeaderVersion 1
+pattern PipelineCacheHeaderVersionOne = PipelineCacheHeaderVersion 1
 
 
 pattern VK_MAX_EXTENSION_NAME_SIZE = 256

--- a/src/Graphics/Vulkan/Constants.hs
+++ b/src/Graphics/Vulkan/Constants.hs
@@ -55,7 +55,7 @@ type False = 0
 -- ** PipelineCacheHeaderVersion
 
 newtype PipelineCacheHeaderVersion = PipelineCacheHeaderVersion Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PipelineCacheHeaderVersion where
   showsPrec _ PipelineCacheHeaderVersionOne = showString "PipelineCacheHeaderVersionOne"

--- a/src/Graphics/Vulkan/Constants.hs
+++ b/src/Graphics/Vulkan/Constants.hs
@@ -24,34 +24,34 @@ import Text.ParserCombinators.ReadPrec( prec
                                       )
 
 
-pattern VK_SUBPASS_EXTERNAL = 0xffffffff :: Word32
+pattern SubpassExternal = 0xffffffff :: Word32
 
-pattern VK_UUID_SIZE = 16
-type VK_UUID_SIZE = 16
+pattern UuidSize = 16
+type UuidSize = 16
 
-pattern VK_REMAINING_MIP_LEVELS = 0xffffffff :: Word32
+pattern RemainingMipLevels = 0xffffffff :: Word32
 
-pattern VK_LOD_CLAMP_NONE = 1000.0
+pattern LodClampNone = 1000.0
 
-pattern VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = 256
-type VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = 256
+pattern MaxPhysicalDeviceNameSize = 256
+type MaxPhysicalDeviceNameSize = 256
 
-pattern VK_ATTACHMENT_UNUSED = 0xffffffff :: Word32
+pattern AttachmentUnused = 0xffffffff :: Word32
 
-pattern VK_MAX_MEMORY_TYPES = 32
-type VK_MAX_MEMORY_TYPES = 32
+pattern MaxMemoryTypes = 32
+type MaxMemoryTypes = 32
 
-pattern VK_WHOLE_SIZE = 0xffffffffffffffff :: Word64
+pattern WholeSize = 0xffffffffffffffff :: Word64
 
-pattern VK_REMAINING_ARRAY_LAYERS = 0xffffffff :: Word32
+pattern RemainingArrayLayers = 0xffffffff :: Word32
 
-pattern VK_QUEUE_FAMILY_IGNORED = 0xffffffff :: Word32
+pattern QueueFamilyIgnored = 0xffffffff :: Word32
 
-pattern VK_MAX_MEMORY_HEAPS = 16
-type VK_MAX_MEMORY_HEAPS = 16
+pattern MaxMemoryHeaps = 16
+type MaxMemoryHeaps = 16
 
-pattern VK_FALSE = 0
-type VK_FALSE = 0
+pattern False = 0
+type False = 0
 -- ** PipelineCacheHeaderVersion
 
 newtype PipelineCacheHeaderVersion = PipelineCacheHeaderVersion Int32
@@ -75,11 +75,11 @@ instance Read PipelineCacheHeaderVersion where
 pattern PipelineCacheHeaderVersionOne = PipelineCacheHeaderVersion 1
 
 
-pattern VK_MAX_EXTENSION_NAME_SIZE = 256
-type VK_MAX_EXTENSION_NAME_SIZE = 256
+pattern MaxExtensionNameSize = 256
+type MaxExtensionNameSize = 256
 
-pattern VK_MAX_DESCRIPTION_SIZE = 256
-type VK_MAX_DESCRIPTION_SIZE = 256
+pattern MaxDescriptionSize = 256
+type MaxDescriptionSize = 256
 
-pattern VK_TRUE = 1
-type VK_TRUE = 1
+pattern True = 1
+type True = 1

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -794,8 +794,8 @@ type VkFlags = Word32
 
 
 data VkExtent2D =
-  VkExtent2D{ vkWidth :: Word32 
-            , vkHeight :: Word32 
+  VkExtent2D{ width :: Word32 
+            , height :: Word32 
             }
   deriving (Eq)
 
@@ -804,8 +804,8 @@ instance Storable VkExtent2D where
   alignment ~_ = 4
   peek ptr = VkExtent2D <$> peek (ptr `plusPtr` 0)
                         <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkWidth (poked :: VkExtent2D))
-                *> poke (ptr `plusPtr` 4) (vkHeight (poked :: VkExtent2D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: VkExtent2D))
+                *> poke (ptr `plusPtr` 4) (height (poked :: VkExtent2D))
 
 
 -- ** VkSharingMode
@@ -1053,8 +1053,8 @@ newtype VkBool32 = VkBool32 Word32
 
 
 data VkOffset2D =
-  VkOffset2D{ vkX :: Int32 
-            , vkY :: Int32 
+  VkOffset2D{ x :: Int32 
+            , y :: Int32 
             }
   deriving (Eq)
 
@@ -1063,15 +1063,15 @@ instance Storable VkOffset2D where
   alignment ~_ = 4
   peek ptr = VkOffset2D <$> peek (ptr `plusPtr` 0)
                         <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkX (poked :: VkOffset2D))
-                *> poke (ptr `plusPtr` 4) (vkY (poked :: VkOffset2D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkOffset2D))
+                *> poke (ptr `plusPtr` 4) (y (poked :: VkOffset2D))
 
 
 
 data VkOffset3D =
-  VkOffset3D{ vkX :: Int32 
-            , vkY :: Int32 
-            , vkZ :: Int32 
+  VkOffset3D{ x :: Int32 
+            , y :: Int32 
+            , z :: Int32 
             }
   deriving (Eq)
 
@@ -1081,16 +1081,16 @@ instance Storable VkOffset3D where
   peek ptr = VkOffset3D <$> peek (ptr `plusPtr` 0)
                         <*> peek (ptr `plusPtr` 4)
                         <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkX (poked :: VkOffset3D))
-                *> poke (ptr `plusPtr` 4) (vkY (poked :: VkOffset3D))
-                *> poke (ptr `plusPtr` 8) (vkZ (poked :: VkOffset3D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkOffset3D))
+                *> poke (ptr `plusPtr` 4) (y (poked :: VkOffset3D))
+                *> poke (ptr `plusPtr` 8) (z (poked :: VkOffset3D))
 
 
 
 data VkExtent3D =
-  VkExtent3D{ vkWidth :: Word32 
-            , vkHeight :: Word32 
-            , vkDepth :: Word32 
+  VkExtent3D{ width :: Word32 
+            , height :: Word32 
+            , depth :: Word32 
             }
   deriving (Eq)
 
@@ -1100,15 +1100,15 @@ instance Storable VkExtent3D where
   peek ptr = VkExtent3D <$> peek (ptr `plusPtr` 0)
                         <*> peek (ptr `plusPtr` 4)
                         <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkWidth (poked :: VkExtent3D))
-                *> poke (ptr `plusPtr` 4) (vkHeight (poked :: VkExtent3D))
-                *> poke (ptr `plusPtr` 8) (vkDepth (poked :: VkExtent3D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: VkExtent3D))
+                *> poke (ptr `plusPtr` 4) (height (poked :: VkExtent3D))
+                *> poke (ptr `plusPtr` 8) (depth (poked :: VkExtent3D))
 
 
 
 data VkRect3D =
-  VkRect3D{ vkOffset :: VkOffset3D 
-          , vkExtent :: VkExtent3D 
+  VkRect3D{ offset :: VkOffset3D 
+          , extent :: VkExtent3D 
           }
   deriving (Eq)
 
@@ -1117,8 +1117,8 @@ instance Storable VkRect3D where
   alignment ~_ = 4
   peek ptr = VkRect3D <$> peek (ptr `plusPtr` 0)
                       <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkOffset (poked :: VkRect3D))
-                *> poke (ptr `plusPtr` 12) (vkExtent (poked :: VkRect3D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkRect3D))
+                *> poke (ptr `plusPtr` 12) (extent (poked :: VkRect3D))
 
 
 -- ** VkResult
@@ -1209,12 +1209,12 @@ pattern VK_ERROR_FORMAT_NOT_SUPPORTED = VkResult (-11)
 
 
 data VkViewport =
-  VkViewport{ vkX :: CFloat 
-            , vkY :: CFloat 
-            , vkWidth :: CFloat 
-            , vkHeight :: CFloat 
-            , vkMinDepth :: CFloat 
-            , vkMaxDepth :: CFloat 
+  VkViewport{ x :: CFloat 
+            , y :: CFloat 
+            , width :: CFloat 
+            , height :: CFloat 
+            , minDepth :: CFloat 
+            , maxDepth :: CFloat 
             }
   deriving (Eq)
 
@@ -1227,18 +1227,18 @@ instance Storable VkViewport where
                         <*> peek (ptr `plusPtr` 12)
                         <*> peek (ptr `plusPtr` 16)
                         <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkX (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 4) (vkY (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 8) (vkWidth (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 12) (vkHeight (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 16) (vkMinDepth (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 20) (vkMaxDepth (poked :: VkViewport))
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkViewport))
+                *> poke (ptr `plusPtr` 4) (y (poked :: VkViewport))
+                *> poke (ptr `plusPtr` 8) (width (poked :: VkViewport))
+                *> poke (ptr `plusPtr` 12) (height (poked :: VkViewport))
+                *> poke (ptr `plusPtr` 16) (minDepth (poked :: VkViewport))
+                *> poke (ptr `plusPtr` 20) (maxDepth (poked :: VkViewport))
 
 
 
 data VkRect2D =
-  VkRect2D{ vkOffset :: VkOffset2D 
-          , vkExtent :: VkExtent2D 
+  VkRect2D{ offset :: VkOffset2D 
+          , extent :: VkExtent2D 
           }
   deriving (Eq)
 
@@ -1247,7 +1247,7 @@ instance Storable VkRect2D where
   alignment ~_ = 4
   peek ptr = VkRect2D <$> peek (ptr `plusPtr` 0)
                       <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkOffset (poked :: VkRect2D))
-                *> poke (ptr `plusPtr` 8) (vkExtent (poked :: VkRect2D))
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkRect2D))
+                *> poke (ptr `plusPtr` 8) (extent (poked :: VkRect2D))
 
 

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -26,7 +26,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , step
                                       )
 import Foreign.C.Types( CFloat
-                      , CFloat(..)
                       )
 
 newtype VkDeviceSize = VkDeviceSize Word64

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -38,379 +38,379 @@ newtype Format = Format Int32
   deriving (Eq, Storable)
 
 instance Show Format where
-  showsPrec _ VK_FORMAT_UNDEFINED = showString "VK_FORMAT_UNDEFINED"
-  showsPrec _ VK_FORMAT_R4G4_UNORM_PACK8 = showString "VK_FORMAT_R4G4_UNORM_PACK8"
-  showsPrec _ VK_FORMAT_R4G4B4A4_UNORM_PACK16 = showString "VK_FORMAT_R4G4B4A4_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_B4G4R4A4_UNORM_PACK16 = showString "VK_FORMAT_B4G4R4A4_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_R5G6B5_UNORM_PACK16 = showString "VK_FORMAT_R5G6B5_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_B5G6R5_UNORM_PACK16 = showString "VK_FORMAT_B5G6R5_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_R5G5B5A1_UNORM_PACK16 = showString "VK_FORMAT_R5G5B5A1_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_B5G5R5A1_UNORM_PACK16 = showString "VK_FORMAT_B5G5R5A1_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_A1R5G5B5_UNORM_PACK16 = showString "VK_FORMAT_A1R5G5B5_UNORM_PACK16"
-  showsPrec _ VK_FORMAT_R8_UNORM = showString "VK_FORMAT_R8_UNORM"
-  showsPrec _ VK_FORMAT_R8_SNORM = showString "VK_FORMAT_R8_SNORM"
-  showsPrec _ VK_FORMAT_R8_USCALED = showString "VK_FORMAT_R8_USCALED"
-  showsPrec _ VK_FORMAT_R8_SSCALED = showString "VK_FORMAT_R8_SSCALED"
-  showsPrec _ VK_FORMAT_R8_UINT = showString "VK_FORMAT_R8_UINT"
-  showsPrec _ VK_FORMAT_R8_SINT = showString "VK_FORMAT_R8_SINT"
-  showsPrec _ VK_FORMAT_R8_SRGB = showString "VK_FORMAT_R8_SRGB"
-  showsPrec _ VK_FORMAT_R8G8_UNORM = showString "VK_FORMAT_R8G8_UNORM"
-  showsPrec _ VK_FORMAT_R8G8_SNORM = showString "VK_FORMAT_R8G8_SNORM"
-  showsPrec _ VK_FORMAT_R8G8_USCALED = showString "VK_FORMAT_R8G8_USCALED"
-  showsPrec _ VK_FORMAT_R8G8_SSCALED = showString "VK_FORMAT_R8G8_SSCALED"
-  showsPrec _ VK_FORMAT_R8G8_UINT = showString "VK_FORMAT_R8G8_UINT"
-  showsPrec _ VK_FORMAT_R8G8_SINT = showString "VK_FORMAT_R8G8_SINT"
-  showsPrec _ VK_FORMAT_R8G8_SRGB = showString "VK_FORMAT_R8G8_SRGB"
-  showsPrec _ VK_FORMAT_R8G8B8_UNORM = showString "VK_FORMAT_R8G8B8_UNORM"
-  showsPrec _ VK_FORMAT_R8G8B8_SNORM = showString "VK_FORMAT_R8G8B8_SNORM"
-  showsPrec _ VK_FORMAT_R8G8B8_USCALED = showString "VK_FORMAT_R8G8B8_USCALED"
-  showsPrec _ VK_FORMAT_R8G8B8_SSCALED = showString "VK_FORMAT_R8G8B8_SSCALED"
-  showsPrec _ VK_FORMAT_R8G8B8_UINT = showString "VK_FORMAT_R8G8B8_UINT"
-  showsPrec _ VK_FORMAT_R8G8B8_SINT = showString "VK_FORMAT_R8G8B8_SINT"
-  showsPrec _ VK_FORMAT_R8G8B8_SRGB = showString "VK_FORMAT_R8G8B8_SRGB"
-  showsPrec _ VK_FORMAT_B8G8R8_UNORM = showString "VK_FORMAT_B8G8R8_UNORM"
-  showsPrec _ VK_FORMAT_B8G8R8_SNORM = showString "VK_FORMAT_B8G8R8_SNORM"
-  showsPrec _ VK_FORMAT_B8G8R8_USCALED = showString "VK_FORMAT_B8G8R8_USCALED"
-  showsPrec _ VK_FORMAT_B8G8R8_SSCALED = showString "VK_FORMAT_B8G8R8_SSCALED"
-  showsPrec _ VK_FORMAT_B8G8R8_UINT = showString "VK_FORMAT_B8G8R8_UINT"
-  showsPrec _ VK_FORMAT_B8G8R8_SINT = showString "VK_FORMAT_B8G8R8_SINT"
-  showsPrec _ VK_FORMAT_B8G8R8_SRGB = showString "VK_FORMAT_B8G8R8_SRGB"
-  showsPrec _ VK_FORMAT_R8G8B8A8_UNORM = showString "VK_FORMAT_R8G8B8A8_UNORM"
-  showsPrec _ VK_FORMAT_R8G8B8A8_SNORM = showString "VK_FORMAT_R8G8B8A8_SNORM"
-  showsPrec _ VK_FORMAT_R8G8B8A8_USCALED = showString "VK_FORMAT_R8G8B8A8_USCALED"
-  showsPrec _ VK_FORMAT_R8G8B8A8_SSCALED = showString "VK_FORMAT_R8G8B8A8_SSCALED"
-  showsPrec _ VK_FORMAT_R8G8B8A8_UINT = showString "VK_FORMAT_R8G8B8A8_UINT"
-  showsPrec _ VK_FORMAT_R8G8B8A8_SINT = showString "VK_FORMAT_R8G8B8A8_SINT"
-  showsPrec _ VK_FORMAT_R8G8B8A8_SRGB = showString "VK_FORMAT_R8G8B8A8_SRGB"
-  showsPrec _ VK_FORMAT_B8G8R8A8_UNORM = showString "VK_FORMAT_B8G8R8A8_UNORM"
-  showsPrec _ VK_FORMAT_B8G8R8A8_SNORM = showString "VK_FORMAT_B8G8R8A8_SNORM"
-  showsPrec _ VK_FORMAT_B8G8R8A8_USCALED = showString "VK_FORMAT_B8G8R8A8_USCALED"
-  showsPrec _ VK_FORMAT_B8G8R8A8_SSCALED = showString "VK_FORMAT_B8G8R8A8_SSCALED"
-  showsPrec _ VK_FORMAT_B8G8R8A8_UINT = showString "VK_FORMAT_B8G8R8A8_UINT"
-  showsPrec _ VK_FORMAT_B8G8R8A8_SINT = showString "VK_FORMAT_B8G8R8A8_SINT"
-  showsPrec _ VK_FORMAT_B8G8R8A8_SRGB = showString "VK_FORMAT_B8G8R8A8_SRGB"
-  showsPrec _ VK_FORMAT_A8B8G8R8_UNORM_PACK32 = showString "VK_FORMAT_A8B8G8R8_UNORM_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_SNORM_PACK32 = showString "VK_FORMAT_A8B8G8R8_SNORM_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_USCALED_PACK32 = showString "VK_FORMAT_A8B8G8R8_USCALED_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = showString "VK_FORMAT_A8B8G8R8_SSCALED_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_UINT_PACK32 = showString "VK_FORMAT_A8B8G8R8_UINT_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_SINT_PACK32 = showString "VK_FORMAT_A8B8G8R8_SINT_PACK32"
-  showsPrec _ VK_FORMAT_A8B8G8R8_SRGB_PACK32 = showString "VK_FORMAT_A8B8G8R8_SRGB_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_UNORM_PACK32 = showString "VK_FORMAT_A2R10G10B10_UNORM_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_SNORM_PACK32 = showString "VK_FORMAT_A2R10G10B10_SNORM_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_USCALED_PACK32 = showString "VK_FORMAT_A2R10G10B10_USCALED_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = showString "VK_FORMAT_A2R10G10B10_SSCALED_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_UINT_PACK32 = showString "VK_FORMAT_A2R10G10B10_UINT_PACK32"
-  showsPrec _ VK_FORMAT_A2R10G10B10_SINT_PACK32 = showString "VK_FORMAT_A2R10G10B10_SINT_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_UNORM_PACK32 = showString "VK_FORMAT_A2B10G10R10_UNORM_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_SNORM_PACK32 = showString "VK_FORMAT_A2B10G10R10_SNORM_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_USCALED_PACK32 = showString "VK_FORMAT_A2B10G10R10_USCALED_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = showString "VK_FORMAT_A2B10G10R10_SSCALED_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_UINT_PACK32 = showString "VK_FORMAT_A2B10G10R10_UINT_PACK32"
-  showsPrec _ VK_FORMAT_A2B10G10R10_SINT_PACK32 = showString "VK_FORMAT_A2B10G10R10_SINT_PACK32"
-  showsPrec _ VK_FORMAT_R16_UNORM = showString "VK_FORMAT_R16_UNORM"
-  showsPrec _ VK_FORMAT_R16_SNORM = showString "VK_FORMAT_R16_SNORM"
-  showsPrec _ VK_FORMAT_R16_USCALED = showString "VK_FORMAT_R16_USCALED"
-  showsPrec _ VK_FORMAT_R16_SSCALED = showString "VK_FORMAT_R16_SSCALED"
-  showsPrec _ VK_FORMAT_R16_UINT = showString "VK_FORMAT_R16_UINT"
-  showsPrec _ VK_FORMAT_R16_SINT = showString "VK_FORMAT_R16_SINT"
-  showsPrec _ VK_FORMAT_R16_SFLOAT = showString "VK_FORMAT_R16_SFLOAT"
-  showsPrec _ VK_FORMAT_R16G16_UNORM = showString "VK_FORMAT_R16G16_UNORM"
-  showsPrec _ VK_FORMAT_R16G16_SNORM = showString "VK_FORMAT_R16G16_SNORM"
-  showsPrec _ VK_FORMAT_R16G16_USCALED = showString "VK_FORMAT_R16G16_USCALED"
-  showsPrec _ VK_FORMAT_R16G16_SSCALED = showString "VK_FORMAT_R16G16_SSCALED"
-  showsPrec _ VK_FORMAT_R16G16_UINT = showString "VK_FORMAT_R16G16_UINT"
-  showsPrec _ VK_FORMAT_R16G16_SINT = showString "VK_FORMAT_R16G16_SINT"
-  showsPrec _ VK_FORMAT_R16G16_SFLOAT = showString "VK_FORMAT_R16G16_SFLOAT"
-  showsPrec _ VK_FORMAT_R16G16B16_UNORM = showString "VK_FORMAT_R16G16B16_UNORM"
-  showsPrec _ VK_FORMAT_R16G16B16_SNORM = showString "VK_FORMAT_R16G16B16_SNORM"
-  showsPrec _ VK_FORMAT_R16G16B16_USCALED = showString "VK_FORMAT_R16G16B16_USCALED"
-  showsPrec _ VK_FORMAT_R16G16B16_SSCALED = showString "VK_FORMAT_R16G16B16_SSCALED"
-  showsPrec _ VK_FORMAT_R16G16B16_UINT = showString "VK_FORMAT_R16G16B16_UINT"
-  showsPrec _ VK_FORMAT_R16G16B16_SINT = showString "VK_FORMAT_R16G16B16_SINT"
-  showsPrec _ VK_FORMAT_R16G16B16_SFLOAT = showString "VK_FORMAT_R16G16B16_SFLOAT"
-  showsPrec _ VK_FORMAT_R16G16B16A16_UNORM = showString "VK_FORMAT_R16G16B16A16_UNORM"
-  showsPrec _ VK_FORMAT_R16G16B16A16_SNORM = showString "VK_FORMAT_R16G16B16A16_SNORM"
-  showsPrec _ VK_FORMAT_R16G16B16A16_USCALED = showString "VK_FORMAT_R16G16B16A16_USCALED"
-  showsPrec _ VK_FORMAT_R16G16B16A16_SSCALED = showString "VK_FORMAT_R16G16B16A16_SSCALED"
-  showsPrec _ VK_FORMAT_R16G16B16A16_UINT = showString "VK_FORMAT_R16G16B16A16_UINT"
-  showsPrec _ VK_FORMAT_R16G16B16A16_SINT = showString "VK_FORMAT_R16G16B16A16_SINT"
-  showsPrec _ VK_FORMAT_R16G16B16A16_SFLOAT = showString "VK_FORMAT_R16G16B16A16_SFLOAT"
-  showsPrec _ VK_FORMAT_R32_UINT = showString "VK_FORMAT_R32_UINT"
-  showsPrec _ VK_FORMAT_R32_SINT = showString "VK_FORMAT_R32_SINT"
-  showsPrec _ VK_FORMAT_R32_SFLOAT = showString "VK_FORMAT_R32_SFLOAT"
-  showsPrec _ VK_FORMAT_R32G32_UINT = showString "VK_FORMAT_R32G32_UINT"
-  showsPrec _ VK_FORMAT_R32G32_SINT = showString "VK_FORMAT_R32G32_SINT"
-  showsPrec _ VK_FORMAT_R32G32_SFLOAT = showString "VK_FORMAT_R32G32_SFLOAT"
-  showsPrec _ VK_FORMAT_R32G32B32_UINT = showString "VK_FORMAT_R32G32B32_UINT"
-  showsPrec _ VK_FORMAT_R32G32B32_SINT = showString "VK_FORMAT_R32G32B32_SINT"
-  showsPrec _ VK_FORMAT_R32G32B32_SFLOAT = showString "VK_FORMAT_R32G32B32_SFLOAT"
-  showsPrec _ VK_FORMAT_R32G32B32A32_UINT = showString "VK_FORMAT_R32G32B32A32_UINT"
-  showsPrec _ VK_FORMAT_R32G32B32A32_SINT = showString "VK_FORMAT_R32G32B32A32_SINT"
-  showsPrec _ VK_FORMAT_R32G32B32A32_SFLOAT = showString "VK_FORMAT_R32G32B32A32_SFLOAT"
-  showsPrec _ VK_FORMAT_R64_UINT = showString "VK_FORMAT_R64_UINT"
-  showsPrec _ VK_FORMAT_R64_SINT = showString "VK_FORMAT_R64_SINT"
-  showsPrec _ VK_FORMAT_R64_SFLOAT = showString "VK_FORMAT_R64_SFLOAT"
-  showsPrec _ VK_FORMAT_R64G64_UINT = showString "VK_FORMAT_R64G64_UINT"
-  showsPrec _ VK_FORMAT_R64G64_SINT = showString "VK_FORMAT_R64G64_SINT"
-  showsPrec _ VK_FORMAT_R64G64_SFLOAT = showString "VK_FORMAT_R64G64_SFLOAT"
-  showsPrec _ VK_FORMAT_R64G64B64_UINT = showString "VK_FORMAT_R64G64B64_UINT"
-  showsPrec _ VK_FORMAT_R64G64B64_SINT = showString "VK_FORMAT_R64G64B64_SINT"
-  showsPrec _ VK_FORMAT_R64G64B64_SFLOAT = showString "VK_FORMAT_R64G64B64_SFLOAT"
-  showsPrec _ VK_FORMAT_R64G64B64A64_UINT = showString "VK_FORMAT_R64G64B64A64_UINT"
-  showsPrec _ VK_FORMAT_R64G64B64A64_SINT = showString "VK_FORMAT_R64G64B64A64_SINT"
-  showsPrec _ VK_FORMAT_R64G64B64A64_SFLOAT = showString "VK_FORMAT_R64G64B64A64_SFLOAT"
-  showsPrec _ VK_FORMAT_B10G11R11_UFLOAT_PACK32 = showString "VK_FORMAT_B10G11R11_UFLOAT_PACK32"
-  showsPrec _ VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = showString "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32"
-  showsPrec _ VK_FORMAT_D16_UNORM = showString "VK_FORMAT_D16_UNORM"
-  showsPrec _ VK_FORMAT_X8_D24_UNORM_PACK32 = showString "VK_FORMAT_X8_D24_UNORM_PACK32"
-  showsPrec _ VK_FORMAT_D32_SFLOAT = showString "VK_FORMAT_D32_SFLOAT"
-  showsPrec _ VK_FORMAT_S8_UINT = showString "VK_FORMAT_S8_UINT"
-  showsPrec _ VK_FORMAT_D16_UNORM_S8_UINT = showString "VK_FORMAT_D16_UNORM_S8_UINT"
-  showsPrec _ VK_FORMAT_D24_UNORM_S8_UINT = showString "VK_FORMAT_D24_UNORM_S8_UINT"
-  showsPrec _ VK_FORMAT_D32_SFLOAT_S8_UINT = showString "VK_FORMAT_D32_SFLOAT_S8_UINT"
-  showsPrec _ VK_FORMAT_BC1_RGB_UNORM_BLOCK = showString "VK_FORMAT_BC1_RGB_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC1_RGB_SRGB_BLOCK = showString "VK_FORMAT_BC1_RGB_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_BC1_RGBA_UNORM_BLOCK = showString "VK_FORMAT_BC1_RGBA_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC1_RGBA_SRGB_BLOCK = showString "VK_FORMAT_BC1_RGBA_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_BC2_UNORM_BLOCK = showString "VK_FORMAT_BC2_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC2_SRGB_BLOCK = showString "VK_FORMAT_BC2_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_BC3_UNORM_BLOCK = showString "VK_FORMAT_BC3_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC3_SRGB_BLOCK = showString "VK_FORMAT_BC3_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_BC4_UNORM_BLOCK = showString "VK_FORMAT_BC4_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC4_SNORM_BLOCK = showString "VK_FORMAT_BC4_SNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC5_UNORM_BLOCK = showString "VK_FORMAT_BC5_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC5_SNORM_BLOCK = showString "VK_FORMAT_BC5_SNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC6H_UFLOAT_BLOCK = showString "VK_FORMAT_BC6H_UFLOAT_BLOCK"
-  showsPrec _ VK_FORMAT_BC6H_SFLOAT_BLOCK = showString "VK_FORMAT_BC6H_SFLOAT_BLOCK"
-  showsPrec _ VK_FORMAT_BC7_UNORM_BLOCK = showString "VK_FORMAT_BC7_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_BC7_SRGB_BLOCK = showString "VK_FORMAT_BC7_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = showString "VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_EAC_R11_UNORM_BLOCK = showString "VK_FORMAT_EAC_R11_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_EAC_R11_SNORM_BLOCK = showString "VK_FORMAT_EAC_R11_SNORM_BLOCK"
-  showsPrec _ VK_FORMAT_EAC_R11G11_UNORM_BLOCK = showString "VK_FORMAT_EAC_R11G11_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_EAC_R11G11_SNORM_BLOCK = showString "VK_FORMAT_EAC_R11G11_SNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_4x4_UNORM_BLOCK = showString "VK_FORMAT_ASTC_4x4_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_4x4_SRGB_BLOCK = showString "VK_FORMAT_ASTC_4x4_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_5x4_UNORM_BLOCK = showString "VK_FORMAT_ASTC_5x4_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_5x4_SRGB_BLOCK = showString "VK_FORMAT_ASTC_5x4_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_5x5_UNORM_BLOCK = showString "VK_FORMAT_ASTC_5x5_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_5x5_SRGB_BLOCK = showString "VK_FORMAT_ASTC_5x5_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_6x5_UNORM_BLOCK = showString "VK_FORMAT_ASTC_6x5_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_6x5_SRGB_BLOCK = showString "VK_FORMAT_ASTC_6x5_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_6x6_UNORM_BLOCK = showString "VK_FORMAT_ASTC_6x6_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_6x6_SRGB_BLOCK = showString "VK_FORMAT_ASTC_6x6_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x5_UNORM_BLOCK = showString "VK_FORMAT_ASTC_8x5_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x5_SRGB_BLOCK = showString "VK_FORMAT_ASTC_8x5_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x6_UNORM_BLOCK = showString "VK_FORMAT_ASTC_8x6_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x6_SRGB_BLOCK = showString "VK_FORMAT_ASTC_8x6_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x8_UNORM_BLOCK = showString "VK_FORMAT_ASTC_8x8_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_8x8_SRGB_BLOCK = showString "VK_FORMAT_ASTC_8x8_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x5_UNORM_BLOCK = showString "VK_FORMAT_ASTC_10x5_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x5_SRGB_BLOCK = showString "VK_FORMAT_ASTC_10x5_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x6_UNORM_BLOCK = showString "VK_FORMAT_ASTC_10x6_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x6_SRGB_BLOCK = showString "VK_FORMAT_ASTC_10x6_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x8_UNORM_BLOCK = showString "VK_FORMAT_ASTC_10x8_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x8_SRGB_BLOCK = showString "VK_FORMAT_ASTC_10x8_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x10_UNORM_BLOCK = showString "VK_FORMAT_ASTC_10x10_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_10x10_SRGB_BLOCK = showString "VK_FORMAT_ASTC_10x10_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_12x10_UNORM_BLOCK = showString "VK_FORMAT_ASTC_12x10_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_12x10_SRGB_BLOCK = showString "VK_FORMAT_ASTC_12x10_SRGB_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_12x12_UNORM_BLOCK = showString "VK_FORMAT_ASTC_12x12_UNORM_BLOCK"
-  showsPrec _ VK_FORMAT_ASTC_12x12_SRGB_BLOCK = showString "VK_FORMAT_ASTC_12x12_SRGB_BLOCK"
+  showsPrec _ FormatUndefined = showString "FormatUndefined"
+  showsPrec _ FormatR4g4UnormPack8 = showString "FormatR4g4UnormPack8"
+  showsPrec _ FormatR4g4b4a4UnormPack16 = showString "FormatR4g4b4a4UnormPack16"
+  showsPrec _ FormatB4g4r4a4UnormPack16 = showString "FormatB4g4r4a4UnormPack16"
+  showsPrec _ FormatR5g6b5UnormPack16 = showString "FormatR5g6b5UnormPack16"
+  showsPrec _ FormatB5g6r5UnormPack16 = showString "FormatB5g6r5UnormPack16"
+  showsPrec _ FormatR5g5b5a1UnormPack16 = showString "FormatR5g5b5a1UnormPack16"
+  showsPrec _ FormatB5g5r5a1UnormPack16 = showString "FormatB5g5r5a1UnormPack16"
+  showsPrec _ FormatA1r5g5b5UnormPack16 = showString "FormatA1r5g5b5UnormPack16"
+  showsPrec _ FormatR8Unorm = showString "FormatR8Unorm"
+  showsPrec _ FormatR8Snorm = showString "FormatR8Snorm"
+  showsPrec _ FormatR8Uscaled = showString "FormatR8Uscaled"
+  showsPrec _ FormatR8Sscaled = showString "FormatR8Sscaled"
+  showsPrec _ FormatR8Uint = showString "FormatR8Uint"
+  showsPrec _ FormatR8Sint = showString "FormatR8Sint"
+  showsPrec _ FormatR8Srgb = showString "FormatR8Srgb"
+  showsPrec _ FormatR8g8Unorm = showString "FormatR8g8Unorm"
+  showsPrec _ FormatR8g8Snorm = showString "FormatR8g8Snorm"
+  showsPrec _ FormatR8g8Uscaled = showString "FormatR8g8Uscaled"
+  showsPrec _ FormatR8g8Sscaled = showString "FormatR8g8Sscaled"
+  showsPrec _ FormatR8g8Uint = showString "FormatR8g8Uint"
+  showsPrec _ FormatR8g8Sint = showString "FormatR8g8Sint"
+  showsPrec _ FormatR8g8Srgb = showString "FormatR8g8Srgb"
+  showsPrec _ FormatR8g8b8Unorm = showString "FormatR8g8b8Unorm"
+  showsPrec _ FormatR8g8b8Snorm = showString "FormatR8g8b8Snorm"
+  showsPrec _ FormatR8g8b8Uscaled = showString "FormatR8g8b8Uscaled"
+  showsPrec _ FormatR8g8b8Sscaled = showString "FormatR8g8b8Sscaled"
+  showsPrec _ FormatR8g8b8Uint = showString "FormatR8g8b8Uint"
+  showsPrec _ FormatR8g8b8Sint = showString "FormatR8g8b8Sint"
+  showsPrec _ FormatR8g8b8Srgb = showString "FormatR8g8b8Srgb"
+  showsPrec _ FormatB8g8r8Unorm = showString "FormatB8g8r8Unorm"
+  showsPrec _ FormatB8g8r8Snorm = showString "FormatB8g8r8Snorm"
+  showsPrec _ FormatB8g8r8Uscaled = showString "FormatB8g8r8Uscaled"
+  showsPrec _ FormatB8g8r8Sscaled = showString "FormatB8g8r8Sscaled"
+  showsPrec _ FormatB8g8r8Uint = showString "FormatB8g8r8Uint"
+  showsPrec _ FormatB8g8r8Sint = showString "FormatB8g8r8Sint"
+  showsPrec _ FormatB8g8r8Srgb = showString "FormatB8g8r8Srgb"
+  showsPrec _ FormatR8g8b8a8Unorm = showString "FormatR8g8b8a8Unorm"
+  showsPrec _ FormatR8g8b8a8Snorm = showString "FormatR8g8b8a8Snorm"
+  showsPrec _ FormatR8g8b8a8Uscaled = showString "FormatR8g8b8a8Uscaled"
+  showsPrec _ FormatR8g8b8a8Sscaled = showString "FormatR8g8b8a8Sscaled"
+  showsPrec _ FormatR8g8b8a8Uint = showString "FormatR8g8b8a8Uint"
+  showsPrec _ FormatR8g8b8a8Sint = showString "FormatR8g8b8a8Sint"
+  showsPrec _ FormatR8g8b8a8Srgb = showString "FormatR8g8b8a8Srgb"
+  showsPrec _ FormatB8g8r8a8Unorm = showString "FormatB8g8r8a8Unorm"
+  showsPrec _ FormatB8g8r8a8Snorm = showString "FormatB8g8r8a8Snorm"
+  showsPrec _ FormatB8g8r8a8Uscaled = showString "FormatB8g8r8a8Uscaled"
+  showsPrec _ FormatB8g8r8a8Sscaled = showString "FormatB8g8r8a8Sscaled"
+  showsPrec _ FormatB8g8r8a8Uint = showString "FormatB8g8r8a8Uint"
+  showsPrec _ FormatB8g8r8a8Sint = showString "FormatB8g8r8a8Sint"
+  showsPrec _ FormatB8g8r8a8Srgb = showString "FormatB8g8r8a8Srgb"
+  showsPrec _ FormatA8b8g8r8UnormPack32 = showString "FormatA8b8g8r8UnormPack32"
+  showsPrec _ FormatA8b8g8r8SnormPack32 = showString "FormatA8b8g8r8SnormPack32"
+  showsPrec _ FormatA8b8g8r8UscaledPack32 = showString "FormatA8b8g8r8UscaledPack32"
+  showsPrec _ FormatA8b8g8r8SscaledPack32 = showString "FormatA8b8g8r8SscaledPack32"
+  showsPrec _ FormatA8b8g8r8UintPack32 = showString "FormatA8b8g8r8UintPack32"
+  showsPrec _ FormatA8b8g8r8SintPack32 = showString "FormatA8b8g8r8SintPack32"
+  showsPrec _ FormatA8b8g8r8SrgbPack32 = showString "FormatA8b8g8r8SrgbPack32"
+  showsPrec _ FormatA2r10g10b10UnormPack32 = showString "FormatA2r10g10b10UnormPack32"
+  showsPrec _ FormatA2r10g10b10SnormPack32 = showString "FormatA2r10g10b10SnormPack32"
+  showsPrec _ FormatA2r10g10b10UscaledPack32 = showString "FormatA2r10g10b10UscaledPack32"
+  showsPrec _ FormatA2r10g10b10SscaledPack32 = showString "FormatA2r10g10b10SscaledPack32"
+  showsPrec _ FormatA2r10g10b10UintPack32 = showString "FormatA2r10g10b10UintPack32"
+  showsPrec _ FormatA2r10g10b10SintPack32 = showString "FormatA2r10g10b10SintPack32"
+  showsPrec _ FormatA2b10g10r10UnormPack32 = showString "FormatA2b10g10r10UnormPack32"
+  showsPrec _ FormatA2b10g10r10SnormPack32 = showString "FormatA2b10g10r10SnormPack32"
+  showsPrec _ FormatA2b10g10r10UscaledPack32 = showString "FormatA2b10g10r10UscaledPack32"
+  showsPrec _ FormatA2b10g10r10SscaledPack32 = showString "FormatA2b10g10r10SscaledPack32"
+  showsPrec _ FormatA2b10g10r10UintPack32 = showString "FormatA2b10g10r10UintPack32"
+  showsPrec _ FormatA2b10g10r10SintPack32 = showString "FormatA2b10g10r10SintPack32"
+  showsPrec _ FormatR16Unorm = showString "FormatR16Unorm"
+  showsPrec _ FormatR16Snorm = showString "FormatR16Snorm"
+  showsPrec _ FormatR16Uscaled = showString "FormatR16Uscaled"
+  showsPrec _ FormatR16Sscaled = showString "FormatR16Sscaled"
+  showsPrec _ FormatR16Uint = showString "FormatR16Uint"
+  showsPrec _ FormatR16Sint = showString "FormatR16Sint"
+  showsPrec _ FormatR16Sfloat = showString "FormatR16Sfloat"
+  showsPrec _ FormatR16g16Unorm = showString "FormatR16g16Unorm"
+  showsPrec _ FormatR16g16Snorm = showString "FormatR16g16Snorm"
+  showsPrec _ FormatR16g16Uscaled = showString "FormatR16g16Uscaled"
+  showsPrec _ FormatR16g16Sscaled = showString "FormatR16g16Sscaled"
+  showsPrec _ FormatR16g16Uint = showString "FormatR16g16Uint"
+  showsPrec _ FormatR16g16Sint = showString "FormatR16g16Sint"
+  showsPrec _ FormatR16g16Sfloat = showString "FormatR16g16Sfloat"
+  showsPrec _ FormatR16g16b16Unorm = showString "FormatR16g16b16Unorm"
+  showsPrec _ FormatR16g16b16Snorm = showString "FormatR16g16b16Snorm"
+  showsPrec _ FormatR16g16b16Uscaled = showString "FormatR16g16b16Uscaled"
+  showsPrec _ FormatR16g16b16Sscaled = showString "FormatR16g16b16Sscaled"
+  showsPrec _ FormatR16g16b16Uint = showString "FormatR16g16b16Uint"
+  showsPrec _ FormatR16g16b16Sint = showString "FormatR16g16b16Sint"
+  showsPrec _ FormatR16g16b16Sfloat = showString "FormatR16g16b16Sfloat"
+  showsPrec _ FormatR16g16b16a16Unorm = showString "FormatR16g16b16a16Unorm"
+  showsPrec _ FormatR16g16b16a16Snorm = showString "FormatR16g16b16a16Snorm"
+  showsPrec _ FormatR16g16b16a16Uscaled = showString "FormatR16g16b16a16Uscaled"
+  showsPrec _ FormatR16g16b16a16Sscaled = showString "FormatR16g16b16a16Sscaled"
+  showsPrec _ FormatR16g16b16a16Uint = showString "FormatR16g16b16a16Uint"
+  showsPrec _ FormatR16g16b16a16Sint = showString "FormatR16g16b16a16Sint"
+  showsPrec _ FormatR16g16b16a16Sfloat = showString "FormatR16g16b16a16Sfloat"
+  showsPrec _ FormatR32Uint = showString "FormatR32Uint"
+  showsPrec _ FormatR32Sint = showString "FormatR32Sint"
+  showsPrec _ FormatR32Sfloat = showString "FormatR32Sfloat"
+  showsPrec _ FormatR32g32Uint = showString "FormatR32g32Uint"
+  showsPrec _ FormatR32g32Sint = showString "FormatR32g32Sint"
+  showsPrec _ FormatR32g32Sfloat = showString "FormatR32g32Sfloat"
+  showsPrec _ FormatR32g32b32Uint = showString "FormatR32g32b32Uint"
+  showsPrec _ FormatR32g32b32Sint = showString "FormatR32g32b32Sint"
+  showsPrec _ FormatR32g32b32Sfloat = showString "FormatR32g32b32Sfloat"
+  showsPrec _ FormatR32g32b32a32Uint = showString "FormatR32g32b32a32Uint"
+  showsPrec _ FormatR32g32b32a32Sint = showString "FormatR32g32b32a32Sint"
+  showsPrec _ FormatR32g32b32a32Sfloat = showString "FormatR32g32b32a32Sfloat"
+  showsPrec _ FormatR64Uint = showString "FormatR64Uint"
+  showsPrec _ FormatR64Sint = showString "FormatR64Sint"
+  showsPrec _ FormatR64Sfloat = showString "FormatR64Sfloat"
+  showsPrec _ FormatR64g64Uint = showString "FormatR64g64Uint"
+  showsPrec _ FormatR64g64Sint = showString "FormatR64g64Sint"
+  showsPrec _ FormatR64g64Sfloat = showString "FormatR64g64Sfloat"
+  showsPrec _ FormatR64g64b64Uint = showString "FormatR64g64b64Uint"
+  showsPrec _ FormatR64g64b64Sint = showString "FormatR64g64b64Sint"
+  showsPrec _ FormatR64g64b64Sfloat = showString "FormatR64g64b64Sfloat"
+  showsPrec _ FormatR64g64b64a64Uint = showString "FormatR64g64b64a64Uint"
+  showsPrec _ FormatR64g64b64a64Sint = showString "FormatR64g64b64a64Sint"
+  showsPrec _ FormatR64g64b64a64Sfloat = showString "FormatR64g64b64a64Sfloat"
+  showsPrec _ FormatB10g11r11UfloatPack32 = showString "FormatB10g11r11UfloatPack32"
+  showsPrec _ FormatE5b9g9r9UfloatPack32 = showString "FormatE5b9g9r9UfloatPack32"
+  showsPrec _ FormatD16Unorm = showString "FormatD16Unorm"
+  showsPrec _ FormatX8D24UnormPack32 = showString "FormatX8D24UnormPack32"
+  showsPrec _ FormatD32Sfloat = showString "FormatD32Sfloat"
+  showsPrec _ FormatS8Uint = showString "FormatS8Uint"
+  showsPrec _ FormatD16UnormS8Uint = showString "FormatD16UnormS8Uint"
+  showsPrec _ FormatD24UnormS8Uint = showString "FormatD24UnormS8Uint"
+  showsPrec _ FormatD32SfloatS8Uint = showString "FormatD32SfloatS8Uint"
+  showsPrec _ FormatBc1RgbUnormBlock = showString "FormatBc1RgbUnormBlock"
+  showsPrec _ FormatBc1RgbSrgbBlock = showString "FormatBc1RgbSrgbBlock"
+  showsPrec _ FormatBc1RgbaUnormBlock = showString "FormatBc1RgbaUnormBlock"
+  showsPrec _ FormatBc1RgbaSrgbBlock = showString "FormatBc1RgbaSrgbBlock"
+  showsPrec _ FormatBc2UnormBlock = showString "FormatBc2UnormBlock"
+  showsPrec _ FormatBc2SrgbBlock = showString "FormatBc2SrgbBlock"
+  showsPrec _ FormatBc3UnormBlock = showString "FormatBc3UnormBlock"
+  showsPrec _ FormatBc3SrgbBlock = showString "FormatBc3SrgbBlock"
+  showsPrec _ FormatBc4UnormBlock = showString "FormatBc4UnormBlock"
+  showsPrec _ FormatBc4SnormBlock = showString "FormatBc4SnormBlock"
+  showsPrec _ FormatBc5UnormBlock = showString "FormatBc5UnormBlock"
+  showsPrec _ FormatBc5SnormBlock = showString "FormatBc5SnormBlock"
+  showsPrec _ FormatBc6hUfloatBlock = showString "FormatBc6hUfloatBlock"
+  showsPrec _ FormatBc6hSfloatBlock = showString "FormatBc6hSfloatBlock"
+  showsPrec _ FormatBc7UnormBlock = showString "FormatBc7UnormBlock"
+  showsPrec _ FormatBc7SrgbBlock = showString "FormatBc7SrgbBlock"
+  showsPrec _ FormatEtc2R8g8b8UnormBlock = showString "FormatEtc2R8g8b8UnormBlock"
+  showsPrec _ FormatEtc2R8g8b8SrgbBlock = showString "FormatEtc2R8g8b8SrgbBlock"
+  showsPrec _ FormatEtc2R8g8b8a1UnormBlock = showString "FormatEtc2R8g8b8a1UnormBlock"
+  showsPrec _ FormatEtc2R8g8b8a1SrgbBlock = showString "FormatEtc2R8g8b8a1SrgbBlock"
+  showsPrec _ FormatEtc2R8g8b8a8UnormBlock = showString "FormatEtc2R8g8b8a8UnormBlock"
+  showsPrec _ FormatEtc2R8g8b8a8SrgbBlock = showString "FormatEtc2R8g8b8a8SrgbBlock"
+  showsPrec _ FormatEacR11UnormBlock = showString "FormatEacR11UnormBlock"
+  showsPrec _ FormatEacR11SnormBlock = showString "FormatEacR11SnormBlock"
+  showsPrec _ FormatEacR11g11UnormBlock = showString "FormatEacR11g11UnormBlock"
+  showsPrec _ FormatEacR11g11SnormBlock = showString "FormatEacR11g11SnormBlock"
+  showsPrec _ FormatAstc4x4UnormBlock = showString "FormatAstc4x4UnormBlock"
+  showsPrec _ FormatAstc4x4SrgbBlock = showString "FormatAstc4x4SrgbBlock"
+  showsPrec _ FormatAstc5x4UnormBlock = showString "FormatAstc5x4UnormBlock"
+  showsPrec _ FormatAstc5x4SrgbBlock = showString "FormatAstc5x4SrgbBlock"
+  showsPrec _ FormatAstc5x5UnormBlock = showString "FormatAstc5x5UnormBlock"
+  showsPrec _ FormatAstc5x5SrgbBlock = showString "FormatAstc5x5SrgbBlock"
+  showsPrec _ FormatAstc6x5UnormBlock = showString "FormatAstc6x5UnormBlock"
+  showsPrec _ FormatAstc6x5SrgbBlock = showString "FormatAstc6x5SrgbBlock"
+  showsPrec _ FormatAstc6x6UnormBlock = showString "FormatAstc6x6UnormBlock"
+  showsPrec _ FormatAstc6x6SrgbBlock = showString "FormatAstc6x6SrgbBlock"
+  showsPrec _ FormatAstc8x5UnormBlock = showString "FormatAstc8x5UnormBlock"
+  showsPrec _ FormatAstc8x5SrgbBlock = showString "FormatAstc8x5SrgbBlock"
+  showsPrec _ FormatAstc8x6UnormBlock = showString "FormatAstc8x6UnormBlock"
+  showsPrec _ FormatAstc8x6SrgbBlock = showString "FormatAstc8x6SrgbBlock"
+  showsPrec _ FormatAstc8x8UnormBlock = showString "FormatAstc8x8UnormBlock"
+  showsPrec _ FormatAstc8x8SrgbBlock = showString "FormatAstc8x8SrgbBlock"
+  showsPrec _ FormatAstc10x5UnormBlock = showString "FormatAstc10x5UnormBlock"
+  showsPrec _ FormatAstc10x5SrgbBlock = showString "FormatAstc10x5SrgbBlock"
+  showsPrec _ FormatAstc10x6UnormBlock = showString "FormatAstc10x6UnormBlock"
+  showsPrec _ FormatAstc10x6SrgbBlock = showString "FormatAstc10x6SrgbBlock"
+  showsPrec _ FormatAstc10x8UnormBlock = showString "FormatAstc10x8UnormBlock"
+  showsPrec _ FormatAstc10x8SrgbBlock = showString "FormatAstc10x8SrgbBlock"
+  showsPrec _ FormatAstc10x10UnormBlock = showString "FormatAstc10x10UnormBlock"
+  showsPrec _ FormatAstc10x10SrgbBlock = showString "FormatAstc10x10SrgbBlock"
+  showsPrec _ FormatAstc12x10UnormBlock = showString "FormatAstc12x10UnormBlock"
+  showsPrec _ FormatAstc12x10SrgbBlock = showString "FormatAstc12x10SrgbBlock"
+  showsPrec _ FormatAstc12x12UnormBlock = showString "FormatAstc12x12UnormBlock"
+  showsPrec _ FormatAstc12x12SrgbBlock = showString "FormatAstc12x12SrgbBlock"
   showsPrec p (Format x) = showParen (p >= 11) (showString "Format " . showsPrec 11 x)
 
 instance Read Format where
-  readPrec = parens ( choose [ ("VK_FORMAT_UNDEFINED", pure VK_FORMAT_UNDEFINED)
-                             , ("VK_FORMAT_R4G4_UNORM_PACK8", pure VK_FORMAT_R4G4_UNORM_PACK8)
-                             , ("VK_FORMAT_R4G4B4A4_UNORM_PACK16", pure VK_FORMAT_R4G4B4A4_UNORM_PACK16)
-                             , ("VK_FORMAT_B4G4R4A4_UNORM_PACK16", pure VK_FORMAT_B4G4R4A4_UNORM_PACK16)
-                             , ("VK_FORMAT_R5G6B5_UNORM_PACK16", pure VK_FORMAT_R5G6B5_UNORM_PACK16)
-                             , ("VK_FORMAT_B5G6R5_UNORM_PACK16", pure VK_FORMAT_B5G6R5_UNORM_PACK16)
-                             , ("VK_FORMAT_R5G5B5A1_UNORM_PACK16", pure VK_FORMAT_R5G5B5A1_UNORM_PACK16)
-                             , ("VK_FORMAT_B5G5R5A1_UNORM_PACK16", pure VK_FORMAT_B5G5R5A1_UNORM_PACK16)
-                             , ("VK_FORMAT_A1R5G5B5_UNORM_PACK16", pure VK_FORMAT_A1R5G5B5_UNORM_PACK16)
-                             , ("VK_FORMAT_R8_UNORM", pure VK_FORMAT_R8_UNORM)
-                             , ("VK_FORMAT_R8_SNORM", pure VK_FORMAT_R8_SNORM)
-                             , ("VK_FORMAT_R8_USCALED", pure VK_FORMAT_R8_USCALED)
-                             , ("VK_FORMAT_R8_SSCALED", pure VK_FORMAT_R8_SSCALED)
-                             , ("VK_FORMAT_R8_UINT", pure VK_FORMAT_R8_UINT)
-                             , ("VK_FORMAT_R8_SINT", pure VK_FORMAT_R8_SINT)
-                             , ("VK_FORMAT_R8_SRGB", pure VK_FORMAT_R8_SRGB)
-                             , ("VK_FORMAT_R8G8_UNORM", pure VK_FORMAT_R8G8_UNORM)
-                             , ("VK_FORMAT_R8G8_SNORM", pure VK_FORMAT_R8G8_SNORM)
-                             , ("VK_FORMAT_R8G8_USCALED", pure VK_FORMAT_R8G8_USCALED)
-                             , ("VK_FORMAT_R8G8_SSCALED", pure VK_FORMAT_R8G8_SSCALED)
-                             , ("VK_FORMAT_R8G8_UINT", pure VK_FORMAT_R8G8_UINT)
-                             , ("VK_FORMAT_R8G8_SINT", pure VK_FORMAT_R8G8_SINT)
-                             , ("VK_FORMAT_R8G8_SRGB", pure VK_FORMAT_R8G8_SRGB)
-                             , ("VK_FORMAT_R8G8B8_UNORM", pure VK_FORMAT_R8G8B8_UNORM)
-                             , ("VK_FORMAT_R8G8B8_SNORM", pure VK_FORMAT_R8G8B8_SNORM)
-                             , ("VK_FORMAT_R8G8B8_USCALED", pure VK_FORMAT_R8G8B8_USCALED)
-                             , ("VK_FORMAT_R8G8B8_SSCALED", pure VK_FORMAT_R8G8B8_SSCALED)
-                             , ("VK_FORMAT_R8G8B8_UINT", pure VK_FORMAT_R8G8B8_UINT)
-                             , ("VK_FORMAT_R8G8B8_SINT", pure VK_FORMAT_R8G8B8_SINT)
-                             , ("VK_FORMAT_R8G8B8_SRGB", pure VK_FORMAT_R8G8B8_SRGB)
-                             , ("VK_FORMAT_B8G8R8_UNORM", pure VK_FORMAT_B8G8R8_UNORM)
-                             , ("VK_FORMAT_B8G8R8_SNORM", pure VK_FORMAT_B8G8R8_SNORM)
-                             , ("VK_FORMAT_B8G8R8_USCALED", pure VK_FORMAT_B8G8R8_USCALED)
-                             , ("VK_FORMAT_B8G8R8_SSCALED", pure VK_FORMAT_B8G8R8_SSCALED)
-                             , ("VK_FORMAT_B8G8R8_UINT", pure VK_FORMAT_B8G8R8_UINT)
-                             , ("VK_FORMAT_B8G8R8_SINT", pure VK_FORMAT_B8G8R8_SINT)
-                             , ("VK_FORMAT_B8G8R8_SRGB", pure VK_FORMAT_B8G8R8_SRGB)
-                             , ("VK_FORMAT_R8G8B8A8_UNORM", pure VK_FORMAT_R8G8B8A8_UNORM)
-                             , ("VK_FORMAT_R8G8B8A8_SNORM", pure VK_FORMAT_R8G8B8A8_SNORM)
-                             , ("VK_FORMAT_R8G8B8A8_USCALED", pure VK_FORMAT_R8G8B8A8_USCALED)
-                             , ("VK_FORMAT_R8G8B8A8_SSCALED", pure VK_FORMAT_R8G8B8A8_SSCALED)
-                             , ("VK_FORMAT_R8G8B8A8_UINT", pure VK_FORMAT_R8G8B8A8_UINT)
-                             , ("VK_FORMAT_R8G8B8A8_SINT", pure VK_FORMAT_R8G8B8A8_SINT)
-                             , ("VK_FORMAT_R8G8B8A8_SRGB", pure VK_FORMAT_R8G8B8A8_SRGB)
-                             , ("VK_FORMAT_B8G8R8A8_UNORM", pure VK_FORMAT_B8G8R8A8_UNORM)
-                             , ("VK_FORMAT_B8G8R8A8_SNORM", pure VK_FORMAT_B8G8R8A8_SNORM)
-                             , ("VK_FORMAT_B8G8R8A8_USCALED", pure VK_FORMAT_B8G8R8A8_USCALED)
-                             , ("VK_FORMAT_B8G8R8A8_SSCALED", pure VK_FORMAT_B8G8R8A8_SSCALED)
-                             , ("VK_FORMAT_B8G8R8A8_UINT", pure VK_FORMAT_B8G8R8A8_UINT)
-                             , ("VK_FORMAT_B8G8R8A8_SINT", pure VK_FORMAT_B8G8R8A8_SINT)
-                             , ("VK_FORMAT_B8G8R8A8_SRGB", pure VK_FORMAT_B8G8R8A8_SRGB)
-                             , ("VK_FORMAT_A8B8G8R8_UNORM_PACK32", pure VK_FORMAT_A8B8G8R8_UNORM_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_SNORM_PACK32", pure VK_FORMAT_A8B8G8R8_SNORM_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_USCALED_PACK32", pure VK_FORMAT_A8B8G8R8_USCALED_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_SSCALED_PACK32", pure VK_FORMAT_A8B8G8R8_SSCALED_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_UINT_PACK32", pure VK_FORMAT_A8B8G8R8_UINT_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_SINT_PACK32", pure VK_FORMAT_A8B8G8R8_SINT_PACK32)
-                             , ("VK_FORMAT_A8B8G8R8_SRGB_PACK32", pure VK_FORMAT_A8B8G8R8_SRGB_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_UNORM_PACK32", pure VK_FORMAT_A2R10G10B10_UNORM_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_SNORM_PACK32", pure VK_FORMAT_A2R10G10B10_SNORM_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_USCALED_PACK32", pure VK_FORMAT_A2R10G10B10_USCALED_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_SSCALED_PACK32", pure VK_FORMAT_A2R10G10B10_SSCALED_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_UINT_PACK32", pure VK_FORMAT_A2R10G10B10_UINT_PACK32)
-                             , ("VK_FORMAT_A2R10G10B10_SINT_PACK32", pure VK_FORMAT_A2R10G10B10_SINT_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_UNORM_PACK32", pure VK_FORMAT_A2B10G10R10_UNORM_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_SNORM_PACK32", pure VK_FORMAT_A2B10G10R10_SNORM_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_USCALED_PACK32", pure VK_FORMAT_A2B10G10R10_USCALED_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_SSCALED_PACK32", pure VK_FORMAT_A2B10G10R10_SSCALED_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_UINT_PACK32", pure VK_FORMAT_A2B10G10R10_UINT_PACK32)
-                             , ("VK_FORMAT_A2B10G10R10_SINT_PACK32", pure VK_FORMAT_A2B10G10R10_SINT_PACK32)
-                             , ("VK_FORMAT_R16_UNORM", pure VK_FORMAT_R16_UNORM)
-                             , ("VK_FORMAT_R16_SNORM", pure VK_FORMAT_R16_SNORM)
-                             , ("VK_FORMAT_R16_USCALED", pure VK_FORMAT_R16_USCALED)
-                             , ("VK_FORMAT_R16_SSCALED", pure VK_FORMAT_R16_SSCALED)
-                             , ("VK_FORMAT_R16_UINT", pure VK_FORMAT_R16_UINT)
-                             , ("VK_FORMAT_R16_SINT", pure VK_FORMAT_R16_SINT)
-                             , ("VK_FORMAT_R16_SFLOAT", pure VK_FORMAT_R16_SFLOAT)
-                             , ("VK_FORMAT_R16G16_UNORM", pure VK_FORMAT_R16G16_UNORM)
-                             , ("VK_FORMAT_R16G16_SNORM", pure VK_FORMAT_R16G16_SNORM)
-                             , ("VK_FORMAT_R16G16_USCALED", pure VK_FORMAT_R16G16_USCALED)
-                             , ("VK_FORMAT_R16G16_SSCALED", pure VK_FORMAT_R16G16_SSCALED)
-                             , ("VK_FORMAT_R16G16_UINT", pure VK_FORMAT_R16G16_UINT)
-                             , ("VK_FORMAT_R16G16_SINT", pure VK_FORMAT_R16G16_SINT)
-                             , ("VK_FORMAT_R16G16_SFLOAT", pure VK_FORMAT_R16G16_SFLOAT)
-                             , ("VK_FORMAT_R16G16B16_UNORM", pure VK_FORMAT_R16G16B16_UNORM)
-                             , ("VK_FORMAT_R16G16B16_SNORM", pure VK_FORMAT_R16G16B16_SNORM)
-                             , ("VK_FORMAT_R16G16B16_USCALED", pure VK_FORMAT_R16G16B16_USCALED)
-                             , ("VK_FORMAT_R16G16B16_SSCALED", pure VK_FORMAT_R16G16B16_SSCALED)
-                             , ("VK_FORMAT_R16G16B16_UINT", pure VK_FORMAT_R16G16B16_UINT)
-                             , ("VK_FORMAT_R16G16B16_SINT", pure VK_FORMAT_R16G16B16_SINT)
-                             , ("VK_FORMAT_R16G16B16_SFLOAT", pure VK_FORMAT_R16G16B16_SFLOAT)
-                             , ("VK_FORMAT_R16G16B16A16_UNORM", pure VK_FORMAT_R16G16B16A16_UNORM)
-                             , ("VK_FORMAT_R16G16B16A16_SNORM", pure VK_FORMAT_R16G16B16A16_SNORM)
-                             , ("VK_FORMAT_R16G16B16A16_USCALED", pure VK_FORMAT_R16G16B16A16_USCALED)
-                             , ("VK_FORMAT_R16G16B16A16_SSCALED", pure VK_FORMAT_R16G16B16A16_SSCALED)
-                             , ("VK_FORMAT_R16G16B16A16_UINT", pure VK_FORMAT_R16G16B16A16_UINT)
-                             , ("VK_FORMAT_R16G16B16A16_SINT", pure VK_FORMAT_R16G16B16A16_SINT)
-                             , ("VK_FORMAT_R16G16B16A16_SFLOAT", pure VK_FORMAT_R16G16B16A16_SFLOAT)
-                             , ("VK_FORMAT_R32_UINT", pure VK_FORMAT_R32_UINT)
-                             , ("VK_FORMAT_R32_SINT", pure VK_FORMAT_R32_SINT)
-                             , ("VK_FORMAT_R32_SFLOAT", pure VK_FORMAT_R32_SFLOAT)
-                             , ("VK_FORMAT_R32G32_UINT", pure VK_FORMAT_R32G32_UINT)
-                             , ("VK_FORMAT_R32G32_SINT", pure VK_FORMAT_R32G32_SINT)
-                             , ("VK_FORMAT_R32G32_SFLOAT", pure VK_FORMAT_R32G32_SFLOAT)
-                             , ("VK_FORMAT_R32G32B32_UINT", pure VK_FORMAT_R32G32B32_UINT)
-                             , ("VK_FORMAT_R32G32B32_SINT", pure VK_FORMAT_R32G32B32_SINT)
-                             , ("VK_FORMAT_R32G32B32_SFLOAT", pure VK_FORMAT_R32G32B32_SFLOAT)
-                             , ("VK_FORMAT_R32G32B32A32_UINT", pure VK_FORMAT_R32G32B32A32_UINT)
-                             , ("VK_FORMAT_R32G32B32A32_SINT", pure VK_FORMAT_R32G32B32A32_SINT)
-                             , ("VK_FORMAT_R32G32B32A32_SFLOAT", pure VK_FORMAT_R32G32B32A32_SFLOAT)
-                             , ("VK_FORMAT_R64_UINT", pure VK_FORMAT_R64_UINT)
-                             , ("VK_FORMAT_R64_SINT", pure VK_FORMAT_R64_SINT)
-                             , ("VK_FORMAT_R64_SFLOAT", pure VK_FORMAT_R64_SFLOAT)
-                             , ("VK_FORMAT_R64G64_UINT", pure VK_FORMAT_R64G64_UINT)
-                             , ("VK_FORMAT_R64G64_SINT", pure VK_FORMAT_R64G64_SINT)
-                             , ("VK_FORMAT_R64G64_SFLOAT", pure VK_FORMAT_R64G64_SFLOAT)
-                             , ("VK_FORMAT_R64G64B64_UINT", pure VK_FORMAT_R64G64B64_UINT)
-                             , ("VK_FORMAT_R64G64B64_SINT", pure VK_FORMAT_R64G64B64_SINT)
-                             , ("VK_FORMAT_R64G64B64_SFLOAT", pure VK_FORMAT_R64G64B64_SFLOAT)
-                             , ("VK_FORMAT_R64G64B64A64_UINT", pure VK_FORMAT_R64G64B64A64_UINT)
-                             , ("VK_FORMAT_R64G64B64A64_SINT", pure VK_FORMAT_R64G64B64A64_SINT)
-                             , ("VK_FORMAT_R64G64B64A64_SFLOAT", pure VK_FORMAT_R64G64B64A64_SFLOAT)
-                             , ("VK_FORMAT_B10G11R11_UFLOAT_PACK32", pure VK_FORMAT_B10G11R11_UFLOAT_PACK32)
-                             , ("VK_FORMAT_E5B9G9R9_UFLOAT_PACK32", pure VK_FORMAT_E5B9G9R9_UFLOAT_PACK32)
-                             , ("VK_FORMAT_D16_UNORM", pure VK_FORMAT_D16_UNORM)
-                             , ("VK_FORMAT_X8_D24_UNORM_PACK32", pure VK_FORMAT_X8_D24_UNORM_PACK32)
-                             , ("VK_FORMAT_D32_SFLOAT", pure VK_FORMAT_D32_SFLOAT)
-                             , ("VK_FORMAT_S8_UINT", pure VK_FORMAT_S8_UINT)
-                             , ("VK_FORMAT_D16_UNORM_S8_UINT", pure VK_FORMAT_D16_UNORM_S8_UINT)
-                             , ("VK_FORMAT_D24_UNORM_S8_UINT", pure VK_FORMAT_D24_UNORM_S8_UINT)
-                             , ("VK_FORMAT_D32_SFLOAT_S8_UINT", pure VK_FORMAT_D32_SFLOAT_S8_UINT)
-                             , ("VK_FORMAT_BC1_RGB_UNORM_BLOCK", pure VK_FORMAT_BC1_RGB_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC1_RGB_SRGB_BLOCK", pure VK_FORMAT_BC1_RGB_SRGB_BLOCK)
-                             , ("VK_FORMAT_BC1_RGBA_UNORM_BLOCK", pure VK_FORMAT_BC1_RGBA_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC1_RGBA_SRGB_BLOCK", pure VK_FORMAT_BC1_RGBA_SRGB_BLOCK)
-                             , ("VK_FORMAT_BC2_UNORM_BLOCK", pure VK_FORMAT_BC2_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC2_SRGB_BLOCK", pure VK_FORMAT_BC2_SRGB_BLOCK)
-                             , ("VK_FORMAT_BC3_UNORM_BLOCK", pure VK_FORMAT_BC3_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC3_SRGB_BLOCK", pure VK_FORMAT_BC3_SRGB_BLOCK)
-                             , ("VK_FORMAT_BC4_UNORM_BLOCK", pure VK_FORMAT_BC4_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC4_SNORM_BLOCK", pure VK_FORMAT_BC4_SNORM_BLOCK)
-                             , ("VK_FORMAT_BC5_UNORM_BLOCK", pure VK_FORMAT_BC5_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC5_SNORM_BLOCK", pure VK_FORMAT_BC5_SNORM_BLOCK)
-                             , ("VK_FORMAT_BC6H_UFLOAT_BLOCK", pure VK_FORMAT_BC6H_UFLOAT_BLOCK)
-                             , ("VK_FORMAT_BC6H_SFLOAT_BLOCK", pure VK_FORMAT_BC6H_SFLOAT_BLOCK)
-                             , ("VK_FORMAT_BC7_UNORM_BLOCK", pure VK_FORMAT_BC7_UNORM_BLOCK)
-                             , ("VK_FORMAT_BC7_SRGB_BLOCK", pure VK_FORMAT_BC7_SRGB_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK", pure VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK", pure VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK", pure VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK", pure VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK", pure VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK)
-                             , ("VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK", pure VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK)
-                             , ("VK_FORMAT_EAC_R11_UNORM_BLOCK", pure VK_FORMAT_EAC_R11_UNORM_BLOCK)
-                             , ("VK_FORMAT_EAC_R11_SNORM_BLOCK", pure VK_FORMAT_EAC_R11_SNORM_BLOCK)
-                             , ("VK_FORMAT_EAC_R11G11_UNORM_BLOCK", pure VK_FORMAT_EAC_R11G11_UNORM_BLOCK)
-                             , ("VK_FORMAT_EAC_R11G11_SNORM_BLOCK", pure VK_FORMAT_EAC_R11G11_SNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_4x4_UNORM_BLOCK", pure VK_FORMAT_ASTC_4x4_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_4x4_SRGB_BLOCK", pure VK_FORMAT_ASTC_4x4_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_5x4_UNORM_BLOCK", pure VK_FORMAT_ASTC_5x4_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_5x4_SRGB_BLOCK", pure VK_FORMAT_ASTC_5x4_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_5x5_UNORM_BLOCK", pure VK_FORMAT_ASTC_5x5_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_5x5_SRGB_BLOCK", pure VK_FORMAT_ASTC_5x5_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_6x5_UNORM_BLOCK", pure VK_FORMAT_ASTC_6x5_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_6x5_SRGB_BLOCK", pure VK_FORMAT_ASTC_6x5_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_6x6_UNORM_BLOCK", pure VK_FORMAT_ASTC_6x6_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_6x6_SRGB_BLOCK", pure VK_FORMAT_ASTC_6x6_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x5_UNORM_BLOCK", pure VK_FORMAT_ASTC_8x5_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x5_SRGB_BLOCK", pure VK_FORMAT_ASTC_8x5_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x6_UNORM_BLOCK", pure VK_FORMAT_ASTC_8x6_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x6_SRGB_BLOCK", pure VK_FORMAT_ASTC_8x6_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x8_UNORM_BLOCK", pure VK_FORMAT_ASTC_8x8_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_8x8_SRGB_BLOCK", pure VK_FORMAT_ASTC_8x8_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x5_UNORM_BLOCK", pure VK_FORMAT_ASTC_10x5_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x5_SRGB_BLOCK", pure VK_FORMAT_ASTC_10x5_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x6_UNORM_BLOCK", pure VK_FORMAT_ASTC_10x6_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x6_SRGB_BLOCK", pure VK_FORMAT_ASTC_10x6_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x8_UNORM_BLOCK", pure VK_FORMAT_ASTC_10x8_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x8_SRGB_BLOCK", pure VK_FORMAT_ASTC_10x8_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x10_UNORM_BLOCK", pure VK_FORMAT_ASTC_10x10_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_10x10_SRGB_BLOCK", pure VK_FORMAT_ASTC_10x10_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_12x10_UNORM_BLOCK", pure VK_FORMAT_ASTC_12x10_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_12x10_SRGB_BLOCK", pure VK_FORMAT_ASTC_12x10_SRGB_BLOCK)
-                             , ("VK_FORMAT_ASTC_12x12_UNORM_BLOCK", pure VK_FORMAT_ASTC_12x12_UNORM_BLOCK)
-                             , ("VK_FORMAT_ASTC_12x12_SRGB_BLOCK", pure VK_FORMAT_ASTC_12x12_SRGB_BLOCK)
+  readPrec = parens ( choose [ ("FormatUndefined", pure FormatUndefined)
+                             , ("FormatR4g4UnormPack8", pure FormatR4g4UnormPack8)
+                             , ("FormatR4g4b4a4UnormPack16", pure FormatR4g4b4a4UnormPack16)
+                             , ("FormatB4g4r4a4UnormPack16", pure FormatB4g4r4a4UnormPack16)
+                             , ("FormatR5g6b5UnormPack16", pure FormatR5g6b5UnormPack16)
+                             , ("FormatB5g6r5UnormPack16", pure FormatB5g6r5UnormPack16)
+                             , ("FormatR5g5b5a1UnormPack16", pure FormatR5g5b5a1UnormPack16)
+                             , ("FormatB5g5r5a1UnormPack16", pure FormatB5g5r5a1UnormPack16)
+                             , ("FormatA1r5g5b5UnormPack16", pure FormatA1r5g5b5UnormPack16)
+                             , ("FormatR8Unorm", pure FormatR8Unorm)
+                             , ("FormatR8Snorm", pure FormatR8Snorm)
+                             , ("FormatR8Uscaled", pure FormatR8Uscaled)
+                             , ("FormatR8Sscaled", pure FormatR8Sscaled)
+                             , ("FormatR8Uint", pure FormatR8Uint)
+                             , ("FormatR8Sint", pure FormatR8Sint)
+                             , ("FormatR8Srgb", pure FormatR8Srgb)
+                             , ("FormatR8g8Unorm", pure FormatR8g8Unorm)
+                             , ("FormatR8g8Snorm", pure FormatR8g8Snorm)
+                             , ("FormatR8g8Uscaled", pure FormatR8g8Uscaled)
+                             , ("FormatR8g8Sscaled", pure FormatR8g8Sscaled)
+                             , ("FormatR8g8Uint", pure FormatR8g8Uint)
+                             , ("FormatR8g8Sint", pure FormatR8g8Sint)
+                             , ("FormatR8g8Srgb", pure FormatR8g8Srgb)
+                             , ("FormatR8g8b8Unorm", pure FormatR8g8b8Unorm)
+                             , ("FormatR8g8b8Snorm", pure FormatR8g8b8Snorm)
+                             , ("FormatR8g8b8Uscaled", pure FormatR8g8b8Uscaled)
+                             , ("FormatR8g8b8Sscaled", pure FormatR8g8b8Sscaled)
+                             , ("FormatR8g8b8Uint", pure FormatR8g8b8Uint)
+                             , ("FormatR8g8b8Sint", pure FormatR8g8b8Sint)
+                             , ("FormatR8g8b8Srgb", pure FormatR8g8b8Srgb)
+                             , ("FormatB8g8r8Unorm", pure FormatB8g8r8Unorm)
+                             , ("FormatB8g8r8Snorm", pure FormatB8g8r8Snorm)
+                             , ("FormatB8g8r8Uscaled", pure FormatB8g8r8Uscaled)
+                             , ("FormatB8g8r8Sscaled", pure FormatB8g8r8Sscaled)
+                             , ("FormatB8g8r8Uint", pure FormatB8g8r8Uint)
+                             , ("FormatB8g8r8Sint", pure FormatB8g8r8Sint)
+                             , ("FormatB8g8r8Srgb", pure FormatB8g8r8Srgb)
+                             , ("FormatR8g8b8a8Unorm", pure FormatR8g8b8a8Unorm)
+                             , ("FormatR8g8b8a8Snorm", pure FormatR8g8b8a8Snorm)
+                             , ("FormatR8g8b8a8Uscaled", pure FormatR8g8b8a8Uscaled)
+                             , ("FormatR8g8b8a8Sscaled", pure FormatR8g8b8a8Sscaled)
+                             , ("FormatR8g8b8a8Uint", pure FormatR8g8b8a8Uint)
+                             , ("FormatR8g8b8a8Sint", pure FormatR8g8b8a8Sint)
+                             , ("FormatR8g8b8a8Srgb", pure FormatR8g8b8a8Srgb)
+                             , ("FormatB8g8r8a8Unorm", pure FormatB8g8r8a8Unorm)
+                             , ("FormatB8g8r8a8Snorm", pure FormatB8g8r8a8Snorm)
+                             , ("FormatB8g8r8a8Uscaled", pure FormatB8g8r8a8Uscaled)
+                             , ("FormatB8g8r8a8Sscaled", pure FormatB8g8r8a8Sscaled)
+                             , ("FormatB8g8r8a8Uint", pure FormatB8g8r8a8Uint)
+                             , ("FormatB8g8r8a8Sint", pure FormatB8g8r8a8Sint)
+                             , ("FormatB8g8r8a8Srgb", pure FormatB8g8r8a8Srgb)
+                             , ("FormatA8b8g8r8UnormPack32", pure FormatA8b8g8r8UnormPack32)
+                             , ("FormatA8b8g8r8SnormPack32", pure FormatA8b8g8r8SnormPack32)
+                             , ("FormatA8b8g8r8UscaledPack32", pure FormatA8b8g8r8UscaledPack32)
+                             , ("FormatA8b8g8r8SscaledPack32", pure FormatA8b8g8r8SscaledPack32)
+                             , ("FormatA8b8g8r8UintPack32", pure FormatA8b8g8r8UintPack32)
+                             , ("FormatA8b8g8r8SintPack32", pure FormatA8b8g8r8SintPack32)
+                             , ("FormatA8b8g8r8SrgbPack32", pure FormatA8b8g8r8SrgbPack32)
+                             , ("FormatA2r10g10b10UnormPack32", pure FormatA2r10g10b10UnormPack32)
+                             , ("FormatA2r10g10b10SnormPack32", pure FormatA2r10g10b10SnormPack32)
+                             , ("FormatA2r10g10b10UscaledPack32", pure FormatA2r10g10b10UscaledPack32)
+                             , ("FormatA2r10g10b10SscaledPack32", pure FormatA2r10g10b10SscaledPack32)
+                             , ("FormatA2r10g10b10UintPack32", pure FormatA2r10g10b10UintPack32)
+                             , ("FormatA2r10g10b10SintPack32", pure FormatA2r10g10b10SintPack32)
+                             , ("FormatA2b10g10r10UnormPack32", pure FormatA2b10g10r10UnormPack32)
+                             , ("FormatA2b10g10r10SnormPack32", pure FormatA2b10g10r10SnormPack32)
+                             , ("FormatA2b10g10r10UscaledPack32", pure FormatA2b10g10r10UscaledPack32)
+                             , ("FormatA2b10g10r10SscaledPack32", pure FormatA2b10g10r10SscaledPack32)
+                             , ("FormatA2b10g10r10UintPack32", pure FormatA2b10g10r10UintPack32)
+                             , ("FormatA2b10g10r10SintPack32", pure FormatA2b10g10r10SintPack32)
+                             , ("FormatR16Unorm", pure FormatR16Unorm)
+                             , ("FormatR16Snorm", pure FormatR16Snorm)
+                             , ("FormatR16Uscaled", pure FormatR16Uscaled)
+                             , ("FormatR16Sscaled", pure FormatR16Sscaled)
+                             , ("FormatR16Uint", pure FormatR16Uint)
+                             , ("FormatR16Sint", pure FormatR16Sint)
+                             , ("FormatR16Sfloat", pure FormatR16Sfloat)
+                             , ("FormatR16g16Unorm", pure FormatR16g16Unorm)
+                             , ("FormatR16g16Snorm", pure FormatR16g16Snorm)
+                             , ("FormatR16g16Uscaled", pure FormatR16g16Uscaled)
+                             , ("FormatR16g16Sscaled", pure FormatR16g16Sscaled)
+                             , ("FormatR16g16Uint", pure FormatR16g16Uint)
+                             , ("FormatR16g16Sint", pure FormatR16g16Sint)
+                             , ("FormatR16g16Sfloat", pure FormatR16g16Sfloat)
+                             , ("FormatR16g16b16Unorm", pure FormatR16g16b16Unorm)
+                             , ("FormatR16g16b16Snorm", pure FormatR16g16b16Snorm)
+                             , ("FormatR16g16b16Uscaled", pure FormatR16g16b16Uscaled)
+                             , ("FormatR16g16b16Sscaled", pure FormatR16g16b16Sscaled)
+                             , ("FormatR16g16b16Uint", pure FormatR16g16b16Uint)
+                             , ("FormatR16g16b16Sint", pure FormatR16g16b16Sint)
+                             , ("FormatR16g16b16Sfloat", pure FormatR16g16b16Sfloat)
+                             , ("FormatR16g16b16a16Unorm", pure FormatR16g16b16a16Unorm)
+                             , ("FormatR16g16b16a16Snorm", pure FormatR16g16b16a16Snorm)
+                             , ("FormatR16g16b16a16Uscaled", pure FormatR16g16b16a16Uscaled)
+                             , ("FormatR16g16b16a16Sscaled", pure FormatR16g16b16a16Sscaled)
+                             , ("FormatR16g16b16a16Uint", pure FormatR16g16b16a16Uint)
+                             , ("FormatR16g16b16a16Sint", pure FormatR16g16b16a16Sint)
+                             , ("FormatR16g16b16a16Sfloat", pure FormatR16g16b16a16Sfloat)
+                             , ("FormatR32Uint", pure FormatR32Uint)
+                             , ("FormatR32Sint", pure FormatR32Sint)
+                             , ("FormatR32Sfloat", pure FormatR32Sfloat)
+                             , ("FormatR32g32Uint", pure FormatR32g32Uint)
+                             , ("FormatR32g32Sint", pure FormatR32g32Sint)
+                             , ("FormatR32g32Sfloat", pure FormatR32g32Sfloat)
+                             , ("FormatR32g32b32Uint", pure FormatR32g32b32Uint)
+                             , ("FormatR32g32b32Sint", pure FormatR32g32b32Sint)
+                             , ("FormatR32g32b32Sfloat", pure FormatR32g32b32Sfloat)
+                             , ("FormatR32g32b32a32Uint", pure FormatR32g32b32a32Uint)
+                             , ("FormatR32g32b32a32Sint", pure FormatR32g32b32a32Sint)
+                             , ("FormatR32g32b32a32Sfloat", pure FormatR32g32b32a32Sfloat)
+                             , ("FormatR64Uint", pure FormatR64Uint)
+                             , ("FormatR64Sint", pure FormatR64Sint)
+                             , ("FormatR64Sfloat", pure FormatR64Sfloat)
+                             , ("FormatR64g64Uint", pure FormatR64g64Uint)
+                             , ("FormatR64g64Sint", pure FormatR64g64Sint)
+                             , ("FormatR64g64Sfloat", pure FormatR64g64Sfloat)
+                             , ("FormatR64g64b64Uint", pure FormatR64g64b64Uint)
+                             , ("FormatR64g64b64Sint", pure FormatR64g64b64Sint)
+                             , ("FormatR64g64b64Sfloat", pure FormatR64g64b64Sfloat)
+                             , ("FormatR64g64b64a64Uint", pure FormatR64g64b64a64Uint)
+                             , ("FormatR64g64b64a64Sint", pure FormatR64g64b64a64Sint)
+                             , ("FormatR64g64b64a64Sfloat", pure FormatR64g64b64a64Sfloat)
+                             , ("FormatB10g11r11UfloatPack32", pure FormatB10g11r11UfloatPack32)
+                             , ("FormatE5b9g9r9UfloatPack32", pure FormatE5b9g9r9UfloatPack32)
+                             , ("FormatD16Unorm", pure FormatD16Unorm)
+                             , ("FormatX8D24UnormPack32", pure FormatX8D24UnormPack32)
+                             , ("FormatD32Sfloat", pure FormatD32Sfloat)
+                             , ("FormatS8Uint", pure FormatS8Uint)
+                             , ("FormatD16UnormS8Uint", pure FormatD16UnormS8Uint)
+                             , ("FormatD24UnormS8Uint", pure FormatD24UnormS8Uint)
+                             , ("FormatD32SfloatS8Uint", pure FormatD32SfloatS8Uint)
+                             , ("FormatBc1RgbUnormBlock", pure FormatBc1RgbUnormBlock)
+                             , ("FormatBc1RgbSrgbBlock", pure FormatBc1RgbSrgbBlock)
+                             , ("FormatBc1RgbaUnormBlock", pure FormatBc1RgbaUnormBlock)
+                             , ("FormatBc1RgbaSrgbBlock", pure FormatBc1RgbaSrgbBlock)
+                             , ("FormatBc2UnormBlock", pure FormatBc2UnormBlock)
+                             , ("FormatBc2SrgbBlock", pure FormatBc2SrgbBlock)
+                             , ("FormatBc3UnormBlock", pure FormatBc3UnormBlock)
+                             , ("FormatBc3SrgbBlock", pure FormatBc3SrgbBlock)
+                             , ("FormatBc4UnormBlock", pure FormatBc4UnormBlock)
+                             , ("FormatBc4SnormBlock", pure FormatBc4SnormBlock)
+                             , ("FormatBc5UnormBlock", pure FormatBc5UnormBlock)
+                             , ("FormatBc5SnormBlock", pure FormatBc5SnormBlock)
+                             , ("FormatBc6hUfloatBlock", pure FormatBc6hUfloatBlock)
+                             , ("FormatBc6hSfloatBlock", pure FormatBc6hSfloatBlock)
+                             , ("FormatBc7UnormBlock", pure FormatBc7UnormBlock)
+                             , ("FormatBc7SrgbBlock", pure FormatBc7SrgbBlock)
+                             , ("FormatEtc2R8g8b8UnormBlock", pure FormatEtc2R8g8b8UnormBlock)
+                             , ("FormatEtc2R8g8b8SrgbBlock", pure FormatEtc2R8g8b8SrgbBlock)
+                             , ("FormatEtc2R8g8b8a1UnormBlock", pure FormatEtc2R8g8b8a1UnormBlock)
+                             , ("FormatEtc2R8g8b8a1SrgbBlock", pure FormatEtc2R8g8b8a1SrgbBlock)
+                             , ("FormatEtc2R8g8b8a8UnormBlock", pure FormatEtc2R8g8b8a8UnormBlock)
+                             , ("FormatEtc2R8g8b8a8SrgbBlock", pure FormatEtc2R8g8b8a8SrgbBlock)
+                             , ("FormatEacR11UnormBlock", pure FormatEacR11UnormBlock)
+                             , ("FormatEacR11SnormBlock", pure FormatEacR11SnormBlock)
+                             , ("FormatEacR11g11UnormBlock", pure FormatEacR11g11UnormBlock)
+                             , ("FormatEacR11g11SnormBlock", pure FormatEacR11g11SnormBlock)
+                             , ("FormatAstc4x4UnormBlock", pure FormatAstc4x4UnormBlock)
+                             , ("FormatAstc4x4SrgbBlock", pure FormatAstc4x4SrgbBlock)
+                             , ("FormatAstc5x4UnormBlock", pure FormatAstc5x4UnormBlock)
+                             , ("FormatAstc5x4SrgbBlock", pure FormatAstc5x4SrgbBlock)
+                             , ("FormatAstc5x5UnormBlock", pure FormatAstc5x5UnormBlock)
+                             , ("FormatAstc5x5SrgbBlock", pure FormatAstc5x5SrgbBlock)
+                             , ("FormatAstc6x5UnormBlock", pure FormatAstc6x5UnormBlock)
+                             , ("FormatAstc6x5SrgbBlock", pure FormatAstc6x5SrgbBlock)
+                             , ("FormatAstc6x6UnormBlock", pure FormatAstc6x6UnormBlock)
+                             , ("FormatAstc6x6SrgbBlock", pure FormatAstc6x6SrgbBlock)
+                             , ("FormatAstc8x5UnormBlock", pure FormatAstc8x5UnormBlock)
+                             , ("FormatAstc8x5SrgbBlock", pure FormatAstc8x5SrgbBlock)
+                             , ("FormatAstc8x6UnormBlock", pure FormatAstc8x6UnormBlock)
+                             , ("FormatAstc8x6SrgbBlock", pure FormatAstc8x6SrgbBlock)
+                             , ("FormatAstc8x8UnormBlock", pure FormatAstc8x8UnormBlock)
+                             , ("FormatAstc8x8SrgbBlock", pure FormatAstc8x8SrgbBlock)
+                             , ("FormatAstc10x5UnormBlock", pure FormatAstc10x5UnormBlock)
+                             , ("FormatAstc10x5SrgbBlock", pure FormatAstc10x5SrgbBlock)
+                             , ("FormatAstc10x6UnormBlock", pure FormatAstc10x6UnormBlock)
+                             , ("FormatAstc10x6SrgbBlock", pure FormatAstc10x6SrgbBlock)
+                             , ("FormatAstc10x8UnormBlock", pure FormatAstc10x8UnormBlock)
+                             , ("FormatAstc10x8SrgbBlock", pure FormatAstc10x8SrgbBlock)
+                             , ("FormatAstc10x10UnormBlock", pure FormatAstc10x10UnormBlock)
+                             , ("FormatAstc10x10SrgbBlock", pure FormatAstc10x10SrgbBlock)
+                             , ("FormatAstc12x10UnormBlock", pure FormatAstc12x10UnormBlock)
+                             , ("FormatAstc12x10SrgbBlock", pure FormatAstc12x10SrgbBlock)
+                             , ("FormatAstc12x12UnormBlock", pure FormatAstc12x12UnormBlock)
+                             , ("FormatAstc12x12SrgbBlock", pure FormatAstc12x12SrgbBlock)
                              ] +++
                       prec 10 (do
                         expectP (Ident "Format")
@@ -420,375 +420,375 @@ instance Read Format where
                     )
 
 
-pattern VK_FORMAT_UNDEFINED = Format 0
+pattern FormatUndefined = Format 0
 
-pattern VK_FORMAT_R4G4_UNORM_PACK8 = Format 1
+pattern FormatR4g4UnormPack8 = Format 1
 
-pattern VK_FORMAT_R4G4B4A4_UNORM_PACK16 = Format 2
+pattern FormatR4g4b4a4UnormPack16 = Format 2
 
-pattern VK_FORMAT_B4G4R4A4_UNORM_PACK16 = Format 3
+pattern FormatB4g4r4a4UnormPack16 = Format 3
 
-pattern VK_FORMAT_R5G6B5_UNORM_PACK16 = Format 4
+pattern FormatR5g6b5UnormPack16 = Format 4
 
-pattern VK_FORMAT_B5G6R5_UNORM_PACK16 = Format 5
+pattern FormatB5g6r5UnormPack16 = Format 5
 
-pattern VK_FORMAT_R5G5B5A1_UNORM_PACK16 = Format 6
+pattern FormatR5g5b5a1UnormPack16 = Format 6
 
-pattern VK_FORMAT_B5G5R5A1_UNORM_PACK16 = Format 7
+pattern FormatB5g5r5a1UnormPack16 = Format 7
 
-pattern VK_FORMAT_A1R5G5B5_UNORM_PACK16 = Format 8
+pattern FormatA1r5g5b5UnormPack16 = Format 8
 
-pattern VK_FORMAT_R8_UNORM = Format 9
+pattern FormatR8Unorm = Format 9
 
-pattern VK_FORMAT_R8_SNORM = Format 10
+pattern FormatR8Snorm = Format 10
 
-pattern VK_FORMAT_R8_USCALED = Format 11
+pattern FormatR8Uscaled = Format 11
 
-pattern VK_FORMAT_R8_SSCALED = Format 12
+pattern FormatR8Sscaled = Format 12
 
-pattern VK_FORMAT_R8_UINT = Format 13
+pattern FormatR8Uint = Format 13
 
-pattern VK_FORMAT_R8_SINT = Format 14
+pattern FormatR8Sint = Format 14
 
-pattern VK_FORMAT_R8_SRGB = Format 15
+pattern FormatR8Srgb = Format 15
 
-pattern VK_FORMAT_R8G8_UNORM = Format 16
+pattern FormatR8g8Unorm = Format 16
 
-pattern VK_FORMAT_R8G8_SNORM = Format 17
+pattern FormatR8g8Snorm = Format 17
 
-pattern VK_FORMAT_R8G8_USCALED = Format 18
+pattern FormatR8g8Uscaled = Format 18
 
-pattern VK_FORMAT_R8G8_SSCALED = Format 19
+pattern FormatR8g8Sscaled = Format 19
 
-pattern VK_FORMAT_R8G8_UINT = Format 20
+pattern FormatR8g8Uint = Format 20
 
-pattern VK_FORMAT_R8G8_SINT = Format 21
+pattern FormatR8g8Sint = Format 21
 
-pattern VK_FORMAT_R8G8_SRGB = Format 22
+pattern FormatR8g8Srgb = Format 22
 
-pattern VK_FORMAT_R8G8B8_UNORM = Format 23
+pattern FormatR8g8b8Unorm = Format 23
 
-pattern VK_FORMAT_R8G8B8_SNORM = Format 24
+pattern FormatR8g8b8Snorm = Format 24
 
-pattern VK_FORMAT_R8G8B8_USCALED = Format 25
+pattern FormatR8g8b8Uscaled = Format 25
 
-pattern VK_FORMAT_R8G8B8_SSCALED = Format 26
+pattern FormatR8g8b8Sscaled = Format 26
 
-pattern VK_FORMAT_R8G8B8_UINT = Format 27
+pattern FormatR8g8b8Uint = Format 27
 
-pattern VK_FORMAT_R8G8B8_SINT = Format 28
+pattern FormatR8g8b8Sint = Format 28
 
-pattern VK_FORMAT_R8G8B8_SRGB = Format 29
+pattern FormatR8g8b8Srgb = Format 29
 
-pattern VK_FORMAT_B8G8R8_UNORM = Format 30
+pattern FormatB8g8r8Unorm = Format 30
 
-pattern VK_FORMAT_B8G8R8_SNORM = Format 31
+pattern FormatB8g8r8Snorm = Format 31
 
-pattern VK_FORMAT_B8G8R8_USCALED = Format 32
+pattern FormatB8g8r8Uscaled = Format 32
 
-pattern VK_FORMAT_B8G8R8_SSCALED = Format 33
+pattern FormatB8g8r8Sscaled = Format 33
 
-pattern VK_FORMAT_B8G8R8_UINT = Format 34
+pattern FormatB8g8r8Uint = Format 34
 
-pattern VK_FORMAT_B8G8R8_SINT = Format 35
+pattern FormatB8g8r8Sint = Format 35
 
-pattern VK_FORMAT_B8G8R8_SRGB = Format 36
+pattern FormatB8g8r8Srgb = Format 36
 
-pattern VK_FORMAT_R8G8B8A8_UNORM = Format 37
+pattern FormatR8g8b8a8Unorm = Format 37
 
-pattern VK_FORMAT_R8G8B8A8_SNORM = Format 38
+pattern FormatR8g8b8a8Snorm = Format 38
 
-pattern VK_FORMAT_R8G8B8A8_USCALED = Format 39
+pattern FormatR8g8b8a8Uscaled = Format 39
 
-pattern VK_FORMAT_R8G8B8A8_SSCALED = Format 40
+pattern FormatR8g8b8a8Sscaled = Format 40
 
-pattern VK_FORMAT_R8G8B8A8_UINT = Format 41
+pattern FormatR8g8b8a8Uint = Format 41
 
-pattern VK_FORMAT_R8G8B8A8_SINT = Format 42
+pattern FormatR8g8b8a8Sint = Format 42
 
-pattern VK_FORMAT_R8G8B8A8_SRGB = Format 43
+pattern FormatR8g8b8a8Srgb = Format 43
 
-pattern VK_FORMAT_B8G8R8A8_UNORM = Format 44
+pattern FormatB8g8r8a8Unorm = Format 44
 
-pattern VK_FORMAT_B8G8R8A8_SNORM = Format 45
+pattern FormatB8g8r8a8Snorm = Format 45
 
-pattern VK_FORMAT_B8G8R8A8_USCALED = Format 46
+pattern FormatB8g8r8a8Uscaled = Format 46
 
-pattern VK_FORMAT_B8G8R8A8_SSCALED = Format 47
+pattern FormatB8g8r8a8Sscaled = Format 47
 
-pattern VK_FORMAT_B8G8R8A8_UINT = Format 48
+pattern FormatB8g8r8a8Uint = Format 48
 
-pattern VK_FORMAT_B8G8R8A8_SINT = Format 49
+pattern FormatB8g8r8a8Sint = Format 49
 
-pattern VK_FORMAT_B8G8R8A8_SRGB = Format 50
+pattern FormatB8g8r8a8Srgb = Format 50
 
-pattern VK_FORMAT_A8B8G8R8_UNORM_PACK32 = Format 51
+pattern FormatA8b8g8r8UnormPack32 = Format 51
 
-pattern VK_FORMAT_A8B8G8R8_SNORM_PACK32 = Format 52
+pattern FormatA8b8g8r8SnormPack32 = Format 52
 
-pattern VK_FORMAT_A8B8G8R8_USCALED_PACK32 = Format 53
+pattern FormatA8b8g8r8UscaledPack32 = Format 53
 
-pattern VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = Format 54
+pattern FormatA8b8g8r8SscaledPack32 = Format 54
 
-pattern VK_FORMAT_A8B8G8R8_UINT_PACK32 = Format 55
+pattern FormatA8b8g8r8UintPack32 = Format 55
 
-pattern VK_FORMAT_A8B8G8R8_SINT_PACK32 = Format 56
+pattern FormatA8b8g8r8SintPack32 = Format 56
 
-pattern VK_FORMAT_A8B8G8R8_SRGB_PACK32 = Format 57
+pattern FormatA8b8g8r8SrgbPack32 = Format 57
 
-pattern VK_FORMAT_A2R10G10B10_UNORM_PACK32 = Format 58
+pattern FormatA2r10g10b10UnormPack32 = Format 58
 
-pattern VK_FORMAT_A2R10G10B10_SNORM_PACK32 = Format 59
+pattern FormatA2r10g10b10SnormPack32 = Format 59
 
-pattern VK_FORMAT_A2R10G10B10_USCALED_PACK32 = Format 60
+pattern FormatA2r10g10b10UscaledPack32 = Format 60
 
-pattern VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = Format 61
+pattern FormatA2r10g10b10SscaledPack32 = Format 61
 
-pattern VK_FORMAT_A2R10G10B10_UINT_PACK32 = Format 62
+pattern FormatA2r10g10b10UintPack32 = Format 62
 
-pattern VK_FORMAT_A2R10G10B10_SINT_PACK32 = Format 63
+pattern FormatA2r10g10b10SintPack32 = Format 63
 
-pattern VK_FORMAT_A2B10G10R10_UNORM_PACK32 = Format 64
+pattern FormatA2b10g10r10UnormPack32 = Format 64
 
-pattern VK_FORMAT_A2B10G10R10_SNORM_PACK32 = Format 65
+pattern FormatA2b10g10r10SnormPack32 = Format 65
 
-pattern VK_FORMAT_A2B10G10R10_USCALED_PACK32 = Format 66
+pattern FormatA2b10g10r10UscaledPack32 = Format 66
 
-pattern VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = Format 67
+pattern FormatA2b10g10r10SscaledPack32 = Format 67
 
-pattern VK_FORMAT_A2B10G10R10_UINT_PACK32 = Format 68
+pattern FormatA2b10g10r10UintPack32 = Format 68
 
-pattern VK_FORMAT_A2B10G10R10_SINT_PACK32 = Format 69
+pattern FormatA2b10g10r10SintPack32 = Format 69
 
-pattern VK_FORMAT_R16_UNORM = Format 70
+pattern FormatR16Unorm = Format 70
 
-pattern VK_FORMAT_R16_SNORM = Format 71
+pattern FormatR16Snorm = Format 71
 
-pattern VK_FORMAT_R16_USCALED = Format 72
+pattern FormatR16Uscaled = Format 72
 
-pattern VK_FORMAT_R16_SSCALED = Format 73
+pattern FormatR16Sscaled = Format 73
 
-pattern VK_FORMAT_R16_UINT = Format 74
+pattern FormatR16Uint = Format 74
 
-pattern VK_FORMAT_R16_SINT = Format 75
+pattern FormatR16Sint = Format 75
 
-pattern VK_FORMAT_R16_SFLOAT = Format 76
+pattern FormatR16Sfloat = Format 76
 
-pattern VK_FORMAT_R16G16_UNORM = Format 77
+pattern FormatR16g16Unorm = Format 77
 
-pattern VK_FORMAT_R16G16_SNORM = Format 78
+pattern FormatR16g16Snorm = Format 78
 
-pattern VK_FORMAT_R16G16_USCALED = Format 79
+pattern FormatR16g16Uscaled = Format 79
 
-pattern VK_FORMAT_R16G16_SSCALED = Format 80
+pattern FormatR16g16Sscaled = Format 80
 
-pattern VK_FORMAT_R16G16_UINT = Format 81
+pattern FormatR16g16Uint = Format 81
 
-pattern VK_FORMAT_R16G16_SINT = Format 82
+pattern FormatR16g16Sint = Format 82
 
-pattern VK_FORMAT_R16G16_SFLOAT = Format 83
+pattern FormatR16g16Sfloat = Format 83
 
-pattern VK_FORMAT_R16G16B16_UNORM = Format 84
+pattern FormatR16g16b16Unorm = Format 84
 
-pattern VK_FORMAT_R16G16B16_SNORM = Format 85
+pattern FormatR16g16b16Snorm = Format 85
 
-pattern VK_FORMAT_R16G16B16_USCALED = Format 86
+pattern FormatR16g16b16Uscaled = Format 86
 
-pattern VK_FORMAT_R16G16B16_SSCALED = Format 87
+pattern FormatR16g16b16Sscaled = Format 87
 
-pattern VK_FORMAT_R16G16B16_UINT = Format 88
+pattern FormatR16g16b16Uint = Format 88
 
-pattern VK_FORMAT_R16G16B16_SINT = Format 89
+pattern FormatR16g16b16Sint = Format 89
 
-pattern VK_FORMAT_R16G16B16_SFLOAT = Format 90
+pattern FormatR16g16b16Sfloat = Format 90
 
-pattern VK_FORMAT_R16G16B16A16_UNORM = Format 91
+pattern FormatR16g16b16a16Unorm = Format 91
 
-pattern VK_FORMAT_R16G16B16A16_SNORM = Format 92
+pattern FormatR16g16b16a16Snorm = Format 92
 
-pattern VK_FORMAT_R16G16B16A16_USCALED = Format 93
+pattern FormatR16g16b16a16Uscaled = Format 93
 
-pattern VK_FORMAT_R16G16B16A16_SSCALED = Format 94
+pattern FormatR16g16b16a16Sscaled = Format 94
 
-pattern VK_FORMAT_R16G16B16A16_UINT = Format 95
+pattern FormatR16g16b16a16Uint = Format 95
 
-pattern VK_FORMAT_R16G16B16A16_SINT = Format 96
+pattern FormatR16g16b16a16Sint = Format 96
 
-pattern VK_FORMAT_R16G16B16A16_SFLOAT = Format 97
+pattern FormatR16g16b16a16Sfloat = Format 97
 
-pattern VK_FORMAT_R32_UINT = Format 98
+pattern FormatR32Uint = Format 98
 
-pattern VK_FORMAT_R32_SINT = Format 99
+pattern FormatR32Sint = Format 99
 
-pattern VK_FORMAT_R32_SFLOAT = Format 100
+pattern FormatR32Sfloat = Format 100
 
-pattern VK_FORMAT_R32G32_UINT = Format 101
+pattern FormatR32g32Uint = Format 101
 
-pattern VK_FORMAT_R32G32_SINT = Format 102
+pattern FormatR32g32Sint = Format 102
 
-pattern VK_FORMAT_R32G32_SFLOAT = Format 103
+pattern FormatR32g32Sfloat = Format 103
 
-pattern VK_FORMAT_R32G32B32_UINT = Format 104
+pattern FormatR32g32b32Uint = Format 104
 
-pattern VK_FORMAT_R32G32B32_SINT = Format 105
+pattern FormatR32g32b32Sint = Format 105
 
-pattern VK_FORMAT_R32G32B32_SFLOAT = Format 106
+pattern FormatR32g32b32Sfloat = Format 106
 
-pattern VK_FORMAT_R32G32B32A32_UINT = Format 107
+pattern FormatR32g32b32a32Uint = Format 107
 
-pattern VK_FORMAT_R32G32B32A32_SINT = Format 108
+pattern FormatR32g32b32a32Sint = Format 108
 
-pattern VK_FORMAT_R32G32B32A32_SFLOAT = Format 109
+pattern FormatR32g32b32a32Sfloat = Format 109
 
-pattern VK_FORMAT_R64_UINT = Format 110
+pattern FormatR64Uint = Format 110
 
-pattern VK_FORMAT_R64_SINT = Format 111
+pattern FormatR64Sint = Format 111
 
-pattern VK_FORMAT_R64_SFLOAT = Format 112
+pattern FormatR64Sfloat = Format 112
 
-pattern VK_FORMAT_R64G64_UINT = Format 113
+pattern FormatR64g64Uint = Format 113
 
-pattern VK_FORMAT_R64G64_SINT = Format 114
+pattern FormatR64g64Sint = Format 114
 
-pattern VK_FORMAT_R64G64_SFLOAT = Format 115
+pattern FormatR64g64Sfloat = Format 115
 
-pattern VK_FORMAT_R64G64B64_UINT = Format 116
+pattern FormatR64g64b64Uint = Format 116
 
-pattern VK_FORMAT_R64G64B64_SINT = Format 117
+pattern FormatR64g64b64Sint = Format 117
 
-pattern VK_FORMAT_R64G64B64_SFLOAT = Format 118
+pattern FormatR64g64b64Sfloat = Format 118
 
-pattern VK_FORMAT_R64G64B64A64_UINT = Format 119
+pattern FormatR64g64b64a64Uint = Format 119
 
-pattern VK_FORMAT_R64G64B64A64_SINT = Format 120
+pattern FormatR64g64b64a64Sint = Format 120
 
-pattern VK_FORMAT_R64G64B64A64_SFLOAT = Format 121
+pattern FormatR64g64b64a64Sfloat = Format 121
 
-pattern VK_FORMAT_B10G11R11_UFLOAT_PACK32 = Format 122
+pattern FormatB10g11r11UfloatPack32 = Format 122
 
-pattern VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = Format 123
+pattern FormatE5b9g9r9UfloatPack32 = Format 123
 
-pattern VK_FORMAT_D16_UNORM = Format 124
+pattern FormatD16Unorm = Format 124
 
-pattern VK_FORMAT_X8_D24_UNORM_PACK32 = Format 125
+pattern FormatX8D24UnormPack32 = Format 125
 
-pattern VK_FORMAT_D32_SFLOAT = Format 126
+pattern FormatD32Sfloat = Format 126
 
-pattern VK_FORMAT_S8_UINT = Format 127
+pattern FormatS8Uint = Format 127
 
-pattern VK_FORMAT_D16_UNORM_S8_UINT = Format 128
+pattern FormatD16UnormS8Uint = Format 128
 
-pattern VK_FORMAT_D24_UNORM_S8_UINT = Format 129
+pattern FormatD24UnormS8Uint = Format 129
 
-pattern VK_FORMAT_D32_SFLOAT_S8_UINT = Format 130
+pattern FormatD32SfloatS8Uint = Format 130
 
-pattern VK_FORMAT_BC1_RGB_UNORM_BLOCK = Format 131
+pattern FormatBc1RgbUnormBlock = Format 131
 
-pattern VK_FORMAT_BC1_RGB_SRGB_BLOCK = Format 132
+pattern FormatBc1RgbSrgbBlock = Format 132
 
-pattern VK_FORMAT_BC1_RGBA_UNORM_BLOCK = Format 133
+pattern FormatBc1RgbaUnormBlock = Format 133
 
-pattern VK_FORMAT_BC1_RGBA_SRGB_BLOCK = Format 134
+pattern FormatBc1RgbaSrgbBlock = Format 134
 
-pattern VK_FORMAT_BC2_UNORM_BLOCK = Format 135
+pattern FormatBc2UnormBlock = Format 135
 
-pattern VK_FORMAT_BC2_SRGB_BLOCK = Format 136
+pattern FormatBc2SrgbBlock = Format 136
 
-pattern VK_FORMAT_BC3_UNORM_BLOCK = Format 137
+pattern FormatBc3UnormBlock = Format 137
 
-pattern VK_FORMAT_BC3_SRGB_BLOCK = Format 138
+pattern FormatBc3SrgbBlock = Format 138
 
-pattern VK_FORMAT_BC4_UNORM_BLOCK = Format 139
+pattern FormatBc4UnormBlock = Format 139
 
-pattern VK_FORMAT_BC4_SNORM_BLOCK = Format 140
+pattern FormatBc4SnormBlock = Format 140
 
-pattern VK_FORMAT_BC5_UNORM_BLOCK = Format 141
+pattern FormatBc5UnormBlock = Format 141
 
-pattern VK_FORMAT_BC5_SNORM_BLOCK = Format 142
+pattern FormatBc5SnormBlock = Format 142
 
-pattern VK_FORMAT_BC6H_UFLOAT_BLOCK = Format 143
+pattern FormatBc6hUfloatBlock = Format 143
 
-pattern VK_FORMAT_BC6H_SFLOAT_BLOCK = Format 144
+pattern FormatBc6hSfloatBlock = Format 144
 
-pattern VK_FORMAT_BC7_UNORM_BLOCK = Format 145
+pattern FormatBc7UnormBlock = Format 145
 
-pattern VK_FORMAT_BC7_SRGB_BLOCK = Format 146
+pattern FormatBc7SrgbBlock = Format 146
 
-pattern VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = Format 147
+pattern FormatEtc2R8g8b8UnormBlock = Format 147
 
-pattern VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = Format 148
+pattern FormatEtc2R8g8b8SrgbBlock = Format 148
 
-pattern VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = Format 149
+pattern FormatEtc2R8g8b8a1UnormBlock = Format 149
 
-pattern VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = Format 150
+pattern FormatEtc2R8g8b8a1SrgbBlock = Format 150
 
-pattern VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = Format 151
+pattern FormatEtc2R8g8b8a8UnormBlock = Format 151
 
-pattern VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = Format 152
+pattern FormatEtc2R8g8b8a8SrgbBlock = Format 152
 
-pattern VK_FORMAT_EAC_R11_UNORM_BLOCK = Format 153
+pattern FormatEacR11UnormBlock = Format 153
 
-pattern VK_FORMAT_EAC_R11_SNORM_BLOCK = Format 154
+pattern FormatEacR11SnormBlock = Format 154
 
-pattern VK_FORMAT_EAC_R11G11_UNORM_BLOCK = Format 155
+pattern FormatEacR11g11UnormBlock = Format 155
 
-pattern VK_FORMAT_EAC_R11G11_SNORM_BLOCK = Format 156
+pattern FormatEacR11g11SnormBlock = Format 156
 
-pattern VK_FORMAT_ASTC_4x4_UNORM_BLOCK = Format 157
+pattern FormatAstc4x4UnormBlock = Format 157
 
-pattern VK_FORMAT_ASTC_4x4_SRGB_BLOCK = Format 158
+pattern FormatAstc4x4SrgbBlock = Format 158
 
-pattern VK_FORMAT_ASTC_5x4_UNORM_BLOCK = Format 159
+pattern FormatAstc5x4UnormBlock = Format 159
 
-pattern VK_FORMAT_ASTC_5x4_SRGB_BLOCK = Format 160
+pattern FormatAstc5x4SrgbBlock = Format 160
 
-pattern VK_FORMAT_ASTC_5x5_UNORM_BLOCK = Format 161
+pattern FormatAstc5x5UnormBlock = Format 161
 
-pattern VK_FORMAT_ASTC_5x5_SRGB_BLOCK = Format 162
+pattern FormatAstc5x5SrgbBlock = Format 162
 
-pattern VK_FORMAT_ASTC_6x5_UNORM_BLOCK = Format 163
+pattern FormatAstc6x5UnormBlock = Format 163
 
-pattern VK_FORMAT_ASTC_6x5_SRGB_BLOCK = Format 164
+pattern FormatAstc6x5SrgbBlock = Format 164
 
-pattern VK_FORMAT_ASTC_6x6_UNORM_BLOCK = Format 165
+pattern FormatAstc6x6UnormBlock = Format 165
 
-pattern VK_FORMAT_ASTC_6x6_SRGB_BLOCK = Format 166
+pattern FormatAstc6x6SrgbBlock = Format 166
 
-pattern VK_FORMAT_ASTC_8x5_UNORM_BLOCK = Format 167
+pattern FormatAstc8x5UnormBlock = Format 167
 
-pattern VK_FORMAT_ASTC_8x5_SRGB_BLOCK = Format 168
+pattern FormatAstc8x5SrgbBlock = Format 168
 
-pattern VK_FORMAT_ASTC_8x6_UNORM_BLOCK = Format 169
+pattern FormatAstc8x6UnormBlock = Format 169
 
-pattern VK_FORMAT_ASTC_8x6_SRGB_BLOCK = Format 170
+pattern FormatAstc8x6SrgbBlock = Format 170
 
-pattern VK_FORMAT_ASTC_8x8_UNORM_BLOCK = Format 171
+pattern FormatAstc8x8UnormBlock = Format 171
 
-pattern VK_FORMAT_ASTC_8x8_SRGB_BLOCK = Format 172
+pattern FormatAstc8x8SrgbBlock = Format 172
 
-pattern VK_FORMAT_ASTC_10x5_UNORM_BLOCK = Format 173
+pattern FormatAstc10x5UnormBlock = Format 173
 
-pattern VK_FORMAT_ASTC_10x5_SRGB_BLOCK = Format 174
+pattern FormatAstc10x5SrgbBlock = Format 174
 
-pattern VK_FORMAT_ASTC_10x6_UNORM_BLOCK = Format 175
+pattern FormatAstc10x6UnormBlock = Format 175
 
-pattern VK_FORMAT_ASTC_10x6_SRGB_BLOCK = Format 176
+pattern FormatAstc10x6SrgbBlock = Format 176
 
-pattern VK_FORMAT_ASTC_10x8_UNORM_BLOCK = Format 177
+pattern FormatAstc10x8UnormBlock = Format 177
 
-pattern VK_FORMAT_ASTC_10x8_SRGB_BLOCK = Format 178
+pattern FormatAstc10x8SrgbBlock = Format 178
 
-pattern VK_FORMAT_ASTC_10x10_UNORM_BLOCK = Format 179
+pattern FormatAstc10x10UnormBlock = Format 179
 
-pattern VK_FORMAT_ASTC_10x10_SRGB_BLOCK = Format 180
+pattern FormatAstc10x10SrgbBlock = Format 180
 
-pattern VK_FORMAT_ASTC_12x10_UNORM_BLOCK = Format 181
+pattern FormatAstc12x10UnormBlock = Format 181
 
-pattern VK_FORMAT_ASTC_12x10_SRGB_BLOCK = Format 182
+pattern FormatAstc12x10SrgbBlock = Format 182
 
-pattern VK_FORMAT_ASTC_12x12_UNORM_BLOCK = Format 183
+pattern FormatAstc12x12UnormBlock = Format 183
 
-pattern VK_FORMAT_ASTC_12x12_SRGB_BLOCK = Format 184
+pattern FormatAstc12x12SrgbBlock = Format 184
 
 type Flags = Word32
 
@@ -814,13 +814,13 @@ newtype SharingMode = SharingMode Int32
   deriving (Eq, Storable)
 
 instance Show SharingMode where
-  showsPrec _ VK_SHARING_MODE_EXCLUSIVE = showString "VK_SHARING_MODE_EXCLUSIVE"
-  showsPrec _ VK_SHARING_MODE_CONCURRENT = showString "VK_SHARING_MODE_CONCURRENT"
+  showsPrec _ SharingModeExclusive = showString "SharingModeExclusive"
+  showsPrec _ SharingModeConcurrent = showString "SharingModeConcurrent"
   showsPrec p (SharingMode x) = showParen (p >= 11) (showString "SharingMode " . showsPrec 11 x)
 
 instance Read SharingMode where
-  readPrec = parens ( choose [ ("VK_SHARING_MODE_EXCLUSIVE", pure VK_SHARING_MODE_EXCLUSIVE)
-                             , ("VK_SHARING_MODE_CONCURRENT", pure VK_SHARING_MODE_CONCURRENT)
+  readPrec = parens ( choose [ ("SharingModeExclusive", pure SharingModeExclusive)
+                             , ("SharingModeConcurrent", pure SharingModeConcurrent)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SharingMode")
@@ -830,9 +830,9 @@ instance Read SharingMode where
                     )
 
 
-pattern VK_SHARING_MODE_EXCLUSIVE = SharingMode 0
+pattern SharingModeExclusive = SharingMode 0
 
-pattern VK_SHARING_MODE_CONCURRENT = SharingMode 1
+pattern SharingModeConcurrent = SharingMode 1
 
 -- ** StructureType
 -- | Structure type enumerant
@@ -840,107 +840,107 @@ newtype StructureType = StructureType Int32
   deriving (Eq, Storable)
 
 instance Show StructureType where
-  showsPrec _ VK_STRUCTURE_TYPE_APPLICATION_INFO = showString "VK_STRUCTURE_TYPE_APPLICATION_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_SUBMIT_INFO = showString "VK_STRUCTURE_TYPE_SUBMIT_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO = showString "VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE = showString "VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE"
-  showsPrec _ VK_STRUCTURE_TYPE_BIND_SPARSE_INFO = showString "VK_STRUCTURE_TYPE_BIND_SPARSE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_FENCE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_FENCE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_EVENT_CREATE_INFO = showString "VK_STRUCTURE_TYPE_EVENT_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO = showString "VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO = showString "VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO = showString "VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO = showString "VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO = showString "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO = showString "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO = showString "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO = showString "VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO = showString "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET = showString "VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET"
-  showsPrec _ VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET = showString "VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET"
-  showsPrec _ VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO = showString "VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO = showString "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO = showString "VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO = showString "VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO = showString "VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO = showString "VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO = showString "VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER = showString "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER"
-  showsPrec _ VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = showString "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER"
-  showsPrec _ VK_STRUCTURE_TYPE_MEMORY_BARRIER = showString "VK_STRUCTURE_TYPE_MEMORY_BARRIER"
-  showsPrec _ VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO"
-  showsPrec _ VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO"
+  showsPrec _ StructureTypeApplicationInfo = showString "StructureTypeApplicationInfo"
+  showsPrec _ StructureTypeInstanceCreateInfo = showString "StructureTypeInstanceCreateInfo"
+  showsPrec _ StructureTypeDeviceQueueCreateInfo = showString "StructureTypeDeviceQueueCreateInfo"
+  showsPrec _ StructureTypeDeviceCreateInfo = showString "StructureTypeDeviceCreateInfo"
+  showsPrec _ StructureTypeSubmitInfo = showString "StructureTypeSubmitInfo"
+  showsPrec _ StructureTypeMemoryAllocateInfo = showString "StructureTypeMemoryAllocateInfo"
+  showsPrec _ StructureTypeMappedMemoryRange = showString "StructureTypeMappedMemoryRange"
+  showsPrec _ StructureTypeBindSparseInfo = showString "StructureTypeBindSparseInfo"
+  showsPrec _ StructureTypeFenceCreateInfo = showString "StructureTypeFenceCreateInfo"
+  showsPrec _ StructureTypeSemaphoreCreateInfo = showString "StructureTypeSemaphoreCreateInfo"
+  showsPrec _ StructureTypeEventCreateInfo = showString "StructureTypeEventCreateInfo"
+  showsPrec _ StructureTypeQueryPoolCreateInfo = showString "StructureTypeQueryPoolCreateInfo"
+  showsPrec _ StructureTypeBufferCreateInfo = showString "StructureTypeBufferCreateInfo"
+  showsPrec _ StructureTypeBufferViewCreateInfo = showString "StructureTypeBufferViewCreateInfo"
+  showsPrec _ StructureTypeImageCreateInfo = showString "StructureTypeImageCreateInfo"
+  showsPrec _ StructureTypeImageViewCreateInfo = showString "StructureTypeImageViewCreateInfo"
+  showsPrec _ StructureTypeShaderModuleCreateInfo = showString "StructureTypeShaderModuleCreateInfo"
+  showsPrec _ StructureTypePipelineCacheCreateInfo = showString "StructureTypePipelineCacheCreateInfo"
+  showsPrec _ StructureTypePipelineShaderStageCreateInfo = showString "StructureTypePipelineShaderStageCreateInfo"
+  showsPrec _ StructureTypePipelineVertexInputStateCreateInfo = showString "StructureTypePipelineVertexInputStateCreateInfo"
+  showsPrec _ StructureTypePipelineInputAssemblyStateCreateInfo = showString "StructureTypePipelineInputAssemblyStateCreateInfo"
+  showsPrec _ StructureTypePipelineTessellationStateCreateInfo = showString "StructureTypePipelineTessellationStateCreateInfo"
+  showsPrec _ StructureTypePipelineViewportStateCreateInfo = showString "StructureTypePipelineViewportStateCreateInfo"
+  showsPrec _ StructureTypePipelineRasterizationStateCreateInfo = showString "StructureTypePipelineRasterizationStateCreateInfo"
+  showsPrec _ StructureTypePipelineMultisampleStateCreateInfo = showString "StructureTypePipelineMultisampleStateCreateInfo"
+  showsPrec _ StructureTypePipelineDepthStencilStateCreateInfo = showString "StructureTypePipelineDepthStencilStateCreateInfo"
+  showsPrec _ StructureTypePipelineColorBlendStateCreateInfo = showString "StructureTypePipelineColorBlendStateCreateInfo"
+  showsPrec _ StructureTypePipelineDynamicStateCreateInfo = showString "StructureTypePipelineDynamicStateCreateInfo"
+  showsPrec _ StructureTypeGraphicsPipelineCreateInfo = showString "StructureTypeGraphicsPipelineCreateInfo"
+  showsPrec _ StructureTypeComputePipelineCreateInfo = showString "StructureTypeComputePipelineCreateInfo"
+  showsPrec _ StructureTypePipelineLayoutCreateInfo = showString "StructureTypePipelineLayoutCreateInfo"
+  showsPrec _ StructureTypeSamplerCreateInfo = showString "StructureTypeSamplerCreateInfo"
+  showsPrec _ StructureTypeDescriptorSetLayoutCreateInfo = showString "StructureTypeDescriptorSetLayoutCreateInfo"
+  showsPrec _ StructureTypeDescriptorPoolCreateInfo = showString "StructureTypeDescriptorPoolCreateInfo"
+  showsPrec _ StructureTypeDescriptorSetAllocateInfo = showString "StructureTypeDescriptorSetAllocateInfo"
+  showsPrec _ StructureTypeWriteDescriptorSet = showString "StructureTypeWriteDescriptorSet"
+  showsPrec _ StructureTypeCopyDescriptorSet = showString "StructureTypeCopyDescriptorSet"
+  showsPrec _ StructureTypeFramebufferCreateInfo = showString "StructureTypeFramebufferCreateInfo"
+  showsPrec _ StructureTypeRenderPassCreateInfo = showString "StructureTypeRenderPassCreateInfo"
+  showsPrec _ StructureTypeCommandPoolCreateInfo = showString "StructureTypeCommandPoolCreateInfo"
+  showsPrec _ StructureTypeCommandBufferAllocateInfo = showString "StructureTypeCommandBufferAllocateInfo"
+  showsPrec _ StructureTypeCommandBufferInheritanceInfo = showString "StructureTypeCommandBufferInheritanceInfo"
+  showsPrec _ StructureTypeCommandBufferBeginInfo = showString "StructureTypeCommandBufferBeginInfo"
+  showsPrec _ StructureTypeRenderPassBeginInfo = showString "StructureTypeRenderPassBeginInfo"
+  showsPrec _ StructureTypeBufferMemoryBarrier = showString "StructureTypeBufferMemoryBarrier"
+  showsPrec _ StructureTypeImageMemoryBarrier = showString "StructureTypeImageMemoryBarrier"
+  showsPrec _ StructureTypeMemoryBarrier = showString "StructureTypeMemoryBarrier"
+  showsPrec _ StructureTypeLoaderInstanceCreateInfo = showString "StructureTypeLoaderInstanceCreateInfo"
+  showsPrec _ StructureTypeLoaderDeviceCreateInfo = showString "StructureTypeLoaderDeviceCreateInfo"
   showsPrec p (StructureType x) = showParen (p >= 11) (showString "StructureType " . showsPrec 11 x)
 
 instance Read StructureType where
-  readPrec = parens ( choose [ ("VK_STRUCTURE_TYPE_APPLICATION_INFO", pure VK_STRUCTURE_TYPE_APPLICATION_INFO)
-                             , ("VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO", pure VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO", pure VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO", pure VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_SUBMIT_INFO", pure VK_STRUCTURE_TYPE_SUBMIT_INFO)
-                             , ("VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO", pure VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE", pure VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE)
-                             , ("VK_STRUCTURE_TYPE_BIND_SPARSE_INFO", pure VK_STRUCTURE_TYPE_BIND_SPARSE_INFO)
-                             , ("VK_STRUCTURE_TYPE_FENCE_CREATE_INFO", pure VK_STRUCTURE_TYPE_FENCE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO", pure VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_EVENT_CREATE_INFO", pure VK_STRUCTURE_TYPE_EVENT_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO", pure VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO", pure VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO", pure VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO", pure VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO", pure VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO", pure VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO", pure VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO", pure VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO", pure VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO", pure VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO", pure VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO", pure VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO", pure VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET", pure VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET)
-                             , ("VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET", pure VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET)
-                             , ("VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO", pure VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO", pure VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO", pure VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO", pure VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO", pure VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO)
-                             , ("VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO", pure VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO)
-                             , ("VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO", pure VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO)
-                             , ("VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER", pure VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER)
-                             , ("VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER", pure VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER)
-                             , ("VK_STRUCTURE_TYPE_MEMORY_BARRIER", pure VK_STRUCTURE_TYPE_MEMORY_BARRIER)
-                             , ("VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO", pure VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO)
-                             , ("VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO", pure VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO)
+  readPrec = parens ( choose [ ("StructureTypeApplicationInfo", pure StructureTypeApplicationInfo)
+                             , ("StructureTypeInstanceCreateInfo", pure StructureTypeInstanceCreateInfo)
+                             , ("StructureTypeDeviceQueueCreateInfo", pure StructureTypeDeviceQueueCreateInfo)
+                             , ("StructureTypeDeviceCreateInfo", pure StructureTypeDeviceCreateInfo)
+                             , ("StructureTypeSubmitInfo", pure StructureTypeSubmitInfo)
+                             , ("StructureTypeMemoryAllocateInfo", pure StructureTypeMemoryAllocateInfo)
+                             , ("StructureTypeMappedMemoryRange", pure StructureTypeMappedMemoryRange)
+                             , ("StructureTypeBindSparseInfo", pure StructureTypeBindSparseInfo)
+                             , ("StructureTypeFenceCreateInfo", pure StructureTypeFenceCreateInfo)
+                             , ("StructureTypeSemaphoreCreateInfo", pure StructureTypeSemaphoreCreateInfo)
+                             , ("StructureTypeEventCreateInfo", pure StructureTypeEventCreateInfo)
+                             , ("StructureTypeQueryPoolCreateInfo", pure StructureTypeQueryPoolCreateInfo)
+                             , ("StructureTypeBufferCreateInfo", pure StructureTypeBufferCreateInfo)
+                             , ("StructureTypeBufferViewCreateInfo", pure StructureTypeBufferViewCreateInfo)
+                             , ("StructureTypeImageCreateInfo", pure StructureTypeImageCreateInfo)
+                             , ("StructureTypeImageViewCreateInfo", pure StructureTypeImageViewCreateInfo)
+                             , ("StructureTypeShaderModuleCreateInfo", pure StructureTypeShaderModuleCreateInfo)
+                             , ("StructureTypePipelineCacheCreateInfo", pure StructureTypePipelineCacheCreateInfo)
+                             , ("StructureTypePipelineShaderStageCreateInfo", pure StructureTypePipelineShaderStageCreateInfo)
+                             , ("StructureTypePipelineVertexInputStateCreateInfo", pure StructureTypePipelineVertexInputStateCreateInfo)
+                             , ("StructureTypePipelineInputAssemblyStateCreateInfo", pure StructureTypePipelineInputAssemblyStateCreateInfo)
+                             , ("StructureTypePipelineTessellationStateCreateInfo", pure StructureTypePipelineTessellationStateCreateInfo)
+                             , ("StructureTypePipelineViewportStateCreateInfo", pure StructureTypePipelineViewportStateCreateInfo)
+                             , ("StructureTypePipelineRasterizationStateCreateInfo", pure StructureTypePipelineRasterizationStateCreateInfo)
+                             , ("StructureTypePipelineMultisampleStateCreateInfo", pure StructureTypePipelineMultisampleStateCreateInfo)
+                             , ("StructureTypePipelineDepthStencilStateCreateInfo", pure StructureTypePipelineDepthStencilStateCreateInfo)
+                             , ("StructureTypePipelineColorBlendStateCreateInfo", pure StructureTypePipelineColorBlendStateCreateInfo)
+                             , ("StructureTypePipelineDynamicStateCreateInfo", pure StructureTypePipelineDynamicStateCreateInfo)
+                             , ("StructureTypeGraphicsPipelineCreateInfo", pure StructureTypeGraphicsPipelineCreateInfo)
+                             , ("StructureTypeComputePipelineCreateInfo", pure StructureTypeComputePipelineCreateInfo)
+                             , ("StructureTypePipelineLayoutCreateInfo", pure StructureTypePipelineLayoutCreateInfo)
+                             , ("StructureTypeSamplerCreateInfo", pure StructureTypeSamplerCreateInfo)
+                             , ("StructureTypeDescriptorSetLayoutCreateInfo", pure StructureTypeDescriptorSetLayoutCreateInfo)
+                             , ("StructureTypeDescriptorPoolCreateInfo", pure StructureTypeDescriptorPoolCreateInfo)
+                             , ("StructureTypeDescriptorSetAllocateInfo", pure StructureTypeDescriptorSetAllocateInfo)
+                             , ("StructureTypeWriteDescriptorSet", pure StructureTypeWriteDescriptorSet)
+                             , ("StructureTypeCopyDescriptorSet", pure StructureTypeCopyDescriptorSet)
+                             , ("StructureTypeFramebufferCreateInfo", pure StructureTypeFramebufferCreateInfo)
+                             , ("StructureTypeRenderPassCreateInfo", pure StructureTypeRenderPassCreateInfo)
+                             , ("StructureTypeCommandPoolCreateInfo", pure StructureTypeCommandPoolCreateInfo)
+                             , ("StructureTypeCommandBufferAllocateInfo", pure StructureTypeCommandBufferAllocateInfo)
+                             , ("StructureTypeCommandBufferInheritanceInfo", pure StructureTypeCommandBufferInheritanceInfo)
+                             , ("StructureTypeCommandBufferBeginInfo", pure StructureTypeCommandBufferBeginInfo)
+                             , ("StructureTypeRenderPassBeginInfo", pure StructureTypeRenderPassBeginInfo)
+                             , ("StructureTypeBufferMemoryBarrier", pure StructureTypeBufferMemoryBarrier)
+                             , ("StructureTypeImageMemoryBarrier", pure StructureTypeImageMemoryBarrier)
+                             , ("StructureTypeMemoryBarrier", pure StructureTypeMemoryBarrier)
+                             , ("StructureTypeLoaderInstanceCreateInfo", pure StructureTypeLoaderInstanceCreateInfo)
+                             , ("StructureTypeLoaderDeviceCreateInfo", pure StructureTypeLoaderDeviceCreateInfo)
                              ] +++
                       prec 10 (do
                         expectP (Ident "StructureType")
@@ -950,103 +950,103 @@ instance Read StructureType where
                     )
 
 
-pattern VK_STRUCTURE_TYPE_APPLICATION_INFO = StructureType 0
+pattern StructureTypeApplicationInfo = StructureType 0
 
-pattern VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = StructureType 1
+pattern StructureTypeInstanceCreateInfo = StructureType 1
 
-pattern VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = StructureType 2
+pattern StructureTypeDeviceQueueCreateInfo = StructureType 2
 
-pattern VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO = StructureType 3
+pattern StructureTypeDeviceCreateInfo = StructureType 3
 
-pattern VK_STRUCTURE_TYPE_SUBMIT_INFO = StructureType 4
+pattern StructureTypeSubmitInfo = StructureType 4
 
-pattern VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO = StructureType 5
+pattern StructureTypeMemoryAllocateInfo = StructureType 5
 
-pattern VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE = StructureType 6
+pattern StructureTypeMappedMemoryRange = StructureType 6
 
-pattern VK_STRUCTURE_TYPE_BIND_SPARSE_INFO = StructureType 7
+pattern StructureTypeBindSparseInfo = StructureType 7
 
-pattern VK_STRUCTURE_TYPE_FENCE_CREATE_INFO = StructureType 8
+pattern StructureTypeFenceCreateInfo = StructureType 8
 
-pattern VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO = StructureType 9
+pattern StructureTypeSemaphoreCreateInfo = StructureType 9
 
-pattern VK_STRUCTURE_TYPE_EVENT_CREATE_INFO = StructureType 10
+pattern StructureTypeEventCreateInfo = StructureType 10
 
-pattern VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO = StructureType 11
+pattern StructureTypeQueryPoolCreateInfo = StructureType 11
 
-pattern VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO = StructureType 12
+pattern StructureTypeBufferCreateInfo = StructureType 12
 
-pattern VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO = StructureType 13
+pattern StructureTypeBufferViewCreateInfo = StructureType 13
 
-pattern VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO = StructureType 14
+pattern StructureTypeImageCreateInfo = StructureType 14
 
-pattern VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO = StructureType 15
+pattern StructureTypeImageViewCreateInfo = StructureType 15
 
-pattern VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO = StructureType 16
+pattern StructureTypeShaderModuleCreateInfo = StructureType 16
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO = StructureType 17
+pattern StructureTypePipelineCacheCreateInfo = StructureType 17
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO = StructureType 18
+pattern StructureTypePipelineShaderStageCreateInfo = StructureType 18
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO = StructureType 19
+pattern StructureTypePipelineVertexInputStateCreateInfo = StructureType 19
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO = StructureType 20
+pattern StructureTypePipelineInputAssemblyStateCreateInfo = StructureType 20
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO = StructureType 21
+pattern StructureTypePipelineTessellationStateCreateInfo = StructureType 21
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO = StructureType 22
+pattern StructureTypePipelineViewportStateCreateInfo = StructureType 22
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO = StructureType 23
+pattern StructureTypePipelineRasterizationStateCreateInfo = StructureType 23
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO = StructureType 24
+pattern StructureTypePipelineMultisampleStateCreateInfo = StructureType 24
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO = StructureType 25
+pattern StructureTypePipelineDepthStencilStateCreateInfo = StructureType 25
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO = StructureType 26
+pattern StructureTypePipelineColorBlendStateCreateInfo = StructureType 26
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO = StructureType 27
+pattern StructureTypePipelineDynamicStateCreateInfo = StructureType 27
 
-pattern VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO = StructureType 28
+pattern StructureTypeGraphicsPipelineCreateInfo = StructureType 28
 
-pattern VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO = StructureType 29
+pattern StructureTypeComputePipelineCreateInfo = StructureType 29
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO = StructureType 30
+pattern StructureTypePipelineLayoutCreateInfo = StructureType 30
 
-pattern VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO = StructureType 31
+pattern StructureTypeSamplerCreateInfo = StructureType 31
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO = StructureType 32
+pattern StructureTypeDescriptorSetLayoutCreateInfo = StructureType 32
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO = StructureType 33
+pattern StructureTypeDescriptorPoolCreateInfo = StructureType 33
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO = StructureType 34
+pattern StructureTypeDescriptorSetAllocateInfo = StructureType 34
 
-pattern VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET = StructureType 35
+pattern StructureTypeWriteDescriptorSet = StructureType 35
 
-pattern VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET = StructureType 36
+pattern StructureTypeCopyDescriptorSet = StructureType 36
 
-pattern VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO = StructureType 37
+pattern StructureTypeFramebufferCreateInfo = StructureType 37
 
-pattern VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO = StructureType 38
+pattern StructureTypeRenderPassCreateInfo = StructureType 38
 
-pattern VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO = StructureType 39
+pattern StructureTypeCommandPoolCreateInfo = StructureType 39
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO = StructureType 40
+pattern StructureTypeCommandBufferAllocateInfo = StructureType 40
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO = StructureType 41
+pattern StructureTypeCommandBufferInheritanceInfo = StructureType 41
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO = StructureType 42
+pattern StructureTypeCommandBufferBeginInfo = StructureType 42
 
-pattern VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO = StructureType 43
+pattern StructureTypeRenderPassBeginInfo = StructureType 43
 
-pattern VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER = StructureType 44
+pattern StructureTypeBufferMemoryBarrier = StructureType 44
 
-pattern VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = StructureType 45
+pattern StructureTypeImageMemoryBarrier = StructureType 45
 
-pattern VK_STRUCTURE_TYPE_MEMORY_BARRIER = StructureType 46
+pattern StructureTypeMemoryBarrier = StructureType 46
 
-pattern VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = StructureType 47
+pattern StructureTypeLoaderInstanceCreateInfo = StructureType 47
 
-pattern VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = StructureType 48
+pattern StructureTypeLoaderDeviceCreateInfo = StructureType 48
 
 newtype Bool32 = Bool32 Word32
   deriving (Eq, Storable)
@@ -1127,43 +1127,43 @@ newtype Result = Result Int32
   deriving (Eq, Storable)
 
 instance Show Result where
-  showsPrec _ VK_SUCCESS = showString "VK_SUCCESS"
-  showsPrec _ VK_NOT_READY = showString "VK_NOT_READY"
-  showsPrec _ VK_TIMEOUT = showString "VK_TIMEOUT"
-  showsPrec _ VK_EVENT_SET = showString "VK_EVENT_SET"
-  showsPrec _ VK_EVENT_RESET = showString "VK_EVENT_RESET"
-  showsPrec _ VK_INCOMPLETE = showString "VK_INCOMPLETE"
-  showsPrec _ VK_ERROR_OUT_OF_HOST_MEMORY = showString "VK_ERROR_OUT_OF_HOST_MEMORY"
-  showsPrec _ VK_ERROR_OUT_OF_DEVICE_MEMORY = showString "VK_ERROR_OUT_OF_DEVICE_MEMORY"
-  showsPrec _ VK_ERROR_INITIALIZATION_FAILED = showString "VK_ERROR_INITIALIZATION_FAILED"
-  showsPrec _ VK_ERROR_DEVICE_LOST = showString "VK_ERROR_DEVICE_LOST"
-  showsPrec _ VK_ERROR_MEMORY_MAP_FAILED = showString "VK_ERROR_MEMORY_MAP_FAILED"
-  showsPrec _ VK_ERROR_LAYER_NOT_PRESENT = showString "VK_ERROR_LAYER_NOT_PRESENT"
-  showsPrec _ VK_ERROR_EXTENSION_NOT_PRESENT = showString "VK_ERROR_EXTENSION_NOT_PRESENT"
-  showsPrec _ VK_ERROR_FEATURE_NOT_PRESENT = showString "VK_ERROR_FEATURE_NOT_PRESENT"
-  showsPrec _ VK_ERROR_INCOMPATIBLE_DRIVER = showString "VK_ERROR_INCOMPATIBLE_DRIVER"
-  showsPrec _ VK_ERROR_TOO_MANY_OBJECTS = showString "VK_ERROR_TOO_MANY_OBJECTS"
-  showsPrec _ VK_ERROR_FORMAT_NOT_SUPPORTED = showString "VK_ERROR_FORMAT_NOT_SUPPORTED"
+  showsPrec _ Success = showString "Success"
+  showsPrec _ NotReady = showString "NotReady"
+  showsPrec _ Timeout = showString "Timeout"
+  showsPrec _ EventSet = showString "EventSet"
+  showsPrec _ EventReset = showString "EventReset"
+  showsPrec _ Incomplete = showString "Incomplete"
+  showsPrec _ ErrorOutOfHostMemory = showString "ErrorOutOfHostMemory"
+  showsPrec _ ErrorOutOfDeviceMemory = showString "ErrorOutOfDeviceMemory"
+  showsPrec _ ErrorInitializationFailed = showString "ErrorInitializationFailed"
+  showsPrec _ ErrorDeviceLost = showString "ErrorDeviceLost"
+  showsPrec _ ErrorMemoryMapFailed = showString "ErrorMemoryMapFailed"
+  showsPrec _ ErrorLayerNotPresent = showString "ErrorLayerNotPresent"
+  showsPrec _ ErrorExtensionNotPresent = showString "ErrorExtensionNotPresent"
+  showsPrec _ ErrorFeatureNotPresent = showString "ErrorFeatureNotPresent"
+  showsPrec _ ErrorIncompatibleDriver = showString "ErrorIncompatibleDriver"
+  showsPrec _ ErrorTooManyObjects = showString "ErrorTooManyObjects"
+  showsPrec _ ErrorFormatNotSupported = showString "ErrorFormatNotSupported"
   showsPrec p (Result x) = showParen (p >= 11) (showString "Result " . showsPrec 11 x)
 
 instance Read Result where
-  readPrec = parens ( choose [ ("VK_SUCCESS", pure VK_SUCCESS)
-                             , ("VK_NOT_READY", pure VK_NOT_READY)
-                             , ("VK_TIMEOUT", pure VK_TIMEOUT)
-                             , ("VK_EVENT_SET", pure VK_EVENT_SET)
-                             , ("VK_EVENT_RESET", pure VK_EVENT_RESET)
-                             , ("VK_INCOMPLETE", pure VK_INCOMPLETE)
-                             , ("VK_ERROR_OUT_OF_HOST_MEMORY", pure VK_ERROR_OUT_OF_HOST_MEMORY)
-                             , ("VK_ERROR_OUT_OF_DEVICE_MEMORY", pure VK_ERROR_OUT_OF_DEVICE_MEMORY)
-                             , ("VK_ERROR_INITIALIZATION_FAILED", pure VK_ERROR_INITIALIZATION_FAILED)
-                             , ("VK_ERROR_DEVICE_LOST", pure VK_ERROR_DEVICE_LOST)
-                             , ("VK_ERROR_MEMORY_MAP_FAILED", pure VK_ERROR_MEMORY_MAP_FAILED)
-                             , ("VK_ERROR_LAYER_NOT_PRESENT", pure VK_ERROR_LAYER_NOT_PRESENT)
-                             , ("VK_ERROR_EXTENSION_NOT_PRESENT", pure VK_ERROR_EXTENSION_NOT_PRESENT)
-                             , ("VK_ERROR_FEATURE_NOT_PRESENT", pure VK_ERROR_FEATURE_NOT_PRESENT)
-                             , ("VK_ERROR_INCOMPATIBLE_DRIVER", pure VK_ERROR_INCOMPATIBLE_DRIVER)
-                             , ("VK_ERROR_TOO_MANY_OBJECTS", pure VK_ERROR_TOO_MANY_OBJECTS)
-                             , ("VK_ERROR_FORMAT_NOT_SUPPORTED", pure VK_ERROR_FORMAT_NOT_SUPPORTED)
+  readPrec = parens ( choose [ ("Success", pure Success)
+                             , ("NotReady", pure NotReady)
+                             , ("Timeout", pure Timeout)
+                             , ("EventSet", pure EventSet)
+                             , ("EventReset", pure EventReset)
+                             , ("Incomplete", pure Incomplete)
+                             , ("ErrorOutOfHostMemory", pure ErrorOutOfHostMemory)
+                             , ("ErrorOutOfDeviceMemory", pure ErrorOutOfDeviceMemory)
+                             , ("ErrorInitializationFailed", pure ErrorInitializationFailed)
+                             , ("ErrorDeviceLost", pure ErrorDeviceLost)
+                             , ("ErrorMemoryMapFailed", pure ErrorMemoryMapFailed)
+                             , ("ErrorLayerNotPresent", pure ErrorLayerNotPresent)
+                             , ("ErrorExtensionNotPresent", pure ErrorExtensionNotPresent)
+                             , ("ErrorFeatureNotPresent", pure ErrorFeatureNotPresent)
+                             , ("ErrorIncompatibleDriver", pure ErrorIncompatibleDriver)
+                             , ("ErrorTooManyObjects", pure ErrorTooManyObjects)
+                             , ("ErrorFormatNotSupported", pure ErrorFormatNotSupported)
                              ] +++
                       prec 10 (do
                         expectP (Ident "Result")
@@ -1173,39 +1173,39 @@ instance Read Result where
                     )
 
 -- | Command completed successfully
-pattern VK_SUCCESS = Result 0
+pattern Success = Result 0
 -- | A fence or query has not yet completed
-pattern VK_NOT_READY = Result 1
+pattern NotReady = Result 1
 -- | A wait operation has not completed in the specified time
-pattern VK_TIMEOUT = Result 2
+pattern Timeout = Result 2
 -- | An event is signaled
-pattern VK_EVENT_SET = Result 3
+pattern EventSet = Result 3
 -- | An event is unsignalled
-pattern VK_EVENT_RESET = Result 4
+pattern EventReset = Result 4
 -- | A return array was too small for the resul
-pattern VK_INCOMPLETE = Result 5
+pattern Incomplete = Result 5
 -- | A host memory allocation has failed
-pattern VK_ERROR_OUT_OF_HOST_MEMORY = Result (-1)
+pattern ErrorOutOfHostMemory = Result (-1)
 -- | A device memory allocation has failed
-pattern VK_ERROR_OUT_OF_DEVICE_MEMORY = Result (-2)
+pattern ErrorOutOfDeviceMemory = Result (-2)
 -- | The logical device has been lost. See <<devsandqueues-lost-device>>
-pattern VK_ERROR_INITIALIZATION_FAILED = Result (-3)
+pattern ErrorInitializationFailed = Result (-3)
 -- | Initialization of a object has failed
-pattern VK_ERROR_DEVICE_LOST = Result (-4)
+pattern ErrorDeviceLost = Result (-4)
 -- | Mapping of a memory object has failed
-pattern VK_ERROR_MEMORY_MAP_FAILED = Result (-5)
+pattern ErrorMemoryMapFailed = Result (-5)
 -- | Layer specified does not exist
-pattern VK_ERROR_LAYER_NOT_PRESENT = Result (-6)
+pattern ErrorLayerNotPresent = Result (-6)
 -- | Extension specified does not exist
-pattern VK_ERROR_EXTENSION_NOT_PRESENT = Result (-7)
+pattern ErrorExtensionNotPresent = Result (-7)
 -- | Requested feature is not available on this device
-pattern VK_ERROR_FEATURE_NOT_PRESENT = Result (-8)
+pattern ErrorFeatureNotPresent = Result (-8)
 -- | Unable to find a Vulkan driver
-pattern VK_ERROR_INCOMPATIBLE_DRIVER = Result (-9)
+pattern ErrorIncompatibleDriver = Result (-9)
 -- | Too many objects of the type have already been created
-pattern VK_ERROR_TOO_MANY_OBJECTS = Result (-10)
+pattern ErrorTooManyObjects = Result (-10)
 -- | Requested format is not supported on this device
-pattern VK_ERROR_FORMAT_NOT_SUPPORTED = Result (-11)
+pattern ErrorFormatNotSupported = Result (-11)
 
 
 data Viewport =

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -25,6 +25,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Core( VkExtent3D
+                           , VkExtent2D
+                           , VkOffset2D
+                           , VkOffset3D
+                           )
 import Foreign.C.Types( CFloat
                       )
 

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -32,12 +32,12 @@ import Foreign.C.Types( CFloat(..)
 newtype VkDeviceSize = VkDeviceSize Word64
   deriving (Eq, Storable)
 
--- ** VkFormat
+-- ** Format
 -- | Vulkan format definitions
-newtype VkFormat = VkFormat Int32
+newtype Format = Format Int32
   deriving (Eq, Storable)
 
-instance Show VkFormat where
+instance Show Format where
   showsPrec _ VK_FORMAT_UNDEFINED = showString "VK_FORMAT_UNDEFINED"
   showsPrec _ VK_FORMAT_R4G4_UNORM_PACK8 = showString "VK_FORMAT_R4G4_UNORM_PACK8"
   showsPrec _ VK_FORMAT_R4G4B4A4_UNORM_PACK16 = showString "VK_FORMAT_R4G4B4A4_UNORM_PACK16"
@@ -223,9 +223,9 @@ instance Show VkFormat where
   showsPrec _ VK_FORMAT_ASTC_12x10_SRGB_BLOCK = showString "VK_FORMAT_ASTC_12x10_SRGB_BLOCK"
   showsPrec _ VK_FORMAT_ASTC_12x12_UNORM_BLOCK = showString "VK_FORMAT_ASTC_12x12_UNORM_BLOCK"
   showsPrec _ VK_FORMAT_ASTC_12x12_SRGB_BLOCK = showString "VK_FORMAT_ASTC_12x12_SRGB_BLOCK"
-  showsPrec p (VkFormat x) = showParen (p >= 11) (showString "VkFormat " . showsPrec 11 x)
+  showsPrec p (Format x) = showParen (p >= 11) (showString "Format " . showsPrec 11 x)
 
-instance Read VkFormat where
+instance Read Format where
   readPrec = parens ( choose [ ("VK_FORMAT_UNDEFINED", pure VK_FORMAT_UNDEFINED)
                              , ("VK_FORMAT_R4G4_UNORM_PACK8", pure VK_FORMAT_R4G4_UNORM_PACK8)
                              , ("VK_FORMAT_R4G4B4A4_UNORM_PACK16", pure VK_FORMAT_R4G4B4A4_UNORM_PACK16)
@@ -413,382 +413,382 @@ instance Read VkFormat where
                              , ("VK_FORMAT_ASTC_12x12_SRGB_BLOCK", pure VK_FORMAT_ASTC_12x12_SRGB_BLOCK)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFormat")
+                        expectP (Ident "Format")
                         v <- step readPrec
-                        pure (VkFormat v)
+                        pure (Format v)
                         )
                     )
 
 
-pattern VK_FORMAT_UNDEFINED = VkFormat 0
+pattern VK_FORMAT_UNDEFINED = Format 0
 
-pattern VK_FORMAT_R4G4_UNORM_PACK8 = VkFormat 1
+pattern VK_FORMAT_R4G4_UNORM_PACK8 = Format 1
 
-pattern VK_FORMAT_R4G4B4A4_UNORM_PACK16 = VkFormat 2
+pattern VK_FORMAT_R4G4B4A4_UNORM_PACK16 = Format 2
 
-pattern VK_FORMAT_B4G4R4A4_UNORM_PACK16 = VkFormat 3
+pattern VK_FORMAT_B4G4R4A4_UNORM_PACK16 = Format 3
 
-pattern VK_FORMAT_R5G6B5_UNORM_PACK16 = VkFormat 4
+pattern VK_FORMAT_R5G6B5_UNORM_PACK16 = Format 4
 
-pattern VK_FORMAT_B5G6R5_UNORM_PACK16 = VkFormat 5
+pattern VK_FORMAT_B5G6R5_UNORM_PACK16 = Format 5
 
-pattern VK_FORMAT_R5G5B5A1_UNORM_PACK16 = VkFormat 6
+pattern VK_FORMAT_R5G5B5A1_UNORM_PACK16 = Format 6
 
-pattern VK_FORMAT_B5G5R5A1_UNORM_PACK16 = VkFormat 7
+pattern VK_FORMAT_B5G5R5A1_UNORM_PACK16 = Format 7
 
-pattern VK_FORMAT_A1R5G5B5_UNORM_PACK16 = VkFormat 8
+pattern VK_FORMAT_A1R5G5B5_UNORM_PACK16 = Format 8
 
-pattern VK_FORMAT_R8_UNORM = VkFormat 9
+pattern VK_FORMAT_R8_UNORM = Format 9
 
-pattern VK_FORMAT_R8_SNORM = VkFormat 10
+pattern VK_FORMAT_R8_SNORM = Format 10
 
-pattern VK_FORMAT_R8_USCALED = VkFormat 11
+pattern VK_FORMAT_R8_USCALED = Format 11
 
-pattern VK_FORMAT_R8_SSCALED = VkFormat 12
+pattern VK_FORMAT_R8_SSCALED = Format 12
 
-pattern VK_FORMAT_R8_UINT = VkFormat 13
+pattern VK_FORMAT_R8_UINT = Format 13
 
-pattern VK_FORMAT_R8_SINT = VkFormat 14
+pattern VK_FORMAT_R8_SINT = Format 14
 
-pattern VK_FORMAT_R8_SRGB = VkFormat 15
+pattern VK_FORMAT_R8_SRGB = Format 15
 
-pattern VK_FORMAT_R8G8_UNORM = VkFormat 16
+pattern VK_FORMAT_R8G8_UNORM = Format 16
 
-pattern VK_FORMAT_R8G8_SNORM = VkFormat 17
+pattern VK_FORMAT_R8G8_SNORM = Format 17
 
-pattern VK_FORMAT_R8G8_USCALED = VkFormat 18
+pattern VK_FORMAT_R8G8_USCALED = Format 18
 
-pattern VK_FORMAT_R8G8_SSCALED = VkFormat 19
+pattern VK_FORMAT_R8G8_SSCALED = Format 19
 
-pattern VK_FORMAT_R8G8_UINT = VkFormat 20
+pattern VK_FORMAT_R8G8_UINT = Format 20
 
-pattern VK_FORMAT_R8G8_SINT = VkFormat 21
+pattern VK_FORMAT_R8G8_SINT = Format 21
 
-pattern VK_FORMAT_R8G8_SRGB = VkFormat 22
+pattern VK_FORMAT_R8G8_SRGB = Format 22
 
-pattern VK_FORMAT_R8G8B8_UNORM = VkFormat 23
+pattern VK_FORMAT_R8G8B8_UNORM = Format 23
 
-pattern VK_FORMAT_R8G8B8_SNORM = VkFormat 24
+pattern VK_FORMAT_R8G8B8_SNORM = Format 24
 
-pattern VK_FORMAT_R8G8B8_USCALED = VkFormat 25
+pattern VK_FORMAT_R8G8B8_USCALED = Format 25
 
-pattern VK_FORMAT_R8G8B8_SSCALED = VkFormat 26
+pattern VK_FORMAT_R8G8B8_SSCALED = Format 26
 
-pattern VK_FORMAT_R8G8B8_UINT = VkFormat 27
+pattern VK_FORMAT_R8G8B8_UINT = Format 27
 
-pattern VK_FORMAT_R8G8B8_SINT = VkFormat 28
+pattern VK_FORMAT_R8G8B8_SINT = Format 28
 
-pattern VK_FORMAT_R8G8B8_SRGB = VkFormat 29
+pattern VK_FORMAT_R8G8B8_SRGB = Format 29
 
-pattern VK_FORMAT_B8G8R8_UNORM = VkFormat 30
+pattern VK_FORMAT_B8G8R8_UNORM = Format 30
 
-pattern VK_FORMAT_B8G8R8_SNORM = VkFormat 31
+pattern VK_FORMAT_B8G8R8_SNORM = Format 31
 
-pattern VK_FORMAT_B8G8R8_USCALED = VkFormat 32
+pattern VK_FORMAT_B8G8R8_USCALED = Format 32
 
-pattern VK_FORMAT_B8G8R8_SSCALED = VkFormat 33
+pattern VK_FORMAT_B8G8R8_SSCALED = Format 33
 
-pattern VK_FORMAT_B8G8R8_UINT = VkFormat 34
+pattern VK_FORMAT_B8G8R8_UINT = Format 34
 
-pattern VK_FORMAT_B8G8R8_SINT = VkFormat 35
+pattern VK_FORMAT_B8G8R8_SINT = Format 35
 
-pattern VK_FORMAT_B8G8R8_SRGB = VkFormat 36
+pattern VK_FORMAT_B8G8R8_SRGB = Format 36
 
-pattern VK_FORMAT_R8G8B8A8_UNORM = VkFormat 37
+pattern VK_FORMAT_R8G8B8A8_UNORM = Format 37
 
-pattern VK_FORMAT_R8G8B8A8_SNORM = VkFormat 38
+pattern VK_FORMAT_R8G8B8A8_SNORM = Format 38
 
-pattern VK_FORMAT_R8G8B8A8_USCALED = VkFormat 39
+pattern VK_FORMAT_R8G8B8A8_USCALED = Format 39
 
-pattern VK_FORMAT_R8G8B8A8_SSCALED = VkFormat 40
+pattern VK_FORMAT_R8G8B8A8_SSCALED = Format 40
 
-pattern VK_FORMAT_R8G8B8A8_UINT = VkFormat 41
+pattern VK_FORMAT_R8G8B8A8_UINT = Format 41
 
-pattern VK_FORMAT_R8G8B8A8_SINT = VkFormat 42
+pattern VK_FORMAT_R8G8B8A8_SINT = Format 42
 
-pattern VK_FORMAT_R8G8B8A8_SRGB = VkFormat 43
+pattern VK_FORMAT_R8G8B8A8_SRGB = Format 43
 
-pattern VK_FORMAT_B8G8R8A8_UNORM = VkFormat 44
+pattern VK_FORMAT_B8G8R8A8_UNORM = Format 44
 
-pattern VK_FORMAT_B8G8R8A8_SNORM = VkFormat 45
+pattern VK_FORMAT_B8G8R8A8_SNORM = Format 45
 
-pattern VK_FORMAT_B8G8R8A8_USCALED = VkFormat 46
+pattern VK_FORMAT_B8G8R8A8_USCALED = Format 46
 
-pattern VK_FORMAT_B8G8R8A8_SSCALED = VkFormat 47
+pattern VK_FORMAT_B8G8R8A8_SSCALED = Format 47
 
-pattern VK_FORMAT_B8G8R8A8_UINT = VkFormat 48
+pattern VK_FORMAT_B8G8R8A8_UINT = Format 48
 
-pattern VK_FORMAT_B8G8R8A8_SINT = VkFormat 49
+pattern VK_FORMAT_B8G8R8A8_SINT = Format 49
 
-pattern VK_FORMAT_B8G8R8A8_SRGB = VkFormat 50
+pattern VK_FORMAT_B8G8R8A8_SRGB = Format 50
 
-pattern VK_FORMAT_A8B8G8R8_UNORM_PACK32 = VkFormat 51
+pattern VK_FORMAT_A8B8G8R8_UNORM_PACK32 = Format 51
 
-pattern VK_FORMAT_A8B8G8R8_SNORM_PACK32 = VkFormat 52
+pattern VK_FORMAT_A8B8G8R8_SNORM_PACK32 = Format 52
 
-pattern VK_FORMAT_A8B8G8R8_USCALED_PACK32 = VkFormat 53
+pattern VK_FORMAT_A8B8G8R8_USCALED_PACK32 = Format 53
 
-pattern VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = VkFormat 54
+pattern VK_FORMAT_A8B8G8R8_SSCALED_PACK32 = Format 54
 
-pattern VK_FORMAT_A8B8G8R8_UINT_PACK32 = VkFormat 55
+pattern VK_FORMAT_A8B8G8R8_UINT_PACK32 = Format 55
 
-pattern VK_FORMAT_A8B8G8R8_SINT_PACK32 = VkFormat 56
+pattern VK_FORMAT_A8B8G8R8_SINT_PACK32 = Format 56
 
-pattern VK_FORMAT_A8B8G8R8_SRGB_PACK32 = VkFormat 57
+pattern VK_FORMAT_A8B8G8R8_SRGB_PACK32 = Format 57
 
-pattern VK_FORMAT_A2R10G10B10_UNORM_PACK32 = VkFormat 58
+pattern VK_FORMAT_A2R10G10B10_UNORM_PACK32 = Format 58
 
-pattern VK_FORMAT_A2R10G10B10_SNORM_PACK32 = VkFormat 59
+pattern VK_FORMAT_A2R10G10B10_SNORM_PACK32 = Format 59
 
-pattern VK_FORMAT_A2R10G10B10_USCALED_PACK32 = VkFormat 60
+pattern VK_FORMAT_A2R10G10B10_USCALED_PACK32 = Format 60
 
-pattern VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = VkFormat 61
+pattern VK_FORMAT_A2R10G10B10_SSCALED_PACK32 = Format 61
 
-pattern VK_FORMAT_A2R10G10B10_UINT_PACK32 = VkFormat 62
+pattern VK_FORMAT_A2R10G10B10_UINT_PACK32 = Format 62
 
-pattern VK_FORMAT_A2R10G10B10_SINT_PACK32 = VkFormat 63
+pattern VK_FORMAT_A2R10G10B10_SINT_PACK32 = Format 63
 
-pattern VK_FORMAT_A2B10G10R10_UNORM_PACK32 = VkFormat 64
+pattern VK_FORMAT_A2B10G10R10_UNORM_PACK32 = Format 64
 
-pattern VK_FORMAT_A2B10G10R10_SNORM_PACK32 = VkFormat 65
+pattern VK_FORMAT_A2B10G10R10_SNORM_PACK32 = Format 65
 
-pattern VK_FORMAT_A2B10G10R10_USCALED_PACK32 = VkFormat 66
+pattern VK_FORMAT_A2B10G10R10_USCALED_PACK32 = Format 66
 
-pattern VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = VkFormat 67
+pattern VK_FORMAT_A2B10G10R10_SSCALED_PACK32 = Format 67
 
-pattern VK_FORMAT_A2B10G10R10_UINT_PACK32 = VkFormat 68
+pattern VK_FORMAT_A2B10G10R10_UINT_PACK32 = Format 68
 
-pattern VK_FORMAT_A2B10G10R10_SINT_PACK32 = VkFormat 69
+pattern VK_FORMAT_A2B10G10R10_SINT_PACK32 = Format 69
 
-pattern VK_FORMAT_R16_UNORM = VkFormat 70
+pattern VK_FORMAT_R16_UNORM = Format 70
 
-pattern VK_FORMAT_R16_SNORM = VkFormat 71
+pattern VK_FORMAT_R16_SNORM = Format 71
 
-pattern VK_FORMAT_R16_USCALED = VkFormat 72
+pattern VK_FORMAT_R16_USCALED = Format 72
 
-pattern VK_FORMAT_R16_SSCALED = VkFormat 73
+pattern VK_FORMAT_R16_SSCALED = Format 73
 
-pattern VK_FORMAT_R16_UINT = VkFormat 74
+pattern VK_FORMAT_R16_UINT = Format 74
 
-pattern VK_FORMAT_R16_SINT = VkFormat 75
+pattern VK_FORMAT_R16_SINT = Format 75
 
-pattern VK_FORMAT_R16_SFLOAT = VkFormat 76
+pattern VK_FORMAT_R16_SFLOAT = Format 76
 
-pattern VK_FORMAT_R16G16_UNORM = VkFormat 77
+pattern VK_FORMAT_R16G16_UNORM = Format 77
 
-pattern VK_FORMAT_R16G16_SNORM = VkFormat 78
+pattern VK_FORMAT_R16G16_SNORM = Format 78
 
-pattern VK_FORMAT_R16G16_USCALED = VkFormat 79
+pattern VK_FORMAT_R16G16_USCALED = Format 79
 
-pattern VK_FORMAT_R16G16_SSCALED = VkFormat 80
+pattern VK_FORMAT_R16G16_SSCALED = Format 80
 
-pattern VK_FORMAT_R16G16_UINT = VkFormat 81
+pattern VK_FORMAT_R16G16_UINT = Format 81
 
-pattern VK_FORMAT_R16G16_SINT = VkFormat 82
+pattern VK_FORMAT_R16G16_SINT = Format 82
 
-pattern VK_FORMAT_R16G16_SFLOAT = VkFormat 83
+pattern VK_FORMAT_R16G16_SFLOAT = Format 83
 
-pattern VK_FORMAT_R16G16B16_UNORM = VkFormat 84
+pattern VK_FORMAT_R16G16B16_UNORM = Format 84
 
-pattern VK_FORMAT_R16G16B16_SNORM = VkFormat 85
+pattern VK_FORMAT_R16G16B16_SNORM = Format 85
 
-pattern VK_FORMAT_R16G16B16_USCALED = VkFormat 86
+pattern VK_FORMAT_R16G16B16_USCALED = Format 86
 
-pattern VK_FORMAT_R16G16B16_SSCALED = VkFormat 87
+pattern VK_FORMAT_R16G16B16_SSCALED = Format 87
 
-pattern VK_FORMAT_R16G16B16_UINT = VkFormat 88
+pattern VK_FORMAT_R16G16B16_UINT = Format 88
 
-pattern VK_FORMAT_R16G16B16_SINT = VkFormat 89
+pattern VK_FORMAT_R16G16B16_SINT = Format 89
 
-pattern VK_FORMAT_R16G16B16_SFLOAT = VkFormat 90
+pattern VK_FORMAT_R16G16B16_SFLOAT = Format 90
 
-pattern VK_FORMAT_R16G16B16A16_UNORM = VkFormat 91
+pattern VK_FORMAT_R16G16B16A16_UNORM = Format 91
 
-pattern VK_FORMAT_R16G16B16A16_SNORM = VkFormat 92
+pattern VK_FORMAT_R16G16B16A16_SNORM = Format 92
 
-pattern VK_FORMAT_R16G16B16A16_USCALED = VkFormat 93
+pattern VK_FORMAT_R16G16B16A16_USCALED = Format 93
 
-pattern VK_FORMAT_R16G16B16A16_SSCALED = VkFormat 94
+pattern VK_FORMAT_R16G16B16A16_SSCALED = Format 94
 
-pattern VK_FORMAT_R16G16B16A16_UINT = VkFormat 95
+pattern VK_FORMAT_R16G16B16A16_UINT = Format 95
 
-pattern VK_FORMAT_R16G16B16A16_SINT = VkFormat 96
+pattern VK_FORMAT_R16G16B16A16_SINT = Format 96
 
-pattern VK_FORMAT_R16G16B16A16_SFLOAT = VkFormat 97
+pattern VK_FORMAT_R16G16B16A16_SFLOAT = Format 97
 
-pattern VK_FORMAT_R32_UINT = VkFormat 98
+pattern VK_FORMAT_R32_UINT = Format 98
 
-pattern VK_FORMAT_R32_SINT = VkFormat 99
+pattern VK_FORMAT_R32_SINT = Format 99
 
-pattern VK_FORMAT_R32_SFLOAT = VkFormat 100
+pattern VK_FORMAT_R32_SFLOAT = Format 100
 
-pattern VK_FORMAT_R32G32_UINT = VkFormat 101
+pattern VK_FORMAT_R32G32_UINT = Format 101
 
-pattern VK_FORMAT_R32G32_SINT = VkFormat 102
+pattern VK_FORMAT_R32G32_SINT = Format 102
 
-pattern VK_FORMAT_R32G32_SFLOAT = VkFormat 103
+pattern VK_FORMAT_R32G32_SFLOAT = Format 103
 
-pattern VK_FORMAT_R32G32B32_UINT = VkFormat 104
+pattern VK_FORMAT_R32G32B32_UINT = Format 104
 
-pattern VK_FORMAT_R32G32B32_SINT = VkFormat 105
+pattern VK_FORMAT_R32G32B32_SINT = Format 105
 
-pattern VK_FORMAT_R32G32B32_SFLOAT = VkFormat 106
+pattern VK_FORMAT_R32G32B32_SFLOAT = Format 106
 
-pattern VK_FORMAT_R32G32B32A32_UINT = VkFormat 107
+pattern VK_FORMAT_R32G32B32A32_UINT = Format 107
 
-pattern VK_FORMAT_R32G32B32A32_SINT = VkFormat 108
+pattern VK_FORMAT_R32G32B32A32_SINT = Format 108
 
-pattern VK_FORMAT_R32G32B32A32_SFLOAT = VkFormat 109
+pattern VK_FORMAT_R32G32B32A32_SFLOAT = Format 109
 
-pattern VK_FORMAT_R64_UINT = VkFormat 110
+pattern VK_FORMAT_R64_UINT = Format 110
 
-pattern VK_FORMAT_R64_SINT = VkFormat 111
+pattern VK_FORMAT_R64_SINT = Format 111
 
-pattern VK_FORMAT_R64_SFLOAT = VkFormat 112
+pattern VK_FORMAT_R64_SFLOAT = Format 112
 
-pattern VK_FORMAT_R64G64_UINT = VkFormat 113
+pattern VK_FORMAT_R64G64_UINT = Format 113
 
-pattern VK_FORMAT_R64G64_SINT = VkFormat 114
+pattern VK_FORMAT_R64G64_SINT = Format 114
 
-pattern VK_FORMAT_R64G64_SFLOAT = VkFormat 115
+pattern VK_FORMAT_R64G64_SFLOAT = Format 115
 
-pattern VK_FORMAT_R64G64B64_UINT = VkFormat 116
+pattern VK_FORMAT_R64G64B64_UINT = Format 116
 
-pattern VK_FORMAT_R64G64B64_SINT = VkFormat 117
+pattern VK_FORMAT_R64G64B64_SINT = Format 117
 
-pattern VK_FORMAT_R64G64B64_SFLOAT = VkFormat 118
+pattern VK_FORMAT_R64G64B64_SFLOAT = Format 118
 
-pattern VK_FORMAT_R64G64B64A64_UINT = VkFormat 119
+pattern VK_FORMAT_R64G64B64A64_UINT = Format 119
 
-pattern VK_FORMAT_R64G64B64A64_SINT = VkFormat 120
+pattern VK_FORMAT_R64G64B64A64_SINT = Format 120
 
-pattern VK_FORMAT_R64G64B64A64_SFLOAT = VkFormat 121
+pattern VK_FORMAT_R64G64B64A64_SFLOAT = Format 121
 
-pattern VK_FORMAT_B10G11R11_UFLOAT_PACK32 = VkFormat 122
+pattern VK_FORMAT_B10G11R11_UFLOAT_PACK32 = Format 122
 
-pattern VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = VkFormat 123
+pattern VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 = Format 123
 
-pattern VK_FORMAT_D16_UNORM = VkFormat 124
+pattern VK_FORMAT_D16_UNORM = Format 124
 
-pattern VK_FORMAT_X8_D24_UNORM_PACK32 = VkFormat 125
+pattern VK_FORMAT_X8_D24_UNORM_PACK32 = Format 125
 
-pattern VK_FORMAT_D32_SFLOAT = VkFormat 126
+pattern VK_FORMAT_D32_SFLOAT = Format 126
 
-pattern VK_FORMAT_S8_UINT = VkFormat 127
+pattern VK_FORMAT_S8_UINT = Format 127
 
-pattern VK_FORMAT_D16_UNORM_S8_UINT = VkFormat 128
+pattern VK_FORMAT_D16_UNORM_S8_UINT = Format 128
 
-pattern VK_FORMAT_D24_UNORM_S8_UINT = VkFormat 129
+pattern VK_FORMAT_D24_UNORM_S8_UINT = Format 129
 
-pattern VK_FORMAT_D32_SFLOAT_S8_UINT = VkFormat 130
+pattern VK_FORMAT_D32_SFLOAT_S8_UINT = Format 130
 
-pattern VK_FORMAT_BC1_RGB_UNORM_BLOCK = VkFormat 131
+pattern VK_FORMAT_BC1_RGB_UNORM_BLOCK = Format 131
 
-pattern VK_FORMAT_BC1_RGB_SRGB_BLOCK = VkFormat 132
+pattern VK_FORMAT_BC1_RGB_SRGB_BLOCK = Format 132
 
-pattern VK_FORMAT_BC1_RGBA_UNORM_BLOCK = VkFormat 133
+pattern VK_FORMAT_BC1_RGBA_UNORM_BLOCK = Format 133
 
-pattern VK_FORMAT_BC1_RGBA_SRGB_BLOCK = VkFormat 134
+pattern VK_FORMAT_BC1_RGBA_SRGB_BLOCK = Format 134
 
-pattern VK_FORMAT_BC2_UNORM_BLOCK = VkFormat 135
+pattern VK_FORMAT_BC2_UNORM_BLOCK = Format 135
 
-pattern VK_FORMAT_BC2_SRGB_BLOCK = VkFormat 136
+pattern VK_FORMAT_BC2_SRGB_BLOCK = Format 136
 
-pattern VK_FORMAT_BC3_UNORM_BLOCK = VkFormat 137
+pattern VK_FORMAT_BC3_UNORM_BLOCK = Format 137
 
-pattern VK_FORMAT_BC3_SRGB_BLOCK = VkFormat 138
+pattern VK_FORMAT_BC3_SRGB_BLOCK = Format 138
 
-pattern VK_FORMAT_BC4_UNORM_BLOCK = VkFormat 139
+pattern VK_FORMAT_BC4_UNORM_BLOCK = Format 139
 
-pattern VK_FORMAT_BC4_SNORM_BLOCK = VkFormat 140
+pattern VK_FORMAT_BC4_SNORM_BLOCK = Format 140
 
-pattern VK_FORMAT_BC5_UNORM_BLOCK = VkFormat 141
+pattern VK_FORMAT_BC5_UNORM_BLOCK = Format 141
 
-pattern VK_FORMAT_BC5_SNORM_BLOCK = VkFormat 142
+pattern VK_FORMAT_BC5_SNORM_BLOCK = Format 142
 
-pattern VK_FORMAT_BC6H_UFLOAT_BLOCK = VkFormat 143
+pattern VK_FORMAT_BC6H_UFLOAT_BLOCK = Format 143
 
-pattern VK_FORMAT_BC6H_SFLOAT_BLOCK = VkFormat 144
+pattern VK_FORMAT_BC6H_SFLOAT_BLOCK = Format 144
 
-pattern VK_FORMAT_BC7_UNORM_BLOCK = VkFormat 145
+pattern VK_FORMAT_BC7_UNORM_BLOCK = Format 145
 
-pattern VK_FORMAT_BC7_SRGB_BLOCK = VkFormat 146
+pattern VK_FORMAT_BC7_SRGB_BLOCK = Format 146
 
-pattern VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = VkFormat 147
+pattern VK_FORMAT_ETC2_R8G8B8_UNORM_BLOCK = Format 147
 
-pattern VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = VkFormat 148
+pattern VK_FORMAT_ETC2_R8G8B8_SRGB_BLOCK = Format 148
 
-pattern VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = VkFormat 149
+pattern VK_FORMAT_ETC2_R8G8B8A1_UNORM_BLOCK = Format 149
 
-pattern VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = VkFormat 150
+pattern VK_FORMAT_ETC2_R8G8B8A1_SRGB_BLOCK = Format 150
 
-pattern VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = VkFormat 151
+pattern VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK = Format 151
 
-pattern VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = VkFormat 152
+pattern VK_FORMAT_ETC2_R8G8B8A8_SRGB_BLOCK = Format 152
 
-pattern VK_FORMAT_EAC_R11_UNORM_BLOCK = VkFormat 153
+pattern VK_FORMAT_EAC_R11_UNORM_BLOCK = Format 153
 
-pattern VK_FORMAT_EAC_R11_SNORM_BLOCK = VkFormat 154
+pattern VK_FORMAT_EAC_R11_SNORM_BLOCK = Format 154
 
-pattern VK_FORMAT_EAC_R11G11_UNORM_BLOCK = VkFormat 155
+pattern VK_FORMAT_EAC_R11G11_UNORM_BLOCK = Format 155
 
-pattern VK_FORMAT_EAC_R11G11_SNORM_BLOCK = VkFormat 156
+pattern VK_FORMAT_EAC_R11G11_SNORM_BLOCK = Format 156
 
-pattern VK_FORMAT_ASTC_4x4_UNORM_BLOCK = VkFormat 157
+pattern VK_FORMAT_ASTC_4x4_UNORM_BLOCK = Format 157
 
-pattern VK_FORMAT_ASTC_4x4_SRGB_BLOCK = VkFormat 158
+pattern VK_FORMAT_ASTC_4x4_SRGB_BLOCK = Format 158
 
-pattern VK_FORMAT_ASTC_5x4_UNORM_BLOCK = VkFormat 159
+pattern VK_FORMAT_ASTC_5x4_UNORM_BLOCK = Format 159
 
-pattern VK_FORMAT_ASTC_5x4_SRGB_BLOCK = VkFormat 160
+pattern VK_FORMAT_ASTC_5x4_SRGB_BLOCK = Format 160
 
-pattern VK_FORMAT_ASTC_5x5_UNORM_BLOCK = VkFormat 161
+pattern VK_FORMAT_ASTC_5x5_UNORM_BLOCK = Format 161
 
-pattern VK_FORMAT_ASTC_5x5_SRGB_BLOCK = VkFormat 162
+pattern VK_FORMAT_ASTC_5x5_SRGB_BLOCK = Format 162
 
-pattern VK_FORMAT_ASTC_6x5_UNORM_BLOCK = VkFormat 163
+pattern VK_FORMAT_ASTC_6x5_UNORM_BLOCK = Format 163
 
-pattern VK_FORMAT_ASTC_6x5_SRGB_BLOCK = VkFormat 164
+pattern VK_FORMAT_ASTC_6x5_SRGB_BLOCK = Format 164
 
-pattern VK_FORMAT_ASTC_6x6_UNORM_BLOCK = VkFormat 165
+pattern VK_FORMAT_ASTC_6x6_UNORM_BLOCK = Format 165
 
-pattern VK_FORMAT_ASTC_6x6_SRGB_BLOCK = VkFormat 166
+pattern VK_FORMAT_ASTC_6x6_SRGB_BLOCK = Format 166
 
-pattern VK_FORMAT_ASTC_8x5_UNORM_BLOCK = VkFormat 167
+pattern VK_FORMAT_ASTC_8x5_UNORM_BLOCK = Format 167
 
-pattern VK_FORMAT_ASTC_8x5_SRGB_BLOCK = VkFormat 168
+pattern VK_FORMAT_ASTC_8x5_SRGB_BLOCK = Format 168
 
-pattern VK_FORMAT_ASTC_8x6_UNORM_BLOCK = VkFormat 169
+pattern VK_FORMAT_ASTC_8x6_UNORM_BLOCK = Format 169
 
-pattern VK_FORMAT_ASTC_8x6_SRGB_BLOCK = VkFormat 170
+pattern VK_FORMAT_ASTC_8x6_SRGB_BLOCK = Format 170
 
-pattern VK_FORMAT_ASTC_8x8_UNORM_BLOCK = VkFormat 171
+pattern VK_FORMAT_ASTC_8x8_UNORM_BLOCK = Format 171
 
-pattern VK_FORMAT_ASTC_8x8_SRGB_BLOCK = VkFormat 172
+pattern VK_FORMAT_ASTC_8x8_SRGB_BLOCK = Format 172
 
-pattern VK_FORMAT_ASTC_10x5_UNORM_BLOCK = VkFormat 173
+pattern VK_FORMAT_ASTC_10x5_UNORM_BLOCK = Format 173
 
-pattern VK_FORMAT_ASTC_10x5_SRGB_BLOCK = VkFormat 174
+pattern VK_FORMAT_ASTC_10x5_SRGB_BLOCK = Format 174
 
-pattern VK_FORMAT_ASTC_10x6_UNORM_BLOCK = VkFormat 175
+pattern VK_FORMAT_ASTC_10x6_UNORM_BLOCK = Format 175
 
-pattern VK_FORMAT_ASTC_10x6_SRGB_BLOCK = VkFormat 176
+pattern VK_FORMAT_ASTC_10x6_SRGB_BLOCK = Format 176
 
-pattern VK_FORMAT_ASTC_10x8_UNORM_BLOCK = VkFormat 177
+pattern VK_FORMAT_ASTC_10x8_UNORM_BLOCK = Format 177
 
-pattern VK_FORMAT_ASTC_10x8_SRGB_BLOCK = VkFormat 178
+pattern VK_FORMAT_ASTC_10x8_SRGB_BLOCK = Format 178
 
-pattern VK_FORMAT_ASTC_10x10_UNORM_BLOCK = VkFormat 179
+pattern VK_FORMAT_ASTC_10x10_UNORM_BLOCK = Format 179
 
-pattern VK_FORMAT_ASTC_10x10_SRGB_BLOCK = VkFormat 180
+pattern VK_FORMAT_ASTC_10x10_SRGB_BLOCK = Format 180
 
-pattern VK_FORMAT_ASTC_12x10_UNORM_BLOCK = VkFormat 181
+pattern VK_FORMAT_ASTC_12x10_UNORM_BLOCK = Format 181
 
-pattern VK_FORMAT_ASTC_12x10_SRGB_BLOCK = VkFormat 182
+pattern VK_FORMAT_ASTC_12x10_SRGB_BLOCK = Format 182
 
-pattern VK_FORMAT_ASTC_12x12_UNORM_BLOCK = VkFormat 183
+pattern VK_FORMAT_ASTC_12x12_UNORM_BLOCK = Format 183
 
-pattern VK_FORMAT_ASTC_12x12_SRGB_BLOCK = VkFormat 184
+pattern VK_FORMAT_ASTC_12x12_SRGB_BLOCK = Format 184
 
 type VkFlags = Word32
 
@@ -808,38 +808,38 @@ instance Storable Extent2D where
                 *> poke (ptr `plusPtr` 4) (height (poked :: Extent2D))
 
 
--- ** VkSharingMode
+-- ** SharingMode
 
-newtype VkSharingMode = VkSharingMode Int32
+newtype SharingMode = SharingMode Int32
   deriving (Eq, Storable)
 
-instance Show VkSharingMode where
+instance Show SharingMode where
   showsPrec _ VK_SHARING_MODE_EXCLUSIVE = showString "VK_SHARING_MODE_EXCLUSIVE"
   showsPrec _ VK_SHARING_MODE_CONCURRENT = showString "VK_SHARING_MODE_CONCURRENT"
-  showsPrec p (VkSharingMode x) = showParen (p >= 11) (showString "VkSharingMode " . showsPrec 11 x)
+  showsPrec p (SharingMode x) = showParen (p >= 11) (showString "SharingMode " . showsPrec 11 x)
 
-instance Read VkSharingMode where
+instance Read SharingMode where
   readPrec = parens ( choose [ ("VK_SHARING_MODE_EXCLUSIVE", pure VK_SHARING_MODE_EXCLUSIVE)
                              , ("VK_SHARING_MODE_CONCURRENT", pure VK_SHARING_MODE_CONCURRENT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSharingMode")
+                        expectP (Ident "SharingMode")
                         v <- step readPrec
-                        pure (VkSharingMode v)
+                        pure (SharingMode v)
                         )
                     )
 
 
-pattern VK_SHARING_MODE_EXCLUSIVE = VkSharingMode 0
+pattern VK_SHARING_MODE_EXCLUSIVE = SharingMode 0
 
-pattern VK_SHARING_MODE_CONCURRENT = VkSharingMode 1
+pattern VK_SHARING_MODE_CONCURRENT = SharingMode 1
 
--- ** VkStructureType
+-- ** StructureType
 -- | Structure type enumerant
-newtype VkStructureType = VkStructureType Int32
+newtype StructureType = StructureType Int32
   deriving (Eq, Storable)
 
-instance Show VkStructureType where
+instance Show StructureType where
   showsPrec _ VK_STRUCTURE_TYPE_APPLICATION_INFO = showString "VK_STRUCTURE_TYPE_APPLICATION_INFO"
   showsPrec _ VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO"
   showsPrec _ VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO"
@@ -889,9 +889,9 @@ instance Show VkStructureType where
   showsPrec _ VK_STRUCTURE_TYPE_MEMORY_BARRIER = showString "VK_STRUCTURE_TYPE_MEMORY_BARRIER"
   showsPrec _ VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO"
   showsPrec _ VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = showString "VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO"
-  showsPrec p (VkStructureType x) = showParen (p >= 11) (showString "VkStructureType " . showsPrec 11 x)
+  showsPrec p (StructureType x) = showParen (p >= 11) (showString "StructureType " . showsPrec 11 x)
 
-instance Read VkStructureType where
+instance Read StructureType where
   readPrec = parens ( choose [ ("VK_STRUCTURE_TYPE_APPLICATION_INFO", pure VK_STRUCTURE_TYPE_APPLICATION_INFO)
                              , ("VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO", pure VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO)
                              , ("VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO", pure VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO)
@@ -943,110 +943,110 @@ instance Read VkStructureType where
                              , ("VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO", pure VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkStructureType")
+                        expectP (Ident "StructureType")
                         v <- step readPrec
-                        pure (VkStructureType v)
+                        pure (StructureType v)
                         )
                     )
 
 
-pattern VK_STRUCTURE_TYPE_APPLICATION_INFO = VkStructureType 0
+pattern VK_STRUCTURE_TYPE_APPLICATION_INFO = StructureType 0
 
-pattern VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = VkStructureType 1
+pattern VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = StructureType 1
 
-pattern VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = VkStructureType 2
+pattern VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO = StructureType 2
 
-pattern VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO = VkStructureType 3
+pattern VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO = StructureType 3
 
-pattern VK_STRUCTURE_TYPE_SUBMIT_INFO = VkStructureType 4
+pattern VK_STRUCTURE_TYPE_SUBMIT_INFO = StructureType 4
 
-pattern VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO = VkStructureType 5
+pattern VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO = StructureType 5
 
-pattern VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE = VkStructureType 6
+pattern VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE = StructureType 6
 
-pattern VK_STRUCTURE_TYPE_BIND_SPARSE_INFO = VkStructureType 7
+pattern VK_STRUCTURE_TYPE_BIND_SPARSE_INFO = StructureType 7
 
-pattern VK_STRUCTURE_TYPE_FENCE_CREATE_INFO = VkStructureType 8
+pattern VK_STRUCTURE_TYPE_FENCE_CREATE_INFO = StructureType 8
 
-pattern VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO = VkStructureType 9
+pattern VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO = StructureType 9
 
-pattern VK_STRUCTURE_TYPE_EVENT_CREATE_INFO = VkStructureType 10
+pattern VK_STRUCTURE_TYPE_EVENT_CREATE_INFO = StructureType 10
 
-pattern VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO = VkStructureType 11
+pattern VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO = StructureType 11
 
-pattern VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO = VkStructureType 12
+pattern VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO = StructureType 12
 
-pattern VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO = VkStructureType 13
+pattern VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO = StructureType 13
 
-pattern VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO = VkStructureType 14
+pattern VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO = StructureType 14
 
-pattern VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO = VkStructureType 15
+pattern VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO = StructureType 15
 
-pattern VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO = VkStructureType 16
+pattern VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO = StructureType 16
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO = VkStructureType 17
+pattern VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO = StructureType 17
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO = VkStructureType 18
+pattern VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO = StructureType 18
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO = VkStructureType 19
+pattern VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO = StructureType 19
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO = VkStructureType 20
+pattern VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO = StructureType 20
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO = VkStructureType 21
+pattern VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO = StructureType 21
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO = VkStructureType 22
+pattern VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO = StructureType 22
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO = VkStructureType 23
+pattern VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO = StructureType 23
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO = VkStructureType 24
+pattern VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO = StructureType 24
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO = VkStructureType 25
+pattern VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO = StructureType 25
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO = VkStructureType 26
+pattern VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO = StructureType 26
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO = VkStructureType 27
+pattern VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO = StructureType 27
 
-pattern VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO = VkStructureType 28
+pattern VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO = StructureType 28
 
-pattern VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO = VkStructureType 29
+pattern VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO = StructureType 29
 
-pattern VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO = VkStructureType 30
+pattern VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO = StructureType 30
 
-pattern VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO = VkStructureType 31
+pattern VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO = StructureType 31
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO = VkStructureType 32
+pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO = StructureType 32
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO = VkStructureType 33
+pattern VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO = StructureType 33
 
-pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO = VkStructureType 34
+pattern VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO = StructureType 34
 
-pattern VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET = VkStructureType 35
+pattern VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET = StructureType 35
 
-pattern VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET = VkStructureType 36
+pattern VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET = StructureType 36
 
-pattern VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO = VkStructureType 37
+pattern VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO = StructureType 37
 
-pattern VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO = VkStructureType 38
+pattern VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO = StructureType 38
 
-pattern VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO = VkStructureType 39
+pattern VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO = StructureType 39
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO = VkStructureType 40
+pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO = StructureType 40
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO = VkStructureType 41
+pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO = StructureType 41
 
-pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO = VkStructureType 42
+pattern VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO = StructureType 42
 
-pattern VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO = VkStructureType 43
+pattern VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO = StructureType 43
 
-pattern VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER = VkStructureType 44
+pattern VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER = StructureType 44
 
-pattern VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = VkStructureType 45
+pattern VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER = StructureType 45
 
-pattern VK_STRUCTURE_TYPE_MEMORY_BARRIER = VkStructureType 46
+pattern VK_STRUCTURE_TYPE_MEMORY_BARRIER = StructureType 46
 
-pattern VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = VkStructureType 47
+pattern VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = StructureType 47
 
-pattern VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = VkStructureType 48
+pattern VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = StructureType 48
 
 newtype VkBool32 = VkBool32 Word32
   deriving (Eq, Storable)
@@ -1121,12 +1121,12 @@ instance Storable Rect3D where
                 *> poke (ptr `plusPtr` 12) (extent (poked :: Rect3D))
 
 
--- ** VkResult
+-- ** Result
 -- | Error and return codes
-newtype VkResult = VkResult Int32
+newtype Result = Result Int32
   deriving (Eq, Storable)
 
-instance Show VkResult where
+instance Show Result where
   showsPrec _ VK_SUCCESS = showString "VK_SUCCESS"
   showsPrec _ VK_NOT_READY = showString "VK_NOT_READY"
   showsPrec _ VK_TIMEOUT = showString "VK_TIMEOUT"
@@ -1144,9 +1144,9 @@ instance Show VkResult where
   showsPrec _ VK_ERROR_INCOMPATIBLE_DRIVER = showString "VK_ERROR_INCOMPATIBLE_DRIVER"
   showsPrec _ VK_ERROR_TOO_MANY_OBJECTS = showString "VK_ERROR_TOO_MANY_OBJECTS"
   showsPrec _ VK_ERROR_FORMAT_NOT_SUPPORTED = showString "VK_ERROR_FORMAT_NOT_SUPPORTED"
-  showsPrec p (VkResult x) = showParen (p >= 11) (showString "VkResult " . showsPrec 11 x)
+  showsPrec p (Result x) = showParen (p >= 11) (showString "Result " . showsPrec 11 x)
 
-instance Read VkResult where
+instance Read Result where
   readPrec = parens ( choose [ ("VK_SUCCESS", pure VK_SUCCESS)
                              , ("VK_NOT_READY", pure VK_NOT_READY)
                              , ("VK_TIMEOUT", pure VK_TIMEOUT)
@@ -1166,46 +1166,46 @@ instance Read VkResult where
                              , ("VK_ERROR_FORMAT_NOT_SUPPORTED", pure VK_ERROR_FORMAT_NOT_SUPPORTED)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkResult")
+                        expectP (Ident "Result")
                         v <- step readPrec
-                        pure (VkResult v)
+                        pure (Result v)
                         )
                     )
 
 -- | Command completed successfully
-pattern VK_SUCCESS = VkResult 0
+pattern VK_SUCCESS = Result 0
 -- | A fence or query has not yet completed
-pattern VK_NOT_READY = VkResult 1
+pattern VK_NOT_READY = Result 1
 -- | A wait operation has not completed in the specified time
-pattern VK_TIMEOUT = VkResult 2
+pattern VK_TIMEOUT = Result 2
 -- | An event is signaled
-pattern VK_EVENT_SET = VkResult 3
+pattern VK_EVENT_SET = Result 3
 -- | An event is unsignalled
-pattern VK_EVENT_RESET = VkResult 4
+pattern VK_EVENT_RESET = Result 4
 -- | A return array was too small for the resul
-pattern VK_INCOMPLETE = VkResult 5
+pattern VK_INCOMPLETE = Result 5
 -- | A host memory allocation has failed
-pattern VK_ERROR_OUT_OF_HOST_MEMORY = VkResult (-1)
+pattern VK_ERROR_OUT_OF_HOST_MEMORY = Result (-1)
 -- | A device memory allocation has failed
-pattern VK_ERROR_OUT_OF_DEVICE_MEMORY = VkResult (-2)
+pattern VK_ERROR_OUT_OF_DEVICE_MEMORY = Result (-2)
 -- | The logical device has been lost. See <<devsandqueues-lost-device>>
-pattern VK_ERROR_INITIALIZATION_FAILED = VkResult (-3)
+pattern VK_ERROR_INITIALIZATION_FAILED = Result (-3)
 -- | Initialization of a object has failed
-pattern VK_ERROR_DEVICE_LOST = VkResult (-4)
+pattern VK_ERROR_DEVICE_LOST = Result (-4)
 -- | Mapping of a memory object has failed
-pattern VK_ERROR_MEMORY_MAP_FAILED = VkResult (-5)
+pattern VK_ERROR_MEMORY_MAP_FAILED = Result (-5)
 -- | Layer specified does not exist
-pattern VK_ERROR_LAYER_NOT_PRESENT = VkResult (-6)
+pattern VK_ERROR_LAYER_NOT_PRESENT = Result (-6)
 -- | Extension specified does not exist
-pattern VK_ERROR_EXTENSION_NOT_PRESENT = VkResult (-7)
+pattern VK_ERROR_EXTENSION_NOT_PRESENT = Result (-7)
 -- | Requested feature is not available on this device
-pattern VK_ERROR_FEATURE_NOT_PRESENT = VkResult (-8)
+pattern VK_ERROR_FEATURE_NOT_PRESENT = Result (-8)
 -- | Unable to find a Vulkan driver
-pattern VK_ERROR_INCOMPATIBLE_DRIVER = VkResult (-9)
+pattern VK_ERROR_INCOMPATIBLE_DRIVER = Result (-9)
 -- | Too many objects of the type have already been created
-pattern VK_ERROR_TOO_MANY_OBJECTS = VkResult (-10)
+pattern VK_ERROR_TOO_MANY_OBJECTS = Result (-10)
 -- | Requested format is not supported on this device
-pattern VK_ERROR_FORMAT_NOT_SUPPORTED = VkResult (-11)
+pattern VK_ERROR_FORMAT_NOT_SUPPORTED = Result (-11)
 
 
 data Viewport =

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -793,19 +793,19 @@ pattern VK_FORMAT_ASTC_12x12_SRGB_BLOCK = VkFormat 184
 type VkFlags = Word32
 
 
-data VkExtent2D =
-  VkExtent2D{ width :: Word32 
-            , height :: Word32 
-            }
+data Extent2D =
+  Extent2D{ width :: Word32 
+          , height :: Word32 
+          }
   deriving (Eq)
 
-instance Storable VkExtent2D where
+instance Storable Extent2D where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkExtent2D <$> peek (ptr `plusPtr` 0)
-                        <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: VkExtent2D))
-                *> poke (ptr `plusPtr` 4) (height (poked :: VkExtent2D))
+  peek ptr = Extent2D <$> peek (ptr `plusPtr` 0)
+                      <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: Extent2D))
+                *> poke (ptr `plusPtr` 4) (height (poked :: Extent2D))
 
 
 -- ** VkSharingMode
@@ -1052,73 +1052,73 @@ newtype VkBool32 = VkBool32 Word32
   deriving (Eq, Storable)
 
 
-data VkOffset2D =
-  VkOffset2D{ x :: Int32 
-            , y :: Int32 
-            }
-  deriving (Eq)
-
-instance Storable VkOffset2D where
-  sizeOf ~_ = 8
-  alignment ~_ = 4
-  peek ptr = VkOffset2D <$> peek (ptr `plusPtr` 0)
-                        <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkOffset2D))
-                *> poke (ptr `plusPtr` 4) (y (poked :: VkOffset2D))
-
-
-
-data VkOffset3D =
-  VkOffset3D{ x :: Int32 
-            , y :: Int32 
-            , z :: Int32 
-            }
-  deriving (Eq)
-
-instance Storable VkOffset3D where
-  sizeOf ~_ = 12
-  alignment ~_ = 4
-  peek ptr = VkOffset3D <$> peek (ptr `plusPtr` 0)
-                        <*> peek (ptr `plusPtr` 4)
-                        <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkOffset3D))
-                *> poke (ptr `plusPtr` 4) (y (poked :: VkOffset3D))
-                *> poke (ptr `plusPtr` 8) (z (poked :: VkOffset3D))
-
-
-
-data VkExtent3D =
-  VkExtent3D{ width :: Word32 
-            , height :: Word32 
-            , depth :: Word32 
-            }
-  deriving (Eq)
-
-instance Storable VkExtent3D where
-  sizeOf ~_ = 12
-  alignment ~_ = 4
-  peek ptr = VkExtent3D <$> peek (ptr `plusPtr` 0)
-                        <*> peek (ptr `plusPtr` 4)
-                        <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: VkExtent3D))
-                *> poke (ptr `plusPtr` 4) (height (poked :: VkExtent3D))
-                *> poke (ptr `plusPtr` 8) (depth (poked :: VkExtent3D))
-
-
-
-data VkRect3D =
-  VkRect3D{ offset :: VkOffset3D 
-          , extent :: VkExtent3D 
+data Offset2D =
+  Offset2D{ x :: Int32 
+          , y :: Int32 
           }
   deriving (Eq)
 
-instance Storable VkRect3D where
+instance Storable Offset2D where
+  sizeOf ~_ = 8
+  alignment ~_ = 4
+  peek ptr = Offset2D <$> peek (ptr `plusPtr` 0)
+                      <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: Offset2D))
+                *> poke (ptr `plusPtr` 4) (y (poked :: Offset2D))
+
+
+
+data Offset3D =
+  Offset3D{ x :: Int32 
+          , y :: Int32 
+          , z :: Int32 
+          }
+  deriving (Eq)
+
+instance Storable Offset3D where
+  sizeOf ~_ = 12
+  alignment ~_ = 4
+  peek ptr = Offset3D <$> peek (ptr `plusPtr` 0)
+                      <*> peek (ptr `plusPtr` 4)
+                      <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: Offset3D))
+                *> poke (ptr `plusPtr` 4) (y (poked :: Offset3D))
+                *> poke (ptr `plusPtr` 8) (z (poked :: Offset3D))
+
+
+
+data Extent3D =
+  Extent3D{ width :: Word32 
+          , height :: Word32 
+          , depth :: Word32 
+          }
+  deriving (Eq)
+
+instance Storable Extent3D where
+  sizeOf ~_ = 12
+  alignment ~_ = 4
+  peek ptr = Extent3D <$> peek (ptr `plusPtr` 0)
+                      <*> peek (ptr `plusPtr` 4)
+                      <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (width (poked :: Extent3D))
+                *> poke (ptr `plusPtr` 4) (height (poked :: Extent3D))
+                *> poke (ptr `plusPtr` 8) (depth (poked :: Extent3D))
+
+
+
+data Rect3D =
+  Rect3D{ offset :: Offset3D 
+        , extent :: Extent3D 
+        }
+  deriving (Eq)
+
+instance Storable Rect3D where
   sizeOf ~_ = 24
   alignment ~_ = 4
-  peek ptr = VkRect3D <$> peek (ptr `plusPtr` 0)
-                      <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkRect3D))
-                *> poke (ptr `plusPtr` 12) (extent (poked :: VkRect3D))
+  peek ptr = Rect3D <$> peek (ptr `plusPtr` 0)
+                    <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: Rect3D))
+                *> poke (ptr `plusPtr` 12) (extent (poked :: Rect3D))
 
 
 -- ** VkResult
@@ -1208,46 +1208,46 @@ pattern VK_ERROR_TOO_MANY_OBJECTS = VkResult (-10)
 pattern VK_ERROR_FORMAT_NOT_SUPPORTED = VkResult (-11)
 
 
-data VkViewport =
-  VkViewport{ x :: CFloat 
-            , y :: CFloat 
-            , width :: CFloat 
-            , height :: CFloat 
-            , minDepth :: CFloat 
-            , maxDepth :: CFloat 
-            }
-  deriving (Eq)
-
-instance Storable VkViewport where
-  sizeOf ~_ = 24
-  alignment ~_ = 4
-  peek ptr = VkViewport <$> peek (ptr `plusPtr` 0)
-                        <*> peek (ptr `plusPtr` 4)
-                        <*> peek (ptr `plusPtr` 8)
-                        <*> peek (ptr `plusPtr` 12)
-                        <*> peek (ptr `plusPtr` 16)
-                        <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 4) (y (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 8) (width (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 12) (height (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 16) (minDepth (poked :: VkViewport))
-                *> poke (ptr `plusPtr` 20) (maxDepth (poked :: VkViewport))
-
-
-
-data VkRect2D =
-  VkRect2D{ offset :: VkOffset2D 
-          , extent :: VkExtent2D 
+data Viewport =
+  Viewport{ x :: CFloat 
+          , y :: CFloat 
+          , width :: CFloat 
+          , height :: CFloat 
+          , minDepth :: CFloat 
+          , maxDepth :: CFloat 
           }
   deriving (Eq)
 
-instance Storable VkRect2D where
+instance Storable Viewport where
+  sizeOf ~_ = 24
+  alignment ~_ = 4
+  peek ptr = Viewport <$> peek (ptr `plusPtr` 0)
+                      <*> peek (ptr `plusPtr` 4)
+                      <*> peek (ptr `plusPtr` 8)
+                      <*> peek (ptr `plusPtr` 12)
+                      <*> peek (ptr `plusPtr` 16)
+                      <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: Viewport))
+                *> poke (ptr `plusPtr` 4) (y (poked :: Viewport))
+                *> poke (ptr `plusPtr` 8) (width (poked :: Viewport))
+                *> poke (ptr `plusPtr` 12) (height (poked :: Viewport))
+                *> poke (ptr `plusPtr` 16) (minDepth (poked :: Viewport))
+                *> poke (ptr `plusPtr` 20) (maxDepth (poked :: Viewport))
+
+
+
+data Rect2D =
+  Rect2D{ offset :: Offset2D 
+        , extent :: Extent2D 
+        }
+  deriving (Eq)
+
+instance Storable Rect2D where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ptr = VkRect2D <$> peek (ptr `plusPtr` 0)
-                      <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkRect2D))
-                *> poke (ptr `plusPtr` 8) (extent (poked :: VkRect2D))
+  peek ptr = Rect2D <$> peek (ptr `plusPtr` 0)
+                    <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: Rect2D))
+                *> poke (ptr `plusPtr` 8) (extent (poked :: Rect2D))
 
 

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -9,12 +9,13 @@ import Text.Read.Lex( Lexeme(Ident)
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
 import Foreign.Ptr( plusPtr
                   )
-import Data.Int( Int32
+import Data.Int( Int32(..)
+               , Int32
                )
 import Foreign.Storable( Storable(..)
                        )
@@ -25,12 +26,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkExtent3D
-                           , VkExtent2D
-                           , VkOffset2D
-                           , VkOffset3D
-                           )
-import Foreign.C.Types( CFloat
+import Foreign.C.Types( CFloat(..)
                       )
 
 newtype VkDeviceSize = VkDeviceSize Word64

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -29,7 +29,7 @@ import Text.ParserCombinators.ReadPrec( prec
 import Foreign.C.Types( CFloat(..)
                       )
 
-newtype VkDeviceSize = VkDeviceSize Word64
+newtype DeviceSize = DeviceSize Word64
   deriving (Eq, Storable)
 
 -- ** Format
@@ -790,7 +790,7 @@ pattern VK_FORMAT_ASTC_12x12_UNORM_BLOCK = Format 183
 
 pattern VK_FORMAT_ASTC_12x12_SRGB_BLOCK = Format 184
 
-type VkFlags = Word32
+type Flags = Word32
 
 
 data Extent2D =
@@ -1048,7 +1048,7 @@ pattern VK_STRUCTURE_TYPE_LOADER_INSTANCE_CREATE_INFO = StructureType 47
 
 pattern VK_STRUCTURE_TYPE_LOADER_DEVICE_CREATE_INFO = StructureType 48
 
-newtype VkBool32 = VkBool32 Word32
+newtype Bool32 = Bool32 Word32
   deriving (Eq, Storable)
 
 

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -30,12 +30,12 @@ import Foreign.C.Types( CFloat(..)
                       )
 
 newtype DeviceSize = DeviceSize Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** Format
 -- | Vulkan format definitions
 newtype Format = Format Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show Format where
   showsPrec _ FormatUndefined = showString "FormatUndefined"
@@ -797,7 +797,7 @@ data Extent2D =
   Extent2D{ width :: Word32 
           , height :: Word32 
           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Extent2D where
   sizeOf ~_ = 8
@@ -811,7 +811,7 @@ instance Storable Extent2D where
 -- ** SharingMode
 
 newtype SharingMode = SharingMode Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show SharingMode where
   showsPrec _ SharingModeExclusive = showString "SharingModeExclusive"
@@ -837,7 +837,7 @@ pattern SharingModeConcurrent = SharingMode 1
 -- ** StructureType
 -- | Structure type enumerant
 newtype StructureType = StructureType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show StructureType where
   showsPrec _ StructureTypeApplicationInfo = showString "StructureTypeApplicationInfo"
@@ -1049,14 +1049,14 @@ pattern StructureTypeLoaderInstanceCreateInfo = StructureType 47
 pattern StructureTypeLoaderDeviceCreateInfo = StructureType 48
 
 newtype Bool32 = Bool32 Word32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data Offset2D =
   Offset2D{ x :: Int32 
           , y :: Int32 
           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Offset2D where
   sizeOf ~_ = 8
@@ -1073,7 +1073,7 @@ data Offset3D =
           , y :: Int32 
           , z :: Int32 
           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Offset3D where
   sizeOf ~_ = 12
@@ -1092,7 +1092,7 @@ data Extent3D =
           , height :: Word32 
           , depth :: Word32 
           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Extent3D where
   sizeOf ~_ = 12
@@ -1110,7 +1110,7 @@ data Rect3D =
   Rect3D{ offset :: Offset3D 
         , extent :: Extent3D 
         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Rect3D where
   sizeOf ~_ = 24
@@ -1124,7 +1124,7 @@ instance Storable Rect3D where
 -- ** Result
 -- | Error and return codes
 newtype Result = Result Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show Result where
   showsPrec _ Success = showString "Success"
@@ -1216,7 +1216,7 @@ data Viewport =
           , minDepth :: CFloat 
           , maxDepth :: CFloat 
           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Viewport where
   sizeOf ~_ = 24
@@ -1240,7 +1240,7 @@ data Rect2D =
   Rect2D{ offset :: Offset2D 
         , extent :: Extent2D 
         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable Rect2D where
   sizeOf ~_ = 16

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -4,10 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.DescriptorSet where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -28,15 +24,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -44,24 +31,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
-                             , VkShaderStageFlags(..)
-                             )
-import Graphics.Vulkan.Sampler( Sampler(..)
-                              )
-import Graphics.Vulkan.Image( VkImageLayout(..)
-                            )
-import Graphics.Vulkan.ImageView( ImageView(..)
-                                )
-import Graphics.Vulkan.BufferView( BufferView(..)
-                                 )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkUpdateDescriptorSets
 foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -4,9 +4,9 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.DescriptorSet where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -47,13 +47,13 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
                              , VkShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Sampler( VkSampler(..)
+import Graphics.Vulkan.Sampler( Sampler(..)
                               )
 import Graphics.Vulkan.Image( VkImageLayout(..)
                             )
-import Graphics.Vulkan.ImageView( VkImageView(..)
+import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
-import Graphics.Vulkan.BufferView( VkBufferView(..)
+import Graphics.Vulkan.BufferView( BufferView(..)
                                  )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkDeviceSize(..)
@@ -65,7 +65,7 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkUpdateDescriptorSets
 foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
-  VkDevice ->
+  Device ->
   Word32 ->
     Ptr VkWriteDescriptorSet ->
       Word32 -> Ptr VkCopyDescriptorSet -> IO ()
@@ -77,15 +77,14 @@ newtype VkDescriptorPoolResetFlags = VkDescriptorPoolResetFlags VkFlags
 
 -- ** vkAllocateDescriptorSets
 foreign import ccall "vkAllocateDescriptorSets" vkAllocateDescriptorSets ::
-  VkDevice ->
-  Ptr VkDescriptorSetAllocateInfo ->
-    Ptr VkDescriptorSet -> IO VkResult
+  Device ->
+  Ptr VkDescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO VkResult
 
 
 data VkDescriptorBufferInfo =
-  VkDescriptorBufferInfo{ vkBuffer :: VkBuffer 
-                        , vkOffset :: VkDeviceSize 
-                        , vkRange :: VkDeviceSize 
+  VkDescriptorBufferInfo{ buffer :: Buffer 
+                        , offset :: VkDeviceSize 
+                        , range :: VkDeviceSize 
                         }
   deriving (Eq)
 
@@ -95,16 +94,16 @@ instance Storable VkDescriptorBufferInfo where
   peek ptr = VkDescriptorBufferInfo <$> peek (ptr `plusPtr` 0)
                                     <*> peek (ptr `plusPtr` 8)
                                     <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBuffer (poked :: VkDescriptorBufferInfo))
-                *> poke (ptr `plusPtr` 8) (vkOffset (poked :: VkDescriptorBufferInfo))
-                *> poke (ptr `plusPtr` 16) (vkRange (poked :: VkDescriptorBufferInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: VkDescriptorBufferInfo))
+                *> poke (ptr `plusPtr` 8) (offset (poked :: VkDescriptorBufferInfo))
+                *> poke (ptr `plusPtr` 16) (range (poked :: VkDescriptorBufferInfo))
 
 
 
 data VkDescriptorImageInfo =
-  VkDescriptorImageInfo{ vkSampler :: VkSampler 
-                       , vkImageView :: VkImageView 
-                       , vkImageLayout :: VkImageLayout 
+  VkDescriptorImageInfo{ sampler :: Sampler 
+                       , imageView :: ImageView 
+                       , imageLayout :: VkImageLayout 
                        }
   deriving (Eq)
 
@@ -114,22 +113,22 @@ instance Storable VkDescriptorImageInfo where
   peek ptr = VkDescriptorImageInfo <$> peek (ptr `plusPtr` 0)
                                    <*> peek (ptr `plusPtr` 8)
                                    <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSampler (poked :: VkDescriptorImageInfo))
-                *> poke (ptr `plusPtr` 8) (vkImageView (poked :: VkDescriptorImageInfo))
-                *> poke (ptr `plusPtr` 16) (vkImageLayout (poked :: VkDescriptorImageInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sampler (poked :: VkDescriptorImageInfo))
+                *> poke (ptr `plusPtr` 8) (imageView (poked :: VkDescriptorImageInfo))
+                *> poke (ptr `plusPtr` 16) (imageLayout (poked :: VkDescriptorImageInfo))
 
 
 
 data VkCopyDescriptorSet =
-  VkCopyDescriptorSet{ vkSType :: VkStructureType 
-                     , vkPNext :: Ptr Void 
-                     , vkSrcSet :: VkDescriptorSet 
-                     , vkSrcBinding :: Word32 
-                     , vkSrcArrayElement :: Word32 
-                     , vkDstSet :: VkDescriptorSet 
-                     , vkDstBinding :: Word32 
-                     , vkDstArrayElement :: Word32 
-                     , vkDescriptorCount :: Word32 
+  VkCopyDescriptorSet{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , srcSet :: DescriptorSet 
+                     , srcBinding :: Word32 
+                     , srcArrayElement :: Word32 
+                     , dstSet :: DescriptorSet 
+                     , dstBinding :: Word32 
+                     , dstArrayElement :: Word32 
+                     , descriptorCount :: Word32 
                      }
   deriving (Eq)
 
@@ -145,52 +144,51 @@ instance Storable VkCopyDescriptorSet where
                                  <*> peek (ptr `plusPtr` 40)
                                  <*> peek (ptr `plusPtr` 44)
                                  <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 16) (vkSrcSet (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 24) (vkSrcBinding (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 28) (vkSrcArrayElement (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 32) (vkDstSet (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 40) (vkDstBinding (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 44) (vkDstArrayElement (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 48) (vkDescriptorCount (poked :: VkCopyDescriptorSet))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 16) (srcSet (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 24) (srcBinding (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 28) (srcArrayElement (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 32) (dstSet (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 40) (dstBinding (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 44) (dstArrayElement (poked :: VkCopyDescriptorSet))
+                *> poke (ptr `plusPtr` 48) (descriptorCount (poked :: VkCopyDescriptorSet))
 
 
 -- ** vkDestroyDescriptorPool
 foreign import ccall "vkDestroyDescriptorPool" vkDestroyDescriptorPool ::
-  VkDevice -> VkDescriptorPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DescriptorPool -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** vkCreateDescriptorSetLayout
 foreign import ccall "vkCreateDescriptorSetLayout" vkCreateDescriptorSetLayout ::
-  VkDevice ->
+  Device ->
   Ptr VkDescriptorSetLayoutCreateInfo ->
-    Ptr VkAllocationCallbacks ->
-      Ptr VkDescriptorSetLayout -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr DescriptorSetLayout -> IO VkResult
 
-newtype VkDescriptorPool = VkDescriptorPool Word64
+newtype DescriptorPool = DescriptorPool Word64
   deriving (Eq, Storable)
 
 -- ** vkResetDescriptorPool
 foreign import ccall "vkResetDescriptorPool" vkResetDescriptorPool ::
-  VkDevice ->
-  VkDescriptorPool -> VkDescriptorPoolResetFlags -> IO VkResult
+  Device ->
+  DescriptorPool -> VkDescriptorPoolResetFlags -> IO VkResult
 
-newtype VkDescriptorSetLayout = VkDescriptorSetLayout Word64
+newtype DescriptorSetLayout = DescriptorSetLayout Word64
   deriving (Eq, Storable)
 
 -- ** vkFreeDescriptorSets
 foreign import ccall "vkFreeDescriptorSets" vkFreeDescriptorSets ::
-  VkDevice ->
-  VkDescriptorPool -> Word32 -> Ptr VkDescriptorSet -> IO VkResult
+  Device ->
+  DescriptorPool -> Word32 -> Ptr DescriptorSet -> IO VkResult
 
 
 data VkDescriptorPoolCreateInfo =
-  VkDescriptorPoolCreateInfo{ vkSType :: VkStructureType 
-                            , vkPNext :: Ptr Void 
-                            , vkFlags :: VkDescriptorPoolCreateFlags 
-                            , vkMaxSets :: Word32 
-                            , vkPoolSizeCount :: Word32 
-                            , vkPPoolSizes :: Ptr VkDescriptorPoolSize 
+  VkDescriptorPoolCreateInfo{ sType :: VkStructureType 
+                            , pNext :: Ptr Void 
+                            , flags :: VkDescriptorPoolCreateFlags 
+                            , maxSets :: Word32 
+                            , poolSizeCount :: Word32 
+                            , pPoolSizes :: Ptr VkDescriptorPoolSize 
                             }
   deriving (Eq)
 
@@ -203,12 +201,12 @@ instance Storable VkDescriptorPoolCreateInfo where
                                         <*> peek (ptr `plusPtr` 20)
                                         <*> peek (ptr `plusPtr` 24)
                                         <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkMaxSets (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPoolSizeCount (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPPoolSizes (poked :: VkDescriptorPoolCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (maxSets (poked :: VkDescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 24) (poolSizeCount (poked :: VkDescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pPoolSizes (poked :: VkDescriptorPoolCreateInfo))
 
 
 -- ** VkDescriptorSetLayoutCreateFlags
@@ -218,11 +216,11 @@ newtype VkDescriptorSetLayoutCreateFlags = VkDescriptorSetLayoutCreateFlags VkFl
 
 
 data VkDescriptorSetLayoutCreateInfo =
-  VkDescriptorSetLayoutCreateInfo{ vkSType :: VkStructureType 
-                                 , vkPNext :: Ptr Void 
-                                 , vkFlags :: VkDescriptorSetLayoutCreateFlags 
-                                 , vkBindingCount :: Word32 
-                                 , vkPBindings :: Ptr VkDescriptorSetLayoutBinding 
+  VkDescriptorSetLayoutCreateInfo{ sType :: VkStructureType 
+                                 , pNext :: Ptr Void 
+                                 , flags :: VkDescriptorSetLayoutCreateFlags 
+                                 , bindingCount :: Word32 
+                                 , pBindings :: Ptr VkDescriptorSetLayoutBinding 
                                  }
   deriving (Eq)
 
@@ -234,11 +232,11 @@ instance Storable VkDescriptorSetLayoutCreateInfo where
                                              <*> peek (ptr `plusPtr` 16)
                                              <*> peek (ptr `plusPtr` 20)
                                              <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkBindingCount (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPBindings (poked :: VkDescriptorSetLayoutCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 20) (bindingCount (poked :: VkDescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pBindings (poked :: VkDescriptorSetLayoutCreateInfo))
 
 
 -- ** VkDescriptorPoolCreateFlags
@@ -270,8 +268,8 @@ pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = VkDescriptorPoolCrea
 
 
 data VkDescriptorPoolSize =
-  VkDescriptorPoolSize{ vkType :: VkDescriptorType 
-                      , vkDescriptorCount :: Word32 
+  VkDescriptorPoolSize{ _type :: VkDescriptorType 
+                      , descriptorCount :: Word32 
                       }
   deriving (Eq)
 
@@ -280,25 +278,25 @@ instance Storable VkDescriptorPoolSize where
   alignment ~_ = 4
   peek ptr = VkDescriptorPoolSize <$> peek (ptr `plusPtr` 0)
                                   <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkType (poked :: VkDescriptorPoolSize))
-                *> poke (ptr `plusPtr` 4) (vkDescriptorCount (poked :: VkDescriptorPoolSize))
+  poke ptr poked = poke (ptr `plusPtr` 0) (_type (poked :: VkDescriptorPoolSize))
+                *> poke (ptr `plusPtr` 4) (descriptorCount (poked :: VkDescriptorPoolSize))
 
 
-newtype VkDescriptorSet = VkDescriptorSet Word64
+newtype DescriptorSet = DescriptorSet Word64
   deriving (Eq, Storable)
 
 
 data VkWriteDescriptorSet =
-  VkWriteDescriptorSet{ vkSType :: VkStructureType 
-                      , vkPNext :: Ptr Void 
-                      , vkDstSet :: VkDescriptorSet 
-                      , vkDstBinding :: Word32 
-                      , vkDstArrayElement :: Word32 
-                      , vkDescriptorCount :: Word32 
-                      , vkDescriptorType :: VkDescriptorType 
-                      , vkPImageInfo :: Ptr VkDescriptorImageInfo 
-                      , vkPBufferInfo :: Ptr VkDescriptorBufferInfo 
-                      , vkPTexelBufferView :: Ptr VkBufferView 
+  VkWriteDescriptorSet{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , dstSet :: DescriptorSet 
+                      , dstBinding :: Word32 
+                      , dstArrayElement :: Word32 
+                      , descriptorCount :: Word32 
+                      , descriptorType :: VkDescriptorType 
+                      , pImageInfo :: Ptr VkDescriptorImageInfo 
+                      , pBufferInfo :: Ptr VkDescriptorBufferInfo 
+                      , pTexelBufferView :: Ptr BufferView 
                       }
   deriving (Eq)
 
@@ -315,36 +313,35 @@ instance Storable VkWriteDescriptorSet where
                                   <*> peek (ptr `plusPtr` 40)
                                   <*> peek (ptr `plusPtr` 48)
                                   <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 16) (vkDstSet (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 24) (vkDstBinding (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 28) (vkDstArrayElement (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 32) (vkDescriptorCount (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 36) (vkDescriptorType (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 40) (vkPImageInfo (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 48) (vkPBufferInfo (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 56) (vkPTexelBufferView (poked :: VkWriteDescriptorSet))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 16) (dstSet (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 24) (dstBinding (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 28) (dstArrayElement (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 32) (descriptorCount (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 36) (descriptorType (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 40) (pImageInfo (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 48) (pBufferInfo (poked :: VkWriteDescriptorSet))
+                *> poke (ptr `plusPtr` 56) (pTexelBufferView (poked :: VkWriteDescriptorSet))
 
 
 -- ** vkCreateDescriptorPool
 foreign import ccall "vkCreateDescriptorPool" vkCreateDescriptorPool ::
-  VkDevice ->
+  Device ->
   Ptr VkDescriptorPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkDescriptorPool -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr DescriptorPool -> IO VkResult
 
 -- ** vkDestroyDescriptorSetLayout
 foreign import ccall "vkDestroyDescriptorSetLayout" vkDestroyDescriptorSetLayout ::
-  VkDevice ->
-  VkDescriptorSetLayout -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DescriptorSetLayout -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkDescriptorSetLayoutBinding =
-  VkDescriptorSetLayoutBinding{ vkBinding :: Word32 
-                              , vkDescriptorType :: VkDescriptorType 
-                              , vkDescriptorCount :: Word32 
-                              , vkStageFlags :: VkShaderStageFlags 
-                              , vkPImmutableSamplers :: Ptr VkSampler 
+  VkDescriptorSetLayoutBinding{ binding :: Word32 
+                              , descriptorType :: VkDescriptorType 
+                              , descriptorCount :: Word32 
+                              , stageFlags :: VkShaderStageFlags 
+                              , pImmutableSamplers :: Ptr Sampler 
                               }
   deriving (Eq)
 
@@ -356,11 +353,11 @@ instance Storable VkDescriptorSetLayoutBinding where
                                           <*> peek (ptr `plusPtr` 8)
                                           <*> peek (ptr `plusPtr` 12)
                                           <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBinding (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 4) (vkDescriptorType (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 8) (vkDescriptorCount (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 12) (vkStageFlags (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 16) (vkPImmutableSamplers (poked :: VkDescriptorSetLayoutBinding))
+  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: VkDescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 4) (descriptorType (poked :: VkDescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 8) (descriptorCount (poked :: VkDescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 12) (stageFlags (poked :: VkDescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 16) (pImmutableSamplers (poked :: VkDescriptorSetLayoutBinding))
 
 
 -- ** VkDescriptorType
@@ -427,11 +424,11 @@ pattern VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = VkDescriptorType 10
 
 
 data VkDescriptorSetAllocateInfo =
-  VkDescriptorSetAllocateInfo{ vkSType :: VkStructureType 
-                             , vkPNext :: Ptr Void 
-                             , vkDescriptorPool :: VkDescriptorPool 
-                             , vkDescriptorSetCount :: Word32 
-                             , vkPSetLayouts :: Ptr VkDescriptorSetLayout 
+  VkDescriptorSetAllocateInfo{ sType :: VkStructureType 
+                             , pNext :: Ptr Void 
+                             , descriptorPool :: DescriptorPool 
+                             , descriptorSetCount :: Word32 
+                             , pSetLayouts :: Ptr DescriptorSetLayout 
                              }
   deriving (Eq)
 
@@ -443,10 +440,10 @@ instance Storable VkDescriptorSetAllocateInfo where
                                          <*> peek (ptr `plusPtr` 16)
                                          <*> peek (ptr `plusPtr` 24)
                                          <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (vkDescriptorPool (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (vkDescriptorSetCount (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPSetLayouts (poked :: VkDescriptorSetAllocateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (descriptorPool (poked :: VkDescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (descriptorSetCount (poked :: VkDescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 32) (pSetLayouts (poked :: VkDescriptorSetAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -233,12 +233,12 @@ newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DescriptorPoolCreateFlags where
-  showsPrec _ VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = showString "VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT"
+  showsPrec _ DescriptorPoolCreateFreeDescriptorSetBit = showString "DescriptorPoolCreateFreeDescriptorSetBit"
   
   showsPrec p (DescriptorPoolCreateFlags x) = showParen (p >= 11) (showString "DescriptorPoolCreateFlags " . showsPrec 11 x)
 
 instance Read DescriptorPoolCreateFlags where
-  readPrec = parens ( choose [ ("VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT", pure VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT)
+  readPrec = parens ( choose [ ("DescriptorPoolCreateFreeDescriptorSetBit", pure DescriptorPoolCreateFreeDescriptorSetBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DescriptorPoolCreateFlags")
@@ -248,7 +248,7 @@ instance Read DescriptorPoolCreateFlags where
                     )
 
 -- | Descriptor sets may be freed individually
-pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = DescriptorPoolCreateFlags 0x1
+pattern DescriptorPoolCreateFreeDescriptorSetBit = DescriptorPoolCreateFlags 0x1
 
 
 

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -28,7 +28,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -57,8 +57,7 @@ import Graphics.Vulkan.Core( VkStructureType(..)
 foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
   Device ->
   Word32 ->
-    Ptr VkWriteDescriptorSet ->
-      Word32 -> Ptr VkCopyDescriptorSet -> IO ()
+    Ptr WriteDescriptorSet -> Word32 -> Ptr CopyDescriptorSet -> IO ()
 
 -- ** VkDescriptorPoolResetFlags
 -- | Opaque flag
@@ -68,92 +67,92 @@ newtype VkDescriptorPoolResetFlags = VkDescriptorPoolResetFlags VkFlags
 -- ** vkAllocateDescriptorSets
 foreign import ccall "vkAllocateDescriptorSets" vkAllocateDescriptorSets ::
   Device ->
-  Ptr VkDescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO VkResult
+  Ptr DescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO VkResult
 
 
-data VkDescriptorBufferInfo =
-  VkDescriptorBufferInfo{ buffer :: Buffer 
-                        , offset :: VkDeviceSize 
-                        , range :: VkDeviceSize 
-                        }
+data DescriptorBufferInfo =
+  DescriptorBufferInfo{ buffer :: Buffer 
+                      , offset :: VkDeviceSize 
+                      , range :: VkDeviceSize 
+                      }
   deriving (Eq)
 
-instance Storable VkDescriptorBufferInfo where
+instance Storable DescriptorBufferInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkDescriptorBufferInfo <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: VkDescriptorBufferInfo))
-                *> poke (ptr `plusPtr` 8) (offset (poked :: VkDescriptorBufferInfo))
-                *> poke (ptr `plusPtr` 16) (range (poked :: VkDescriptorBufferInfo))
+  peek ptr = DescriptorBufferInfo <$> peek (ptr `plusPtr` 0)
+                                  <*> peek (ptr `plusPtr` 8)
+                                  <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: DescriptorBufferInfo))
+                *> poke (ptr `plusPtr` 8) (offset (poked :: DescriptorBufferInfo))
+                *> poke (ptr `plusPtr` 16) (range (poked :: DescriptorBufferInfo))
 
 
 
-data VkDescriptorImageInfo =
-  VkDescriptorImageInfo{ sampler :: Sampler 
-                       , imageView :: ImageView 
-                       , imageLayout :: VkImageLayout 
-                       }
-  deriving (Eq)
-
-instance Storable VkDescriptorImageInfo where
-  sizeOf ~_ = 24
-  alignment ~_ = 8
-  peek ptr = VkDescriptorImageInfo <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sampler (poked :: VkDescriptorImageInfo))
-                *> poke (ptr `plusPtr` 8) (imageView (poked :: VkDescriptorImageInfo))
-                *> poke (ptr `plusPtr` 16) (imageLayout (poked :: VkDescriptorImageInfo))
-
-
-
-data VkCopyDescriptorSet =
-  VkCopyDescriptorSet{ sType :: VkStructureType 
-                     , pNext :: Ptr Void 
-                     , srcSet :: DescriptorSet 
-                     , srcBinding :: Word32 
-                     , srcArrayElement :: Word32 
-                     , dstSet :: DescriptorSet 
-                     , dstBinding :: Word32 
-                     , dstArrayElement :: Word32 
-                     , descriptorCount :: Word32 
+data DescriptorImageInfo =
+  DescriptorImageInfo{ sampler :: Sampler 
+                     , imageView :: ImageView 
+                     , imageLayout :: VkImageLayout 
                      }
   deriving (Eq)
 
-instance Storable VkCopyDescriptorSet where
-  sizeOf ~_ = 56
+instance Storable DescriptorImageInfo where
+  sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkCopyDescriptorSet <$> peek (ptr `plusPtr` 0)
+  peek ptr = DescriptorImageInfo <$> peek (ptr `plusPtr` 0)
                                  <*> peek (ptr `plusPtr` 8)
                                  <*> peek (ptr `plusPtr` 16)
-                                 <*> peek (ptr `plusPtr` 24)
-                                 <*> peek (ptr `plusPtr` 28)
-                                 <*> peek (ptr `plusPtr` 32)
-                                 <*> peek (ptr `plusPtr` 40)
-                                 <*> peek (ptr `plusPtr` 44)
-                                 <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 16) (srcSet (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 24) (srcBinding (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 28) (srcArrayElement (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 32) (dstSet (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 40) (dstBinding (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 44) (dstArrayElement (poked :: VkCopyDescriptorSet))
-                *> poke (ptr `plusPtr` 48) (descriptorCount (poked :: VkCopyDescriptorSet))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sampler (poked :: DescriptorImageInfo))
+                *> poke (ptr `plusPtr` 8) (imageView (poked :: DescriptorImageInfo))
+                *> poke (ptr `plusPtr` 16) (imageLayout (poked :: DescriptorImageInfo))
+
+
+
+data CopyDescriptorSet =
+  CopyDescriptorSet{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , srcSet :: DescriptorSet 
+                   , srcBinding :: Word32 
+                   , srcArrayElement :: Word32 
+                   , dstSet :: DescriptorSet 
+                   , dstBinding :: Word32 
+                   , dstArrayElement :: Word32 
+                   , descriptorCount :: Word32 
+                   }
+  deriving (Eq)
+
+instance Storable CopyDescriptorSet where
+  sizeOf ~_ = 56
+  alignment ~_ = 8
+  peek ptr = CopyDescriptorSet <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 24)
+                               <*> peek (ptr `plusPtr` 28)
+                               <*> peek (ptr `plusPtr` 32)
+                               <*> peek (ptr `plusPtr` 40)
+                               <*> peek (ptr `plusPtr` 44)
+                               <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 16) (srcSet (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 24) (srcBinding (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 28) (srcArrayElement (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 32) (dstSet (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 40) (dstBinding (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 44) (dstArrayElement (poked :: CopyDescriptorSet))
+                *> poke (ptr `plusPtr` 48) (descriptorCount (poked :: CopyDescriptorSet))
 
 
 -- ** vkDestroyDescriptorPool
 foreign import ccall "vkDestroyDescriptorPool" vkDestroyDescriptorPool ::
-  Device -> DescriptorPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DescriptorPool -> Ptr AllocationCallbacks -> IO ()
 
 -- ** vkCreateDescriptorSetLayout
 foreign import ccall "vkCreateDescriptorSetLayout" vkCreateDescriptorSetLayout ::
   Device ->
-  Ptr VkDescriptorSetLayoutCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr DescriptorSetLayout -> IO VkResult
+  Ptr DescriptorSetLayoutCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr DescriptorSetLayout -> IO VkResult
 
 newtype DescriptorPool = DescriptorPool Word64
   deriving (Eq, Storable)
@@ -172,31 +171,31 @@ foreign import ccall "vkFreeDescriptorSets" vkFreeDescriptorSets ::
   DescriptorPool -> Word32 -> Ptr DescriptorSet -> IO VkResult
 
 
-data VkDescriptorPoolCreateInfo =
-  VkDescriptorPoolCreateInfo{ sType :: VkStructureType 
-                            , pNext :: Ptr Void 
-                            , flags :: VkDescriptorPoolCreateFlags 
-                            , maxSets :: Word32 
-                            , poolSizeCount :: Word32 
-                            , pPoolSizes :: Ptr VkDescriptorPoolSize 
-                            }
+data DescriptorPoolCreateInfo =
+  DescriptorPoolCreateInfo{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkDescriptorPoolCreateFlags 
+                          , maxSets :: Word32 
+                          , poolSizeCount :: Word32 
+                          , pPoolSizes :: Ptr DescriptorPoolSize 
+                          }
   deriving (Eq)
 
-instance Storable VkDescriptorPoolCreateInfo where
+instance Storable DescriptorPoolCreateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkDescriptorPoolCreateInfo <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 8)
-                                        <*> peek (ptr `plusPtr` 16)
-                                        <*> peek (ptr `plusPtr` 20)
-                                        <*> peek (ptr `plusPtr` 24)
-                                        <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (maxSets (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 24) (poolSizeCount (poked :: VkDescriptorPoolCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pPoolSizes (poked :: VkDescriptorPoolCreateInfo))
+  peek ptr = DescriptorPoolCreateInfo <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 20)
+                                      <*> peek (ptr `plusPtr` 24)
+                                      <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (maxSets (poked :: DescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 24) (poolSizeCount (poked :: DescriptorPoolCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pPoolSizes (poked :: DescriptorPoolCreateInfo))
 
 
 -- ** VkDescriptorSetLayoutCreateFlags
@@ -205,28 +204,28 @@ newtype VkDescriptorSetLayoutCreateFlags = VkDescriptorSetLayoutCreateFlags VkFl
   deriving (Eq, Storable)
 
 
-data VkDescriptorSetLayoutCreateInfo =
-  VkDescriptorSetLayoutCreateInfo{ sType :: VkStructureType 
-                                 , pNext :: Ptr Void 
-                                 , flags :: VkDescriptorSetLayoutCreateFlags 
-                                 , bindingCount :: Word32 
-                                 , pBindings :: Ptr VkDescriptorSetLayoutBinding 
-                                 }
+data DescriptorSetLayoutCreateInfo =
+  DescriptorSetLayoutCreateInfo{ sType :: VkStructureType 
+                               , pNext :: Ptr Void 
+                               , flags :: VkDescriptorSetLayoutCreateFlags 
+                               , bindingCount :: Word32 
+                               , pBindings :: Ptr DescriptorSetLayoutBinding 
+                               }
   deriving (Eq)
 
-instance Storable VkDescriptorSetLayoutCreateInfo where
+instance Storable DescriptorSetLayoutCreateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkDescriptorSetLayoutCreateInfo <$> peek (ptr `plusPtr` 0)
-                                             <*> peek (ptr `plusPtr` 8)
-                                             <*> peek (ptr `plusPtr` 16)
-                                             <*> peek (ptr `plusPtr` 20)
-                                             <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 20) (bindingCount (poked :: VkDescriptorSetLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pBindings (poked :: VkDescriptorSetLayoutCreateInfo))
+  peek ptr = DescriptorSetLayoutCreateInfo <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 8)
+                                           <*> peek (ptr `plusPtr` 16)
+                                           <*> peek (ptr `plusPtr` 20)
+                                           <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 20) (bindingCount (poked :: DescriptorSetLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pBindings (poked :: DescriptorSetLayoutCreateInfo))
 
 
 -- ** VkDescriptorPoolCreateFlags
@@ -254,97 +253,97 @@ pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = VkDescriptorPoolCrea
 
 
 
-data VkDescriptorPoolSize =
-  VkDescriptorPoolSize{ _type :: VkDescriptorType 
-                      , descriptorCount :: Word32 
-                      }
+data DescriptorPoolSize =
+  DescriptorPoolSize{ _type :: VkDescriptorType 
+                    , descriptorCount :: Word32 
+                    }
   deriving (Eq)
 
-instance Storable VkDescriptorPoolSize where
+instance Storable DescriptorPoolSize where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkDescriptorPoolSize <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (_type (poked :: VkDescriptorPoolSize))
-                *> poke (ptr `plusPtr` 4) (descriptorCount (poked :: VkDescriptorPoolSize))
+  peek ptr = DescriptorPoolSize <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (_type (poked :: DescriptorPoolSize))
+                *> poke (ptr `plusPtr` 4) (descriptorCount (poked :: DescriptorPoolSize))
 
 
 newtype DescriptorSet = DescriptorSet Word64
   deriving (Eq, Storable)
 
 
-data VkWriteDescriptorSet =
-  VkWriteDescriptorSet{ sType :: VkStructureType 
-                      , pNext :: Ptr Void 
-                      , dstSet :: DescriptorSet 
-                      , dstBinding :: Word32 
-                      , dstArrayElement :: Word32 
-                      , descriptorCount :: Word32 
-                      , descriptorType :: VkDescriptorType 
-                      , pImageInfo :: Ptr VkDescriptorImageInfo 
-                      , pBufferInfo :: Ptr VkDescriptorBufferInfo 
-                      , pTexelBufferView :: Ptr BufferView 
-                      }
+data WriteDescriptorSet =
+  WriteDescriptorSet{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , dstSet :: DescriptorSet 
+                    , dstBinding :: Word32 
+                    , dstArrayElement :: Word32 
+                    , descriptorCount :: Word32 
+                    , descriptorType :: VkDescriptorType 
+                    , pImageInfo :: Ptr DescriptorImageInfo 
+                    , pBufferInfo :: Ptr DescriptorBufferInfo 
+                    , pTexelBufferView :: Ptr BufferView 
+                    }
   deriving (Eq)
 
-instance Storable VkWriteDescriptorSet where
+instance Storable WriteDescriptorSet where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkWriteDescriptorSet <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-                                  <*> peek (ptr `plusPtr` 28)
-                                  <*> peek (ptr `plusPtr` 32)
-                                  <*> peek (ptr `plusPtr` 36)
-                                  <*> peek (ptr `plusPtr` 40)
-                                  <*> peek (ptr `plusPtr` 48)
-                                  <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 16) (dstSet (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 24) (dstBinding (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 28) (dstArrayElement (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 32) (descriptorCount (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 36) (descriptorType (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 40) (pImageInfo (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 48) (pBufferInfo (poked :: VkWriteDescriptorSet))
-                *> poke (ptr `plusPtr` 56) (pTexelBufferView (poked :: VkWriteDescriptorSet))
+  peek ptr = WriteDescriptorSet <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 24)
+                                <*> peek (ptr `plusPtr` 28)
+                                <*> peek (ptr `plusPtr` 32)
+                                <*> peek (ptr `plusPtr` 36)
+                                <*> peek (ptr `plusPtr` 40)
+                                <*> peek (ptr `plusPtr` 48)
+                                <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 16) (dstSet (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 24) (dstBinding (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 28) (dstArrayElement (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 32) (descriptorCount (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 36) (descriptorType (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 40) (pImageInfo (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 48) (pBufferInfo (poked :: WriteDescriptorSet))
+                *> poke (ptr `plusPtr` 56) (pTexelBufferView (poked :: WriteDescriptorSet))
 
 
 -- ** vkCreateDescriptorPool
 foreign import ccall "vkCreateDescriptorPool" vkCreateDescriptorPool ::
   Device ->
-  Ptr VkDescriptorPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr DescriptorPool -> IO VkResult
+  Ptr DescriptorPoolCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr DescriptorPool -> IO VkResult
 
 -- ** vkDestroyDescriptorSetLayout
 foreign import ccall "vkDestroyDescriptorSetLayout" vkDestroyDescriptorSetLayout ::
-  Device -> DescriptorSetLayout -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DescriptorSetLayout -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkDescriptorSetLayoutBinding =
-  VkDescriptorSetLayoutBinding{ binding :: Word32 
-                              , descriptorType :: VkDescriptorType 
-                              , descriptorCount :: Word32 
-                              , stageFlags :: VkShaderStageFlags 
-                              , pImmutableSamplers :: Ptr Sampler 
-                              }
+data DescriptorSetLayoutBinding =
+  DescriptorSetLayoutBinding{ binding :: Word32 
+                            , descriptorType :: VkDescriptorType 
+                            , descriptorCount :: Word32 
+                            , stageFlags :: VkShaderStageFlags 
+                            , pImmutableSamplers :: Ptr Sampler 
+                            }
   deriving (Eq)
 
-instance Storable VkDescriptorSetLayoutBinding where
+instance Storable DescriptorSetLayoutBinding where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkDescriptorSetLayoutBinding <$> peek (ptr `plusPtr` 0)
-                                          <*> peek (ptr `plusPtr` 4)
-                                          <*> peek (ptr `plusPtr` 8)
-                                          <*> peek (ptr `plusPtr` 12)
-                                          <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 4) (descriptorType (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 8) (descriptorCount (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 12) (stageFlags (poked :: VkDescriptorSetLayoutBinding))
-                *> poke (ptr `plusPtr` 16) (pImmutableSamplers (poked :: VkDescriptorSetLayoutBinding))
+  peek ptr = DescriptorSetLayoutBinding <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 4)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 12)
+                                        <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: DescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 4) (descriptorType (poked :: DescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 8) (descriptorCount (poked :: DescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 12) (stageFlags (poked :: DescriptorSetLayoutBinding))
+                *> poke (ptr `plusPtr` 16) (pImmutableSamplers (poked :: DescriptorSetLayoutBinding))
 
 
 -- ** VkDescriptorType
@@ -410,27 +409,27 @@ pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = VkDescriptorType 9
 pattern VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = VkDescriptorType 10
 
 
-data VkDescriptorSetAllocateInfo =
-  VkDescriptorSetAllocateInfo{ sType :: VkStructureType 
-                             , pNext :: Ptr Void 
-                             , descriptorPool :: DescriptorPool 
-                             , descriptorSetCount :: Word32 
-                             , pSetLayouts :: Ptr DescriptorSetLayout 
-                             }
+data DescriptorSetAllocateInfo =
+  DescriptorSetAllocateInfo{ sType :: VkStructureType 
+                           , pNext :: Ptr Void 
+                           , descriptorPool :: DescriptorPool 
+                           , descriptorSetCount :: Word32 
+                           , pSetLayouts :: Ptr DescriptorSetLayout 
+                           }
   deriving (Eq)
 
-instance Storable VkDescriptorSetAllocateInfo where
+instance Storable DescriptorSetAllocateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkDescriptorSetAllocateInfo <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-                                         <*> peek (ptr `plusPtr` 16)
-                                         <*> peek (ptr `plusPtr` 24)
-                                         <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (descriptorPool (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (descriptorSetCount (poked :: VkDescriptorSetAllocateInfo))
-                *> poke (ptr `plusPtr` 32) (pSetLayouts (poked :: VkDescriptorSetAllocateInfo))
+  peek ptr = DescriptorSetAllocateInfo <$> peek (ptr `plusPtr` 0)
+                                       <*> peek (ptr `plusPtr` 8)
+                                       <*> peek (ptr `plusPtr` 16)
+                                       <*> peek (ptr `plusPtr` 24)
+                                       <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (descriptorPool (poked :: DescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (descriptorSetCount (poked :: DescriptorSetAllocateInfo))
+                *> poke (ptr `plusPtr` 32) (pSetLayouts (poked :: DescriptorSetAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -351,31 +351,31 @@ newtype DescriptorType = DescriptorType Int32
   deriving (Eq, Storable)
 
 instance Show DescriptorType where
-  showsPrec _ VK_DESCRIPTOR_TYPE_SAMPLER = showString "VK_DESCRIPTOR_TYPE_SAMPLER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = showString "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE = showString "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE"
-  showsPrec _ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = showString "VK_DESCRIPTOR_TYPE_STORAGE_IMAGE"
-  showsPrec _ VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER = showString "VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER = showString "VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER = showString "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = showString "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER"
-  showsPrec _ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = showString "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC"
-  showsPrec _ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = showString "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC"
-  showsPrec _ VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = showString "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT"
+  showsPrec _ DescriptorTypeSampler = showString "DescriptorTypeSampler"
+  showsPrec _ DescriptorTypeCombinedImageSampler = showString "DescriptorTypeCombinedImageSampler"
+  showsPrec _ DescriptorTypeSampledImage = showString "DescriptorTypeSampledImage"
+  showsPrec _ DescriptorTypeStorageImage = showString "DescriptorTypeStorageImage"
+  showsPrec _ DescriptorTypeUniformTexelBuffer = showString "DescriptorTypeUniformTexelBuffer"
+  showsPrec _ DescriptorTypeStorageTexelBuffer = showString "DescriptorTypeStorageTexelBuffer"
+  showsPrec _ DescriptorTypeUniformBuffer = showString "DescriptorTypeUniformBuffer"
+  showsPrec _ DescriptorTypeStorageBuffer = showString "DescriptorTypeStorageBuffer"
+  showsPrec _ DescriptorTypeUniformBufferDynamic = showString "DescriptorTypeUniformBufferDynamic"
+  showsPrec _ DescriptorTypeStorageBufferDynamic = showString "DescriptorTypeStorageBufferDynamic"
+  showsPrec _ DescriptorTypeInputAttachment = showString "DescriptorTypeInputAttachment"
   showsPrec p (DescriptorType x) = showParen (p >= 11) (showString "DescriptorType " . showsPrec 11 x)
 
 instance Read DescriptorType where
-  readPrec = parens ( choose [ ("VK_DESCRIPTOR_TYPE_SAMPLER", pure VK_DESCRIPTOR_TYPE_SAMPLER)
-                             , ("VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER", pure VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-                             , ("VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE", pure VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)
-                             , ("VK_DESCRIPTOR_TYPE_STORAGE_IMAGE", pure VK_DESCRIPTOR_TYPE_STORAGE_IMAGE)
-                             , ("VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER", pure VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER)
-                             , ("VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER", pure VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)
-                             , ("VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER", pure VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER)
-                             , ("VK_DESCRIPTOR_TYPE_STORAGE_BUFFER", pure VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
-                             , ("VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC", pure VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC)
-                             , ("VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC", pure VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC)
-                             , ("VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT", pure VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
+  readPrec = parens ( choose [ ("DescriptorTypeSampler", pure DescriptorTypeSampler)
+                             , ("DescriptorTypeCombinedImageSampler", pure DescriptorTypeCombinedImageSampler)
+                             , ("DescriptorTypeSampledImage", pure DescriptorTypeSampledImage)
+                             , ("DescriptorTypeStorageImage", pure DescriptorTypeStorageImage)
+                             , ("DescriptorTypeUniformTexelBuffer", pure DescriptorTypeUniformTexelBuffer)
+                             , ("DescriptorTypeStorageTexelBuffer", pure DescriptorTypeStorageTexelBuffer)
+                             , ("DescriptorTypeUniformBuffer", pure DescriptorTypeUniformBuffer)
+                             , ("DescriptorTypeStorageBuffer", pure DescriptorTypeStorageBuffer)
+                             , ("DescriptorTypeUniformBufferDynamic", pure DescriptorTypeUniformBufferDynamic)
+                             , ("DescriptorTypeStorageBufferDynamic", pure DescriptorTypeStorageBufferDynamic)
+                             , ("DescriptorTypeInputAttachment", pure DescriptorTypeInputAttachment)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DescriptorType")
@@ -385,27 +385,27 @@ instance Read DescriptorType where
                     )
 
 
-pattern VK_DESCRIPTOR_TYPE_SAMPLER = DescriptorType 0
+pattern DescriptorTypeSampler = DescriptorType 0
 
-pattern VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = DescriptorType 1
+pattern DescriptorTypeCombinedImageSampler = DescriptorType 1
 
-pattern VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE = DescriptorType 2
+pattern DescriptorTypeSampledImage = DescriptorType 2
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = DescriptorType 3
+pattern DescriptorTypeStorageImage = DescriptorType 3
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER = DescriptorType 4
+pattern DescriptorTypeUniformTexelBuffer = DescriptorType 4
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER = DescriptorType 5
+pattern DescriptorTypeStorageTexelBuffer = DescriptorType 5
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER = DescriptorType 6
+pattern DescriptorTypeUniformBuffer = DescriptorType 6
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = DescriptorType 7
+pattern DescriptorTypeStorageBuffer = DescriptorType 7
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = DescriptorType 8
+pattern DescriptorTypeUniformBufferDynamic = DescriptorType 8
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = DescriptorType 9
+pattern DescriptorTypeStorageBufferDynamic = DescriptorType 9
 
-pattern VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = DescriptorType 10
+pattern DescriptorTypeInputAttachment = DescriptorType 10
 
 
 data DescriptorSetAllocateInfo =

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.DescriptorSet where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Buffer( Buffer
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -15,6 +19,23 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.DescriptorSet( VkDescriptorSetLayoutCreateInfo
+                                    , VkDescriptorBufferInfo
+                                    , DescriptorSetLayout
+                                    , DescriptorPool
+                                    , VkDescriptorPoolResetFlags
+                                    , VkDescriptorType
+                                    , VkDescriptorImageInfo
+                                    , DescriptorSet
+                                    , VkWriteDescriptorSet
+                                    , VkDescriptorSetLayoutBinding
+                                    , VkDescriptorPoolCreateFlags
+                                    , VkDescriptorSetLayoutCreateFlags
+                                    , VkDescriptorPoolSize
+                                    , VkCopyDescriptorSet
+                                    , VkDescriptorSetAllocateInfo
+                                    , VkDescriptorPoolCreateInfo
+                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -24,6 +45,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -31,6 +54,21 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Shader( VkShaderStageFlags
+                             )
+import Graphics.Vulkan.Sampler( Sampler
+                              )
+import Graphics.Vulkan.Image( VkImageLayout
+                            )
+import Graphics.Vulkan.ImageView( ImageView
+                                )
+import Graphics.Vulkan.BufferView( BufferView
+                                 )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 -- ** vkUpdateDescriptorSets
 foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -4,38 +4,21 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.DescriptorSet where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( VkDescriptorSetLayoutCreateInfo
-                                    , VkDescriptorBufferInfo
-                                    , DescriptorSetLayout
-                                    , DescriptorPool
-                                    , VkDescriptorPoolResetFlags
-                                    , VkDescriptorType
-                                    , VkDescriptorImageInfo
-                                    , DescriptorSet
-                                    , VkWriteDescriptorSet
-                                    , VkDescriptorSetLayoutBinding
-                                    , VkDescriptorPoolCreateFlags
-                                    , VkDescriptorSetLayoutCreateFlags
-                                    , VkDescriptorPoolSize
-                                    , VkCopyDescriptorSet
-                                    , VkDescriptorSetAllocateInfo
-                                    , VkDescriptorPoolCreateInfo
-                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -43,9 +26,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -54,20 +37,20 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlags
+import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Sampler( Sampler
+import Graphics.Vulkan.Sampler( Sampler(..)
                               )
-import Graphics.Vulkan.Image( VkImageLayout
+import Graphics.Vulkan.Image( VkImageLayout(..)
                             )
-import Graphics.Vulkan.ImageView( ImageView
+import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
-import Graphics.Vulkan.BufferView( BufferView
+import Graphics.Vulkan.BufferView( BufferView(..)
                                  )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
                            )
 
 -- ** vkUpdateDescriptorSets
@@ -248,29 +231,26 @@ instance Storable VkDescriptorSetLayoutCreateInfo where
 
 -- ** VkDescriptorPoolCreateFlags
 
-newtype VkDescriptorPoolCreateFlagBits = VkDescriptorPoolCreateFlagBits VkFlags
+newtype VkDescriptorPoolCreateFlags = VkDescriptorPoolCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkDescriptorPoolCreateFlagBits
-type VkDescriptorPoolCreateFlags = VkDescriptorPoolCreateFlagBits
-
-instance Show VkDescriptorPoolCreateFlagBits where
+instance Show VkDescriptorPoolCreateFlags where
   showsPrec _ VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = showString "VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT"
   
-  showsPrec p (VkDescriptorPoolCreateFlagBits x) = showParen (p >= 11) (showString "VkDescriptorPoolCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkDescriptorPoolCreateFlags x) = showParen (p >= 11) (showString "VkDescriptorPoolCreateFlags " . showsPrec 11 x)
 
-instance Read VkDescriptorPoolCreateFlagBits where
+instance Read VkDescriptorPoolCreateFlags where
   readPrec = parens ( choose [ ("VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT", pure VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDescriptorPoolCreateFlagBits")
+                        expectP (Ident "VkDescriptorPoolCreateFlags")
                         v <- step readPrec
-                        pure (VkDescriptorPoolCreateFlagBits v)
+                        pure (VkDescriptorPoolCreateFlags v)
                         )
                     )
 
 -- | Descriptor sets may be freed individually
-pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = VkDescriptorPoolCreateFlagBits 0x1
+pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = VkDescriptorPoolCreateFlags 0x1
 
 
 

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -62,7 +62,7 @@ foreign import ccall "vkUpdateDescriptorSets" updateDescriptorSets ::
 -- ** DescriptorPoolResetFlags
 -- | Opaque flag
 newtype DescriptorPoolResetFlags = DescriptorPoolResetFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** allocateDescriptorSets
 foreign import ccall "vkAllocateDescriptorSets" allocateDescriptorSets ::
@@ -75,7 +75,7 @@ data DescriptorBufferInfo =
                       , offset :: DeviceSize 
                       , range :: DeviceSize 
                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorBufferInfo where
   sizeOf ~_ = 24
@@ -94,7 +94,7 @@ data DescriptorImageInfo =
                      , imageView :: ImageView 
                      , imageLayout :: ImageLayout 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorImageInfo where
   sizeOf ~_ = 24
@@ -119,7 +119,7 @@ data CopyDescriptorSet =
                    , dstArrayElement :: Word32 
                    , descriptorCount :: Word32 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable CopyDescriptorSet where
   sizeOf ~_ = 56
@@ -155,14 +155,14 @@ foreign import ccall "vkCreateDescriptorSetLayout" createDescriptorSetLayout ::
     Ptr AllocationCallbacks -> Ptr DescriptorSetLayout -> IO Result
 
 newtype DescriptorPool = DescriptorPool Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** resetDescriptorPool
 foreign import ccall "vkResetDescriptorPool" resetDescriptorPool ::
   Device -> DescriptorPool -> DescriptorPoolResetFlags -> IO Result
 
 newtype DescriptorSetLayout = DescriptorSetLayout Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** freeDescriptorSets
 foreign import ccall "vkFreeDescriptorSets" freeDescriptorSets ::
@@ -178,7 +178,7 @@ data DescriptorPoolCreateInfo =
                           , poolSizeCount :: Word32 
                           , pPoolSizes :: Ptr DescriptorPoolSize 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorPoolCreateInfo where
   sizeOf ~_ = 40
@@ -200,7 +200,7 @@ instance Storable DescriptorPoolCreateInfo where
 -- ** DescriptorSetLayoutCreateFlags
 -- | Opaque flag
 newtype DescriptorSetLayoutCreateFlags = DescriptorSetLayoutCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data DescriptorSetLayoutCreateInfo =
@@ -210,7 +210,7 @@ data DescriptorSetLayoutCreateInfo =
                                , bindingCount :: Word32 
                                , pBindings :: Ptr DescriptorSetLayoutBinding 
                                }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorSetLayoutCreateInfo where
   sizeOf ~_ = 32
@@ -230,7 +230,7 @@ instance Storable DescriptorSetLayoutCreateInfo where
 -- ** DescriptorPoolCreateFlags
 
 newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show DescriptorPoolCreateFlags where
   showsPrec _ DescriptorPoolCreateFreeDescriptorSetBit = showString "DescriptorPoolCreateFreeDescriptorSetBit"
@@ -256,7 +256,7 @@ data DescriptorPoolSize =
   DescriptorPoolSize{ _type :: DescriptorType 
                     , descriptorCount :: Word32 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorPoolSize where
   sizeOf ~_ = 8
@@ -268,7 +268,7 @@ instance Storable DescriptorPoolSize where
 
 
 newtype DescriptorSet = DescriptorSet Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data WriteDescriptorSet =
@@ -283,7 +283,7 @@ data WriteDescriptorSet =
                     , pBufferInfo :: Ptr DescriptorBufferInfo 
                     , pTexelBufferView :: Ptr BufferView 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable WriteDescriptorSet where
   sizeOf ~_ = 64
@@ -328,7 +328,7 @@ data DescriptorSetLayoutBinding =
                             , stageFlags :: ShaderStageFlags 
                             , pImmutableSamplers :: Ptr Sampler 
                             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorSetLayoutBinding where
   sizeOf ~_ = 24
@@ -348,7 +348,7 @@ instance Storable DescriptorSetLayoutBinding where
 -- ** DescriptorType
 
 newtype DescriptorType = DescriptorType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show DescriptorType where
   showsPrec _ DescriptorTypeSampler = showString "DescriptorTypeSampler"
@@ -415,7 +415,7 @@ data DescriptorSetAllocateInfo =
                            , descriptorSetCount :: Word32 
                            , pSetLayouts :: Ptr DescriptorSetLayout 
                            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DescriptorSetAllocateInfo where
   sizeOf ~_ = 40

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -47,10 +47,10 @@ import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
 import Graphics.Vulkan.BufferView( BufferView(..)
                                  )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 
 -- ** vkUpdateDescriptorSets
@@ -61,7 +61,7 @@ foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
 
 -- ** DescriptorPoolResetFlags
 -- | Opaque flag
-newtype DescriptorPoolResetFlags = DescriptorPoolResetFlags VkFlags
+newtype DescriptorPoolResetFlags = DescriptorPoolResetFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkAllocateDescriptorSets
@@ -72,8 +72,8 @@ foreign import ccall "vkAllocateDescriptorSets" vkAllocateDescriptorSets ::
 
 data DescriptorBufferInfo =
   DescriptorBufferInfo{ buffer :: Buffer 
-                      , offset :: VkDeviceSize 
-                      , range :: VkDeviceSize 
+                      , offset :: DeviceSize 
+                      , range :: DeviceSize 
                       }
   deriving (Eq)
 
@@ -199,7 +199,7 @@ instance Storable DescriptorPoolCreateInfo where
 
 -- ** DescriptorSetLayoutCreateFlags
 -- | Opaque flag
-newtype DescriptorSetLayoutCreateFlags = DescriptorSetLayoutCreateFlags VkFlags
+newtype DescriptorSetLayoutCreateFlags = DescriptorSetLayoutCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -229,7 +229,7 @@ instance Storable DescriptorSetLayoutCreateInfo where
 
 -- ** VkDescriptorPoolCreateFlags
 
-newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags VkFlags
+newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DescriptorPoolCreateFlags where

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -227,7 +227,7 @@ instance Storable DescriptorSetLayoutCreateInfo where
                 *> poke (ptr `plusPtr` 24) (pBindings (poked :: DescriptorSetLayoutCreateInfo))
 
 
--- ** VkDescriptorPoolCreateFlags
+-- ** DescriptorPoolCreateFlags
 
 newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -37,19 +37,19 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
+import Graphics.Vulkan.Shader( ShaderStageFlags(..)
                              )
 import Graphics.Vulkan.Sampler( Sampler(..)
                               )
-import Graphics.Vulkan.Image( VkImageLayout(..)
+import Graphics.Vulkan.Image( ImageLayout(..)
                             )
 import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
 import Graphics.Vulkan.BufferView( BufferView(..)
                                  )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 
@@ -59,15 +59,15 @@ foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
   Word32 ->
     Ptr WriteDescriptorSet -> Word32 -> Ptr CopyDescriptorSet -> IO ()
 
--- ** VkDescriptorPoolResetFlags
+-- ** DescriptorPoolResetFlags
 -- | Opaque flag
-newtype VkDescriptorPoolResetFlags = VkDescriptorPoolResetFlags VkFlags
+newtype DescriptorPoolResetFlags = DescriptorPoolResetFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkAllocateDescriptorSets
 foreign import ccall "vkAllocateDescriptorSets" vkAllocateDescriptorSets ::
   Device ->
-  Ptr DescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO VkResult
+  Ptr DescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO Result
 
 
 data DescriptorBufferInfo =
@@ -92,7 +92,7 @@ instance Storable DescriptorBufferInfo where
 data DescriptorImageInfo =
   DescriptorImageInfo{ sampler :: Sampler 
                      , imageView :: ImageView 
-                     , imageLayout :: VkImageLayout 
+                     , imageLayout :: ImageLayout 
                      }
   deriving (Eq)
 
@@ -109,7 +109,7 @@ instance Storable DescriptorImageInfo where
 
 
 data CopyDescriptorSet =
-  CopyDescriptorSet{ sType :: VkStructureType 
+  CopyDescriptorSet{ sType :: StructureType 
                    , pNext :: Ptr Void 
                    , srcSet :: DescriptorSet 
                    , srcBinding :: Word32 
@@ -152,15 +152,14 @@ foreign import ccall "vkDestroyDescriptorPool" vkDestroyDescriptorPool ::
 foreign import ccall "vkCreateDescriptorSetLayout" vkCreateDescriptorSetLayout ::
   Device ->
   Ptr DescriptorSetLayoutCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr DescriptorSetLayout -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr DescriptorSetLayout -> IO Result
 
 newtype DescriptorPool = DescriptorPool Word64
   deriving (Eq, Storable)
 
 -- ** vkResetDescriptorPool
 foreign import ccall "vkResetDescriptorPool" vkResetDescriptorPool ::
-  Device ->
-  DescriptorPool -> VkDescriptorPoolResetFlags -> IO VkResult
+  Device -> DescriptorPool -> DescriptorPoolResetFlags -> IO Result
 
 newtype DescriptorSetLayout = DescriptorSetLayout Word64
   deriving (Eq, Storable)
@@ -168,13 +167,13 @@ newtype DescriptorSetLayout = DescriptorSetLayout Word64
 -- ** vkFreeDescriptorSets
 foreign import ccall "vkFreeDescriptorSets" vkFreeDescriptorSets ::
   Device ->
-  DescriptorPool -> Word32 -> Ptr DescriptorSet -> IO VkResult
+  DescriptorPool -> Word32 -> Ptr DescriptorSet -> IO Result
 
 
 data DescriptorPoolCreateInfo =
-  DescriptorPoolCreateInfo{ sType :: VkStructureType 
+  DescriptorPoolCreateInfo{ sType :: StructureType 
                           , pNext :: Ptr Void 
-                          , flags :: VkDescriptorPoolCreateFlags 
+                          , flags :: DescriptorPoolCreateFlags 
                           , maxSets :: Word32 
                           , poolSizeCount :: Word32 
                           , pPoolSizes :: Ptr DescriptorPoolSize 
@@ -198,16 +197,16 @@ instance Storable DescriptorPoolCreateInfo where
                 *> poke (ptr `plusPtr` 32) (pPoolSizes (poked :: DescriptorPoolCreateInfo))
 
 
--- ** VkDescriptorSetLayoutCreateFlags
+-- ** DescriptorSetLayoutCreateFlags
 -- | Opaque flag
-newtype VkDescriptorSetLayoutCreateFlags = VkDescriptorSetLayoutCreateFlags VkFlags
+newtype DescriptorSetLayoutCreateFlags = DescriptorSetLayoutCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data DescriptorSetLayoutCreateInfo =
-  DescriptorSetLayoutCreateInfo{ sType :: VkStructureType 
+  DescriptorSetLayoutCreateInfo{ sType :: StructureType 
                                , pNext :: Ptr Void 
-                               , flags :: VkDescriptorSetLayoutCreateFlags 
+                               , flags :: DescriptorSetLayoutCreateFlags 
                                , bindingCount :: Word32 
                                , pBindings :: Ptr DescriptorSetLayoutBinding 
                                }
@@ -230,31 +229,31 @@ instance Storable DescriptorSetLayoutCreateInfo where
 
 -- ** VkDescriptorPoolCreateFlags
 
-newtype VkDescriptorPoolCreateFlags = VkDescriptorPoolCreateFlags VkFlags
+newtype DescriptorPoolCreateFlags = DescriptorPoolCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkDescriptorPoolCreateFlags where
+instance Show DescriptorPoolCreateFlags where
   showsPrec _ VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = showString "VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT"
   
-  showsPrec p (VkDescriptorPoolCreateFlags x) = showParen (p >= 11) (showString "VkDescriptorPoolCreateFlags " . showsPrec 11 x)
+  showsPrec p (DescriptorPoolCreateFlags x) = showParen (p >= 11) (showString "DescriptorPoolCreateFlags " . showsPrec 11 x)
 
-instance Read VkDescriptorPoolCreateFlags where
+instance Read DescriptorPoolCreateFlags where
   readPrec = parens ( choose [ ("VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT", pure VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDescriptorPoolCreateFlags")
+                        expectP (Ident "DescriptorPoolCreateFlags")
                         v <- step readPrec
-                        pure (VkDescriptorPoolCreateFlags v)
+                        pure (DescriptorPoolCreateFlags v)
                         )
                     )
 
 -- | Descriptor sets may be freed individually
-pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = VkDescriptorPoolCreateFlags 0x1
+pattern VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT = DescriptorPoolCreateFlags 0x1
 
 
 
 data DescriptorPoolSize =
-  DescriptorPoolSize{ _type :: VkDescriptorType 
+  DescriptorPoolSize{ _type :: DescriptorType 
                     , descriptorCount :: Word32 
                     }
   deriving (Eq)
@@ -273,13 +272,13 @@ newtype DescriptorSet = DescriptorSet Word64
 
 
 data WriteDescriptorSet =
-  WriteDescriptorSet{ sType :: VkStructureType 
+  WriteDescriptorSet{ sType :: StructureType 
                     , pNext :: Ptr Void 
                     , dstSet :: DescriptorSet 
                     , dstBinding :: Word32 
                     , dstArrayElement :: Word32 
                     , descriptorCount :: Word32 
-                    , descriptorType :: VkDescriptorType 
+                    , descriptorType :: DescriptorType 
                     , pImageInfo :: Ptr DescriptorImageInfo 
                     , pBufferInfo :: Ptr DescriptorBufferInfo 
                     , pTexelBufferView :: Ptr BufferView 
@@ -315,7 +314,7 @@ instance Storable WriteDescriptorSet where
 foreign import ccall "vkCreateDescriptorPool" vkCreateDescriptorPool ::
   Device ->
   Ptr DescriptorPoolCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr DescriptorPool -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr DescriptorPool -> IO Result
 
 -- ** vkDestroyDescriptorSetLayout
 foreign import ccall "vkDestroyDescriptorSetLayout" vkDestroyDescriptorSetLayout ::
@@ -324,9 +323,9 @@ foreign import ccall "vkDestroyDescriptorSetLayout" vkDestroyDescriptorSetLayout
 
 data DescriptorSetLayoutBinding =
   DescriptorSetLayoutBinding{ binding :: Word32 
-                            , descriptorType :: VkDescriptorType 
+                            , descriptorType :: DescriptorType 
                             , descriptorCount :: Word32 
-                            , stageFlags :: VkShaderStageFlags 
+                            , stageFlags :: ShaderStageFlags 
                             , pImmutableSamplers :: Ptr Sampler 
                             }
   deriving (Eq)
@@ -346,12 +345,12 @@ instance Storable DescriptorSetLayoutBinding where
                 *> poke (ptr `plusPtr` 16) (pImmutableSamplers (poked :: DescriptorSetLayoutBinding))
 
 
--- ** VkDescriptorType
+-- ** DescriptorType
 
-newtype VkDescriptorType = VkDescriptorType Int32
+newtype DescriptorType = DescriptorType Int32
   deriving (Eq, Storable)
 
-instance Show VkDescriptorType where
+instance Show DescriptorType where
   showsPrec _ VK_DESCRIPTOR_TYPE_SAMPLER = showString "VK_DESCRIPTOR_TYPE_SAMPLER"
   showsPrec _ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = showString "VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER"
   showsPrec _ VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE = showString "VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE"
@@ -363,9 +362,9 @@ instance Show VkDescriptorType where
   showsPrec _ VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = showString "VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC"
   showsPrec _ VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = showString "VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC"
   showsPrec _ VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = showString "VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT"
-  showsPrec p (VkDescriptorType x) = showParen (p >= 11) (showString "VkDescriptorType " . showsPrec 11 x)
+  showsPrec p (DescriptorType x) = showParen (p >= 11) (showString "DescriptorType " . showsPrec 11 x)
 
-instance Read VkDescriptorType where
+instance Read DescriptorType where
   readPrec = parens ( choose [ ("VK_DESCRIPTOR_TYPE_SAMPLER", pure VK_DESCRIPTOR_TYPE_SAMPLER)
                              , ("VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER", pure VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
                              , ("VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE", pure VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)
@@ -379,38 +378,38 @@ instance Read VkDescriptorType where
                              , ("VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT", pure VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDescriptorType")
+                        expectP (Ident "DescriptorType")
                         v <- step readPrec
-                        pure (VkDescriptorType v)
+                        pure (DescriptorType v)
                         )
                     )
 
 
-pattern VK_DESCRIPTOR_TYPE_SAMPLER = VkDescriptorType 0
+pattern VK_DESCRIPTOR_TYPE_SAMPLER = DescriptorType 0
 
-pattern VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = VkDescriptorType 1
+pattern VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER = DescriptorType 1
 
-pattern VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE = VkDescriptorType 2
+pattern VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE = DescriptorType 2
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = VkDescriptorType 3
+pattern VK_DESCRIPTOR_TYPE_STORAGE_IMAGE = DescriptorType 3
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER = VkDescriptorType 4
+pattern VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER = DescriptorType 4
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER = VkDescriptorType 5
+pattern VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER = DescriptorType 5
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER = VkDescriptorType 6
+pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER = DescriptorType 6
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = VkDescriptorType 7
+pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER = DescriptorType 7
 
-pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = VkDescriptorType 8
+pattern VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC = DescriptorType 8
 
-pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = VkDescriptorType 9
+pattern VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC = DescriptorType 9
 
-pattern VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = VkDescriptorType 10
+pattern VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT = DescriptorType 10
 
 
 data DescriptorSetAllocateInfo =
-  DescriptorSetAllocateInfo{ sType :: VkStructureType 
+  DescriptorSetAllocateInfo{ sType :: StructureType 
                            , pNext :: Ptr Void 
                            , descriptorPool :: DescriptorPool 
                            , descriptorSetCount :: Word32 

--- a/src/Graphics/Vulkan/DescriptorSet.hs
+++ b/src/Graphics/Vulkan/DescriptorSet.hs
@@ -53,8 +53,8 @@ import Graphics.Vulkan.Core( StructureType(..)
                            , Flags(..)
                            )
 
--- ** vkUpdateDescriptorSets
-foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
+-- ** updateDescriptorSets
+foreign import ccall "vkUpdateDescriptorSets" updateDescriptorSets ::
   Device ->
   Word32 ->
     Ptr WriteDescriptorSet -> Word32 -> Ptr CopyDescriptorSet -> IO ()
@@ -64,8 +64,8 @@ foreign import ccall "vkUpdateDescriptorSets" vkUpdateDescriptorSets ::
 newtype DescriptorPoolResetFlags = DescriptorPoolResetFlags Flags
   deriving (Eq, Storable)
 
--- ** vkAllocateDescriptorSets
-foreign import ccall "vkAllocateDescriptorSets" vkAllocateDescriptorSets ::
+-- ** allocateDescriptorSets
+foreign import ccall "vkAllocateDescriptorSets" allocateDescriptorSets ::
   Device ->
   Ptr DescriptorSetAllocateInfo -> Ptr DescriptorSet -> IO Result
 
@@ -144,12 +144,12 @@ instance Storable CopyDescriptorSet where
                 *> poke (ptr `plusPtr` 48) (descriptorCount (poked :: CopyDescriptorSet))
 
 
--- ** vkDestroyDescriptorPool
-foreign import ccall "vkDestroyDescriptorPool" vkDestroyDescriptorPool ::
+-- ** destroyDescriptorPool
+foreign import ccall "vkDestroyDescriptorPool" destroyDescriptorPool ::
   Device -> DescriptorPool -> Ptr AllocationCallbacks -> IO ()
 
--- ** vkCreateDescriptorSetLayout
-foreign import ccall "vkCreateDescriptorSetLayout" vkCreateDescriptorSetLayout ::
+-- ** createDescriptorSetLayout
+foreign import ccall "vkCreateDescriptorSetLayout" createDescriptorSetLayout ::
   Device ->
   Ptr DescriptorSetLayoutCreateInfo ->
     Ptr AllocationCallbacks -> Ptr DescriptorSetLayout -> IO Result
@@ -157,15 +157,15 @@ foreign import ccall "vkCreateDescriptorSetLayout" vkCreateDescriptorSetLayout :
 newtype DescriptorPool = DescriptorPool Word64
   deriving (Eq, Storable)
 
--- ** vkResetDescriptorPool
-foreign import ccall "vkResetDescriptorPool" vkResetDescriptorPool ::
+-- ** resetDescriptorPool
+foreign import ccall "vkResetDescriptorPool" resetDescriptorPool ::
   Device -> DescriptorPool -> DescriptorPoolResetFlags -> IO Result
 
 newtype DescriptorSetLayout = DescriptorSetLayout Word64
   deriving (Eq, Storable)
 
--- ** vkFreeDescriptorSets
-foreign import ccall "vkFreeDescriptorSets" vkFreeDescriptorSets ::
+-- ** freeDescriptorSets
+foreign import ccall "vkFreeDescriptorSets" freeDescriptorSets ::
   Device ->
   DescriptorPool -> Word32 -> Ptr DescriptorSet -> IO Result
 
@@ -310,14 +310,14 @@ instance Storable WriteDescriptorSet where
                 *> poke (ptr `plusPtr` 56) (pTexelBufferView (poked :: WriteDescriptorSet))
 
 
--- ** vkCreateDescriptorPool
-foreign import ccall "vkCreateDescriptorPool" vkCreateDescriptorPool ::
+-- ** createDescriptorPool
+foreign import ccall "vkCreateDescriptorPool" createDescriptorPool ::
   Device ->
   Ptr DescriptorPoolCreateInfo ->
     Ptr AllocationCallbacks -> Ptr DescriptorPool -> IO Result
 
--- ** vkDestroyDescriptorSetLayout
-foreign import ccall "vkDestroyDescriptorSetLayout" vkDestroyDescriptorSetLayout ::
+-- ** destroyDescriptorSetLayout
+foreign import ccall "vkDestroyDescriptorSetLayout" destroyDescriptorSetLayout ::
   Device -> DescriptorSetLayout -> Ptr AllocationCallbacks -> IO ()
 
 

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -12,24 +12,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CFloat
-                      , CFloat(..)
                       , CChar
-                      , CSize(..)
                       )
 
 -- ** vkCreateDevice

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -3,6 +3,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Device where
 
+import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures
+                             , Device
+                             , VkDeviceCreateFlags
+                             , VkDeviceQueueCreateFlags
+                             , VkDeviceQueueCreateInfo
+                             , PhysicalDevice
+                             , VkDeviceCreateInfo
+                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +20,13 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CFloat
                       , CChar
                       )

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -15,10 +15,10 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -32,61 +32,61 @@ foreign import ccall "vkCreateDevice" vkCreateDevice ::
 
 
 data PhysicalDeviceFeatures =
-  PhysicalDeviceFeatures{ robustBufferAccess :: VkBool32 
-                        , fullDrawIndexUint32 :: VkBool32 
-                        , imageCubeArray :: VkBool32 
-                        , independentBlend :: VkBool32 
-                        , geometryShader :: VkBool32 
-                        , tessellationShader :: VkBool32 
-                        , sampleRateShading :: VkBool32 
-                        , dualSrcBlend :: VkBool32 
-                        , logicOp :: VkBool32 
-                        , multiDrawIndirect :: VkBool32 
-                        , drawIndirectFirstInstance :: VkBool32 
-                        , depthClamp :: VkBool32 
-                        , depthBiasClamp :: VkBool32 
-                        , fillModeNonSolid :: VkBool32 
-                        , depthBounds :: VkBool32 
-                        , wideLines :: VkBool32 
-                        , largePoints :: VkBool32 
-                        , alphaToOne :: VkBool32 
-                        , multiViewport :: VkBool32 
-                        , samplerAnisotropy :: VkBool32 
-                        , textureCompressionETC2 :: VkBool32 
-                        , textureCompressionASTC_LDR :: VkBool32 
-                        , textureCompressionBC :: VkBool32 
-                        , occlusionQueryPrecise :: VkBool32 
-                        , pipelineStatisticsQuery :: VkBool32 
-                        , vertexPipelineStoresAndAtomics :: VkBool32 
-                        , fragmentStoresAndAtomics :: VkBool32 
-                        , shaderTessellationAndGeometryPointSize :: VkBool32 
-                        , shaderImageGatherExtended :: VkBool32 
-                        , shaderStorageImageExtendedFormats :: VkBool32 
-                        , shaderStorageImageMultisample :: VkBool32 
-                        , shaderStorageImageReadWithoutFormat :: VkBool32 
-                        , shaderStorageImageWriteWithoutFormat :: VkBool32 
-                        , shaderUniformBufferArrayDynamicIndexing :: VkBool32 
-                        , shaderSampledImageArrayDynamicIndexing :: VkBool32 
-                        , shaderStorageBufferArrayDynamicIndexing :: VkBool32 
-                        , shaderStorageImageArrayDynamicIndexing :: VkBool32 
-                        , shaderClipDistance :: VkBool32 
-                        , shaderCullDistance :: VkBool32 
-                        , shaderFloat64 :: VkBool32 
-                        , shaderInt64 :: VkBool32 
-                        , shaderInt16 :: VkBool32 
-                        , shaderResourceResidency :: VkBool32 
-                        , shaderResourceMinLod :: VkBool32 
-                        , sparseBinding :: VkBool32 
-                        , sparseResidencyBuffer :: VkBool32 
-                        , sparseResidencyImage2D :: VkBool32 
-                        , sparseResidencyImage3D :: VkBool32 
-                        , sparseResidency2Samples :: VkBool32 
-                        , sparseResidency4Samples :: VkBool32 
-                        , sparseResidency8Samples :: VkBool32 
-                        , sparseResidency16Samples :: VkBool32 
-                        , sparseResidencyAliased :: VkBool32 
-                        , variableMultisampleRate :: VkBool32 
-                        , inheritedQueries :: VkBool32 
+  PhysicalDeviceFeatures{ robustBufferAccess :: Bool32 
+                        , fullDrawIndexUint32 :: Bool32 
+                        , imageCubeArray :: Bool32 
+                        , independentBlend :: Bool32 
+                        , geometryShader :: Bool32 
+                        , tessellationShader :: Bool32 
+                        , sampleRateShading :: Bool32 
+                        , dualSrcBlend :: Bool32 
+                        , logicOp :: Bool32 
+                        , multiDrawIndirect :: Bool32 
+                        , drawIndirectFirstInstance :: Bool32 
+                        , depthClamp :: Bool32 
+                        , depthBiasClamp :: Bool32 
+                        , fillModeNonSolid :: Bool32 
+                        , depthBounds :: Bool32 
+                        , wideLines :: Bool32 
+                        , largePoints :: Bool32 
+                        , alphaToOne :: Bool32 
+                        , multiViewport :: Bool32 
+                        , samplerAnisotropy :: Bool32 
+                        , textureCompressionETC2 :: Bool32 
+                        , textureCompressionASTC_LDR :: Bool32 
+                        , textureCompressionBC :: Bool32 
+                        , occlusionQueryPrecise :: Bool32 
+                        , pipelineStatisticsQuery :: Bool32 
+                        , vertexPipelineStoresAndAtomics :: Bool32 
+                        , fragmentStoresAndAtomics :: Bool32 
+                        , shaderTessellationAndGeometryPointSize :: Bool32 
+                        , shaderImageGatherExtended :: Bool32 
+                        , shaderStorageImageExtendedFormats :: Bool32 
+                        , shaderStorageImageMultisample :: Bool32 
+                        , shaderStorageImageReadWithoutFormat :: Bool32 
+                        , shaderStorageImageWriteWithoutFormat :: Bool32 
+                        , shaderUniformBufferArrayDynamicIndexing :: Bool32 
+                        , shaderSampledImageArrayDynamicIndexing :: Bool32 
+                        , shaderStorageBufferArrayDynamicIndexing :: Bool32 
+                        , shaderStorageImageArrayDynamicIndexing :: Bool32 
+                        , shaderClipDistance :: Bool32 
+                        , shaderCullDistance :: Bool32 
+                        , shaderFloat64 :: Bool32 
+                        , shaderInt64 :: Bool32 
+                        , shaderInt16 :: Bool32 
+                        , shaderResourceResidency :: Bool32 
+                        , shaderResourceMinLod :: Bool32 
+                        , sparseBinding :: Bool32 
+                        , sparseResidencyBuffer :: Bool32 
+                        , sparseResidencyImage2D :: Bool32 
+                        , sparseResidencyImage3D :: Bool32 
+                        , sparseResidency2Samples :: Bool32 
+                        , sparseResidency4Samples :: Bool32 
+                        , sparseResidency8Samples :: Bool32 
+                        , sparseResidency16Samples :: Bool32 
+                        , sparseResidencyAliased :: Bool32 
+                        , variableMultisampleRate :: Bool32 
+                        , inheritedQueries :: Bool32 
                         }
   deriving (Eq)
 
@@ -207,7 +207,7 @@ instance Storable PhysicalDeviceFeatures where
 
 -- ** DeviceCreateFlags
 -- | Opaque flag
-newtype DeviceCreateFlags = DeviceCreateFlags VkFlags
+newtype DeviceCreateFlags = DeviceCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -240,7 +240,7 @@ instance Storable DeviceQueueCreateInfo where
 
 -- ** DeviceQueueCreateFlags
 -- | Opaque flag
-newtype DeviceQueueCreateFlags = DeviceQueueCreateFlags VkFlags
+newtype DeviceQueueCreateFlags = DeviceQueueCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkDestroyDevice

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -3,32 +3,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Device where
 
-import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures
-                             , Device
-                             , VkDeviceCreateFlags
-                             , VkDeviceQueueCreateFlags
-                             , VkDeviceQueueCreateInfo
-                             , PhysicalDevice
-                             , VkDeviceCreateInfo
-                             )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
+                  , Ptr
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CFloat
-                      , CChar
+import Foreign.C.Types( CFloat(..)
+                      , CChar(..)
                       )
 
 -- ** vkCreateDevice

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -88,7 +88,7 @@ data PhysicalDeviceFeatures =
                         , variableMultisampleRate :: Bool32 
                         , inheritedQueries :: Bool32 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PhysicalDeviceFeatures where
   sizeOf ~_ = 220
@@ -208,7 +208,7 @@ instance Storable PhysicalDeviceFeatures where
 -- ** DeviceCreateFlags
 -- | Opaque flag
 newtype DeviceCreateFlags = DeviceCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data DeviceQueueCreateInfo =
@@ -219,7 +219,7 @@ data DeviceQueueCreateInfo =
                        , queueCount :: Word32 
                        , pQueuePriorities :: Ptr CFloat 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DeviceQueueCreateInfo where
   sizeOf ~_ = 40
@@ -241,7 +241,7 @@ instance Storable DeviceQueueCreateInfo where
 -- ** DeviceQueueCreateFlags
 -- | Opaque flag
 newtype DeviceQueueCreateFlags = DeviceQueueCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroyDevice
 foreign import ccall "vkDestroyDevice" destroyDevice ::
@@ -266,7 +266,7 @@ data DeviceCreateInfo =
                   , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
                   , pEnabledFeatures :: Ptr PhysicalDeviceFeatures 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DeviceCreateInfo where
   sizeOf ~_ = 72

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -24,8 +24,8 @@ import Foreign.C.Types( CFloat(..)
                       , CChar(..)
                       )
 
--- ** vkCreateDevice
-foreign import ccall "vkCreateDevice" vkCreateDevice ::
+-- ** createDevice
+foreign import ccall "vkCreateDevice" createDevice ::
   PhysicalDevice ->
   Ptr DeviceCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Device -> IO Result
@@ -243,8 +243,8 @@ instance Storable DeviceQueueCreateInfo where
 newtype DeviceQueueCreateFlags = DeviceQueueCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkDestroyDevice
-foreign import ccall "vkDestroyDevice" vkDestroyDevice ::
+-- ** destroyDevice
+foreign import ccall "vkDestroyDevice" destroyDevice ::
   Device -> Ptr AllocationCallbacks -> IO ()
 
 data VkPhysicalDevice_T

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -13,7 +13,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFlags(..)
@@ -27,182 +27,182 @@ import Foreign.C.Types( CFloat(..)
 -- ** vkCreateDevice
 foreign import ccall "vkCreateDevice" vkCreateDevice ::
   PhysicalDevice ->
-  Ptr VkDeviceCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Device -> IO VkResult
+  Ptr DeviceCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Device -> IO VkResult
 
 
-data VkPhysicalDeviceFeatures =
-  VkPhysicalDeviceFeatures{ robustBufferAccess :: VkBool32 
-                          , fullDrawIndexUint32 :: VkBool32 
-                          , imageCubeArray :: VkBool32 
-                          , independentBlend :: VkBool32 
-                          , geometryShader :: VkBool32 
-                          , tessellationShader :: VkBool32 
-                          , sampleRateShading :: VkBool32 
-                          , dualSrcBlend :: VkBool32 
-                          , logicOp :: VkBool32 
-                          , multiDrawIndirect :: VkBool32 
-                          , drawIndirectFirstInstance :: VkBool32 
-                          , depthClamp :: VkBool32 
-                          , depthBiasClamp :: VkBool32 
-                          , fillModeNonSolid :: VkBool32 
-                          , depthBounds :: VkBool32 
-                          , wideLines :: VkBool32 
-                          , largePoints :: VkBool32 
-                          , alphaToOne :: VkBool32 
-                          , multiViewport :: VkBool32 
-                          , samplerAnisotropy :: VkBool32 
-                          , textureCompressionETC2 :: VkBool32 
-                          , textureCompressionASTC_LDR :: VkBool32 
-                          , textureCompressionBC :: VkBool32 
-                          , occlusionQueryPrecise :: VkBool32 
-                          , pipelineStatisticsQuery :: VkBool32 
-                          , vertexPipelineStoresAndAtomics :: VkBool32 
-                          , fragmentStoresAndAtomics :: VkBool32 
-                          , shaderTessellationAndGeometryPointSize :: VkBool32 
-                          , shaderImageGatherExtended :: VkBool32 
-                          , shaderStorageImageExtendedFormats :: VkBool32 
-                          , shaderStorageImageMultisample :: VkBool32 
-                          , shaderStorageImageReadWithoutFormat :: VkBool32 
-                          , shaderStorageImageWriteWithoutFormat :: VkBool32 
-                          , shaderUniformBufferArrayDynamicIndexing :: VkBool32 
-                          , shaderSampledImageArrayDynamicIndexing :: VkBool32 
-                          , shaderStorageBufferArrayDynamicIndexing :: VkBool32 
-                          , shaderStorageImageArrayDynamicIndexing :: VkBool32 
-                          , shaderClipDistance :: VkBool32 
-                          , shaderCullDistance :: VkBool32 
-                          , shaderFloat64 :: VkBool32 
-                          , shaderInt64 :: VkBool32 
-                          , shaderInt16 :: VkBool32 
-                          , shaderResourceResidency :: VkBool32 
-                          , shaderResourceMinLod :: VkBool32 
-                          , sparseBinding :: VkBool32 
-                          , sparseResidencyBuffer :: VkBool32 
-                          , sparseResidencyImage2D :: VkBool32 
-                          , sparseResidencyImage3D :: VkBool32 
-                          , sparseResidency2Samples :: VkBool32 
-                          , sparseResidency4Samples :: VkBool32 
-                          , sparseResidency8Samples :: VkBool32 
-                          , sparseResidency16Samples :: VkBool32 
-                          , sparseResidencyAliased :: VkBool32 
-                          , variableMultisampleRate :: VkBool32 
-                          , inheritedQueries :: VkBool32 
-                          }
+data PhysicalDeviceFeatures =
+  PhysicalDeviceFeatures{ robustBufferAccess :: VkBool32 
+                        , fullDrawIndexUint32 :: VkBool32 
+                        , imageCubeArray :: VkBool32 
+                        , independentBlend :: VkBool32 
+                        , geometryShader :: VkBool32 
+                        , tessellationShader :: VkBool32 
+                        , sampleRateShading :: VkBool32 
+                        , dualSrcBlend :: VkBool32 
+                        , logicOp :: VkBool32 
+                        , multiDrawIndirect :: VkBool32 
+                        , drawIndirectFirstInstance :: VkBool32 
+                        , depthClamp :: VkBool32 
+                        , depthBiasClamp :: VkBool32 
+                        , fillModeNonSolid :: VkBool32 
+                        , depthBounds :: VkBool32 
+                        , wideLines :: VkBool32 
+                        , largePoints :: VkBool32 
+                        , alphaToOne :: VkBool32 
+                        , multiViewport :: VkBool32 
+                        , samplerAnisotropy :: VkBool32 
+                        , textureCompressionETC2 :: VkBool32 
+                        , textureCompressionASTC_LDR :: VkBool32 
+                        , textureCompressionBC :: VkBool32 
+                        , occlusionQueryPrecise :: VkBool32 
+                        , pipelineStatisticsQuery :: VkBool32 
+                        , vertexPipelineStoresAndAtomics :: VkBool32 
+                        , fragmentStoresAndAtomics :: VkBool32 
+                        , shaderTessellationAndGeometryPointSize :: VkBool32 
+                        , shaderImageGatherExtended :: VkBool32 
+                        , shaderStorageImageExtendedFormats :: VkBool32 
+                        , shaderStorageImageMultisample :: VkBool32 
+                        , shaderStorageImageReadWithoutFormat :: VkBool32 
+                        , shaderStorageImageWriteWithoutFormat :: VkBool32 
+                        , shaderUniformBufferArrayDynamicIndexing :: VkBool32 
+                        , shaderSampledImageArrayDynamicIndexing :: VkBool32 
+                        , shaderStorageBufferArrayDynamicIndexing :: VkBool32 
+                        , shaderStorageImageArrayDynamicIndexing :: VkBool32 
+                        , shaderClipDistance :: VkBool32 
+                        , shaderCullDistance :: VkBool32 
+                        , shaderFloat64 :: VkBool32 
+                        , shaderInt64 :: VkBool32 
+                        , shaderInt16 :: VkBool32 
+                        , shaderResourceResidency :: VkBool32 
+                        , shaderResourceMinLod :: VkBool32 
+                        , sparseBinding :: VkBool32 
+                        , sparseResidencyBuffer :: VkBool32 
+                        , sparseResidencyImage2D :: VkBool32 
+                        , sparseResidencyImage3D :: VkBool32 
+                        , sparseResidency2Samples :: VkBool32 
+                        , sparseResidency4Samples :: VkBool32 
+                        , sparseResidency8Samples :: VkBool32 
+                        , sparseResidency16Samples :: VkBool32 
+                        , sparseResidencyAliased :: VkBool32 
+                        , variableMultisampleRate :: VkBool32 
+                        , inheritedQueries :: VkBool32 
+                        }
   deriving (Eq)
 
-instance Storable VkPhysicalDeviceFeatures where
+instance Storable PhysicalDeviceFeatures where
   sizeOf ~_ = 220
   alignment ~_ = 4
-  peek ptr = VkPhysicalDeviceFeatures <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 4)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 12)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 20)
-                                      <*> peek (ptr `plusPtr` 24)
-                                      <*> peek (ptr `plusPtr` 28)
-                                      <*> peek (ptr `plusPtr` 32)
-                                      <*> peek (ptr `plusPtr` 36)
-                                      <*> peek (ptr `plusPtr` 40)
-                                      <*> peek (ptr `plusPtr` 44)
-                                      <*> peek (ptr `plusPtr` 48)
-                                      <*> peek (ptr `plusPtr` 52)
-                                      <*> peek (ptr `plusPtr` 56)
-                                      <*> peek (ptr `plusPtr` 60)
-                                      <*> peek (ptr `plusPtr` 64)
-                                      <*> peek (ptr `plusPtr` 68)
-                                      <*> peek (ptr `plusPtr` 72)
-                                      <*> peek (ptr `plusPtr` 76)
-                                      <*> peek (ptr `plusPtr` 80)
-                                      <*> peek (ptr `plusPtr` 84)
-                                      <*> peek (ptr `plusPtr` 88)
-                                      <*> peek (ptr `plusPtr` 92)
-                                      <*> peek (ptr `plusPtr` 96)
-                                      <*> peek (ptr `plusPtr` 100)
-                                      <*> peek (ptr `plusPtr` 104)
-                                      <*> peek (ptr `plusPtr` 108)
-                                      <*> peek (ptr `plusPtr` 112)
-                                      <*> peek (ptr `plusPtr` 116)
-                                      <*> peek (ptr `plusPtr` 120)
-                                      <*> peek (ptr `plusPtr` 124)
-                                      <*> peek (ptr `plusPtr` 128)
-                                      <*> peek (ptr `plusPtr` 132)
-                                      <*> peek (ptr `plusPtr` 136)
-                                      <*> peek (ptr `plusPtr` 140)
-                                      <*> peek (ptr `plusPtr` 144)
-                                      <*> peek (ptr `plusPtr` 148)
-                                      <*> peek (ptr `plusPtr` 152)
-                                      <*> peek (ptr `plusPtr` 156)
-                                      <*> peek (ptr `plusPtr` 160)
-                                      <*> peek (ptr `plusPtr` 164)
-                                      <*> peek (ptr `plusPtr` 168)
-                                      <*> peek (ptr `plusPtr` 172)
-                                      <*> peek (ptr `plusPtr` 176)
-                                      <*> peek (ptr `plusPtr` 180)
-                                      <*> peek (ptr `plusPtr` 184)
-                                      <*> peek (ptr `plusPtr` 188)
-                                      <*> peek (ptr `plusPtr` 192)
-                                      <*> peek (ptr `plusPtr` 196)
-                                      <*> peek (ptr `plusPtr` 200)
-                                      <*> peek (ptr `plusPtr` 204)
-                                      <*> peek (ptr `plusPtr` 208)
-                                      <*> peek (ptr `plusPtr` 212)
-                                      <*> peek (ptr `plusPtr` 216)
-  poke ptr poked = poke (ptr `plusPtr` 0) (robustBufferAccess (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 4) (fullDrawIndexUint32 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 8) (imageCubeArray (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 12) (independentBlend (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 16) (geometryShader (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 20) (tessellationShader (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 24) (sampleRateShading (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 28) (dualSrcBlend (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 32) (logicOp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 36) (multiDrawIndirect (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 40) (drawIndirectFirstInstance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 44) (depthClamp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 52) (fillModeNonSolid (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 56) (depthBounds (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 60) (wideLines (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 64) (largePoints (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 68) (alphaToOne (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 72) (multiViewport (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 76) (samplerAnisotropy (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 80) (textureCompressionETC2 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 84) (textureCompressionASTC_LDR (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 88) (textureCompressionBC (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 92) (occlusionQueryPrecise (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 96) (pipelineStatisticsQuery (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 100) (vertexPipelineStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 104) (fragmentStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 108) (shaderTessellationAndGeometryPointSize (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 112) (shaderImageGatherExtended (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 116) (shaderStorageImageExtendedFormats (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 120) (shaderStorageImageMultisample (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 124) (shaderStorageImageReadWithoutFormat (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 128) (shaderStorageImageWriteWithoutFormat (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 132) (shaderUniformBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 136) (shaderSampledImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 140) (shaderStorageBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 144) (shaderStorageImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 148) (shaderClipDistance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 152) (shaderCullDistance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 156) (shaderFloat64 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 160) (shaderInt64 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 164) (shaderInt16 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 168) (shaderResourceResidency (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 172) (shaderResourceMinLod (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 176) (sparseBinding (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 180) (sparseResidencyBuffer (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 184) (sparseResidencyImage2D (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 188) (sparseResidencyImage3D (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 192) (sparseResidency2Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 196) (sparseResidency4Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 200) (sparseResidency8Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 204) (sparseResidency16Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 208) (sparseResidencyAliased (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 212) (variableMultisampleRate (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 216) (inheritedQueries (poked :: VkPhysicalDeviceFeatures))
+  peek ptr = PhysicalDeviceFeatures <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 4)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 12)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 20)
+                                    <*> peek (ptr `plusPtr` 24)
+                                    <*> peek (ptr `plusPtr` 28)
+                                    <*> peek (ptr `plusPtr` 32)
+                                    <*> peek (ptr `plusPtr` 36)
+                                    <*> peek (ptr `plusPtr` 40)
+                                    <*> peek (ptr `plusPtr` 44)
+                                    <*> peek (ptr `plusPtr` 48)
+                                    <*> peek (ptr `plusPtr` 52)
+                                    <*> peek (ptr `plusPtr` 56)
+                                    <*> peek (ptr `plusPtr` 60)
+                                    <*> peek (ptr `plusPtr` 64)
+                                    <*> peek (ptr `plusPtr` 68)
+                                    <*> peek (ptr `plusPtr` 72)
+                                    <*> peek (ptr `plusPtr` 76)
+                                    <*> peek (ptr `plusPtr` 80)
+                                    <*> peek (ptr `plusPtr` 84)
+                                    <*> peek (ptr `plusPtr` 88)
+                                    <*> peek (ptr `plusPtr` 92)
+                                    <*> peek (ptr `plusPtr` 96)
+                                    <*> peek (ptr `plusPtr` 100)
+                                    <*> peek (ptr `plusPtr` 104)
+                                    <*> peek (ptr `plusPtr` 108)
+                                    <*> peek (ptr `plusPtr` 112)
+                                    <*> peek (ptr `plusPtr` 116)
+                                    <*> peek (ptr `plusPtr` 120)
+                                    <*> peek (ptr `plusPtr` 124)
+                                    <*> peek (ptr `plusPtr` 128)
+                                    <*> peek (ptr `plusPtr` 132)
+                                    <*> peek (ptr `plusPtr` 136)
+                                    <*> peek (ptr `plusPtr` 140)
+                                    <*> peek (ptr `plusPtr` 144)
+                                    <*> peek (ptr `plusPtr` 148)
+                                    <*> peek (ptr `plusPtr` 152)
+                                    <*> peek (ptr `plusPtr` 156)
+                                    <*> peek (ptr `plusPtr` 160)
+                                    <*> peek (ptr `plusPtr` 164)
+                                    <*> peek (ptr `plusPtr` 168)
+                                    <*> peek (ptr `plusPtr` 172)
+                                    <*> peek (ptr `plusPtr` 176)
+                                    <*> peek (ptr `plusPtr` 180)
+                                    <*> peek (ptr `plusPtr` 184)
+                                    <*> peek (ptr `plusPtr` 188)
+                                    <*> peek (ptr `plusPtr` 192)
+                                    <*> peek (ptr `plusPtr` 196)
+                                    <*> peek (ptr `plusPtr` 200)
+                                    <*> peek (ptr `plusPtr` 204)
+                                    <*> peek (ptr `plusPtr` 208)
+                                    <*> peek (ptr `plusPtr` 212)
+                                    <*> peek (ptr `plusPtr` 216)
+  poke ptr poked = poke (ptr `plusPtr` 0) (robustBufferAccess (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 4) (fullDrawIndexUint32 (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 8) (imageCubeArray (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 12) (independentBlend (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 16) (geometryShader (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 20) (tessellationShader (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 24) (sampleRateShading (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 28) (dualSrcBlend (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 32) (logicOp (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 36) (multiDrawIndirect (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 40) (drawIndirectFirstInstance (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 44) (depthClamp (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 52) (fillModeNonSolid (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 56) (depthBounds (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 60) (wideLines (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 64) (largePoints (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 68) (alphaToOne (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 72) (multiViewport (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 76) (samplerAnisotropy (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 80) (textureCompressionETC2 (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 84) (textureCompressionASTC_LDR (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 88) (textureCompressionBC (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 92) (occlusionQueryPrecise (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 96) (pipelineStatisticsQuery (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 100) (vertexPipelineStoresAndAtomics (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 104) (fragmentStoresAndAtomics (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 108) (shaderTessellationAndGeometryPointSize (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 112) (shaderImageGatherExtended (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 116) (shaderStorageImageExtendedFormats (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 120) (shaderStorageImageMultisample (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 124) (shaderStorageImageReadWithoutFormat (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 128) (shaderStorageImageWriteWithoutFormat (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 132) (shaderUniformBufferArrayDynamicIndexing (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 136) (shaderSampledImageArrayDynamicIndexing (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 140) (shaderStorageBufferArrayDynamicIndexing (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 144) (shaderStorageImageArrayDynamicIndexing (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 148) (shaderClipDistance (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 152) (shaderCullDistance (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 156) (shaderFloat64 (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 160) (shaderInt64 (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 164) (shaderInt16 (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 168) (shaderResourceResidency (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 172) (shaderResourceMinLod (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 176) (sparseBinding (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 180) (sparseResidencyBuffer (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 184) (sparseResidencyImage2D (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 188) (sparseResidencyImage3D (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 192) (sparseResidency2Samples (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 196) (sparseResidency4Samples (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 200) (sparseResidency8Samples (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 204) (sparseResidency16Samples (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 208) (sparseResidencyAliased (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 212) (variableMultisampleRate (poked :: PhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 216) (inheritedQueries (poked :: PhysicalDeviceFeatures))
 
 
 -- ** VkDeviceCreateFlags
@@ -211,31 +211,31 @@ newtype VkDeviceCreateFlags = VkDeviceCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
-data VkDeviceQueueCreateInfo =
-  VkDeviceQueueCreateInfo{ sType :: VkStructureType 
-                         , pNext :: Ptr Void 
-                         , flags :: VkDeviceQueueCreateFlags 
-                         , queueFamilyIndex :: Word32 
-                         , queueCount :: Word32 
-                         , pQueuePriorities :: Ptr CFloat 
-                         }
+data DeviceQueueCreateInfo =
+  DeviceQueueCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkDeviceQueueCreateFlags 
+                       , queueFamilyIndex :: Word32 
+                       , queueCount :: Word32 
+                       , pQueuePriorities :: Ptr CFloat 
+                       }
   deriving (Eq)
 
-instance Storable VkDeviceQueueCreateInfo where
+instance Storable DeviceQueueCreateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkDeviceQueueCreateInfo <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 20)
-                                     <*> peek (ptr `plusPtr` 24)
-                                     <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 24) (queueCount (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pQueuePriorities (poked :: VkDeviceQueueCreateInfo))
+  peek ptr = DeviceQueueCreateInfo <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 20)
+                                   <*> peek (ptr `plusPtr` 24)
+                                   <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: DeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 24) (queueCount (poked :: DeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pQueuePriorities (poked :: DeviceQueueCreateInfo))
 
 
 -- ** VkDeviceQueueCreateFlags
@@ -245,7 +245,7 @@ newtype VkDeviceQueueCreateFlags = VkDeviceQueueCreateFlags VkFlags
 
 -- ** vkDestroyDevice
 foreign import ccall "vkDestroyDevice" vkDestroyDevice ::
-  Device -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Ptr AllocationCallbacks -> IO ()
 
 data VkPhysicalDevice_T
 type PhysicalDevice = Ptr VkPhysicalDevice_T
@@ -254,42 +254,42 @@ data VkDevice_T
 type Device = Ptr VkDevice_T
 
 
-data VkDeviceCreateInfo =
-  VkDeviceCreateInfo{ sType :: VkStructureType 
-                    , pNext :: Ptr Void 
-                    , flags :: VkDeviceCreateFlags 
-                    , queueCreateInfoCount :: Word32 
-                    , pQueueCreateInfos :: Ptr VkDeviceQueueCreateInfo 
-                    , enabledLayerCount :: Word32 
-                    , ppEnabledLayerNames :: Ptr (Ptr CChar) 
-                    , enabledExtensionCount :: Word32 
-                    , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
-                    , pEnabledFeatures :: Ptr VkPhysicalDeviceFeatures 
-                    }
+data DeviceCreateInfo =
+  DeviceCreateInfo{ sType :: VkStructureType 
+                  , pNext :: Ptr Void 
+                  , flags :: VkDeviceCreateFlags 
+                  , queueCreateInfoCount :: Word32 
+                  , pQueueCreateInfos :: Ptr DeviceQueueCreateInfo 
+                  , enabledLayerCount :: Word32 
+                  , ppEnabledLayerNames :: Ptr (Ptr CChar) 
+                  , enabledExtensionCount :: Word32 
+                  , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
+                  , pEnabledFeatures :: Ptr PhysicalDeviceFeatures 
+                  }
   deriving (Eq)
 
-instance Storable VkDeviceCreateInfo where
+instance Storable DeviceCreateInfo where
   sizeOf ~_ = 72
   alignment ~_ = 8
-  peek ptr = VkDeviceCreateInfo <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 8)
-                                <*> peek (ptr `plusPtr` 16)
-                                <*> peek (ptr `plusPtr` 20)
-                                <*> peek (ptr `plusPtr` 24)
-                                <*> peek (ptr `plusPtr` 32)
-                                <*> peek (ptr `plusPtr` 40)
-                                <*> peek (ptr `plusPtr` 48)
-                                <*> peek (ptr `plusPtr` 56)
-                                <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 20) (queueCreateInfoCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pQueueCreateInfos (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 64) (pEnabledFeatures (poked :: VkDeviceCreateInfo))
+  peek ptr = DeviceCreateInfo <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 8)
+                              <*> peek (ptr `plusPtr` 16)
+                              <*> peek (ptr `plusPtr` 20)
+                              <*> peek (ptr `plusPtr` 24)
+                              <*> peek (ptr `plusPtr` 32)
+                              <*> peek (ptr `plusPtr` 40)
+                              <*> peek (ptr `plusPtr` 48)
+                              <*> peek (ptr `plusPtr` 56)
+                              <*> peek (ptr `plusPtr` 64)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueCreateInfoCount (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pQueueCreateInfos (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: DeviceCreateInfo))
+                *> poke (ptr `plusPtr` 64) (pEnabledFeatures (poked :: DeviceCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -34,67 +34,67 @@ import Foreign.C.Types( CFloat
 
 -- ** vkCreateDevice
 foreign import ccall "vkCreateDevice" vkCreateDevice ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr VkDeviceCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkDevice -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Device -> IO VkResult
 
 
 data VkPhysicalDeviceFeatures =
-  VkPhysicalDeviceFeatures{ vkRobustBufferAccess :: VkBool32 
-                          , vkFullDrawIndexUint32 :: VkBool32 
-                          , vkImageCubeArray :: VkBool32 
-                          , vkIndependentBlend :: VkBool32 
-                          , vkGeometryShader :: VkBool32 
-                          , vkTessellationShader :: VkBool32 
-                          , vkSampleRateShading :: VkBool32 
-                          , vkDualSrcBlend :: VkBool32 
-                          , vkLogicOp :: VkBool32 
-                          , vkMultiDrawIndirect :: VkBool32 
-                          , vkDrawIndirectFirstInstance :: VkBool32 
-                          , vkDepthClamp :: VkBool32 
-                          , vkDepthBiasClamp :: VkBool32 
-                          , vkFillModeNonSolid :: VkBool32 
-                          , vkDepthBounds :: VkBool32 
-                          , vkWideLines :: VkBool32 
-                          , vkLargePoints :: VkBool32 
-                          , vkAlphaToOne :: VkBool32 
-                          , vkMultiViewport :: VkBool32 
-                          , vkSamplerAnisotropy :: VkBool32 
-                          , vkTextureCompressionETC2 :: VkBool32 
-                          , vkTextureCompressionASTC_LDR :: VkBool32 
-                          , vkTextureCompressionBC :: VkBool32 
-                          , vkOcclusionQueryPrecise :: VkBool32 
-                          , vkPipelineStatisticsQuery :: VkBool32 
-                          , vkVertexPipelineStoresAndAtomics :: VkBool32 
-                          , vkFragmentStoresAndAtomics :: VkBool32 
-                          , vkShaderTessellationAndGeometryPointSize :: VkBool32 
-                          , vkShaderImageGatherExtended :: VkBool32 
-                          , vkShaderStorageImageExtendedFormats :: VkBool32 
-                          , vkShaderStorageImageMultisample :: VkBool32 
-                          , vkShaderStorageImageReadWithoutFormat :: VkBool32 
-                          , vkShaderStorageImageWriteWithoutFormat :: VkBool32 
-                          , vkShaderUniformBufferArrayDynamicIndexing :: VkBool32 
-                          , vkShaderSampledImageArrayDynamicIndexing :: VkBool32 
-                          , vkShaderStorageBufferArrayDynamicIndexing :: VkBool32 
-                          , vkShaderStorageImageArrayDynamicIndexing :: VkBool32 
-                          , vkShaderClipDistance :: VkBool32 
-                          , vkShaderCullDistance :: VkBool32 
-                          , vkShaderFloat64 :: VkBool32 
-                          , vkShaderInt64 :: VkBool32 
-                          , vkShaderInt16 :: VkBool32 
-                          , vkShaderResourceResidency :: VkBool32 
-                          , vkShaderResourceMinLod :: VkBool32 
-                          , vkSparseBinding :: VkBool32 
-                          , vkSparseResidencyBuffer :: VkBool32 
-                          , vkSparseResidencyImage2D :: VkBool32 
-                          , vkSparseResidencyImage3D :: VkBool32 
-                          , vkSparseResidency2Samples :: VkBool32 
-                          , vkSparseResidency4Samples :: VkBool32 
-                          , vkSparseResidency8Samples :: VkBool32 
-                          , vkSparseResidency16Samples :: VkBool32 
-                          , vkSparseResidencyAliased :: VkBool32 
-                          , vkVariableMultisampleRate :: VkBool32 
-                          , vkInheritedQueries :: VkBool32 
+  VkPhysicalDeviceFeatures{ robustBufferAccess :: VkBool32 
+                          , fullDrawIndexUint32 :: VkBool32 
+                          , imageCubeArray :: VkBool32 
+                          , independentBlend :: VkBool32 
+                          , geometryShader :: VkBool32 
+                          , tessellationShader :: VkBool32 
+                          , sampleRateShading :: VkBool32 
+                          , dualSrcBlend :: VkBool32 
+                          , logicOp :: VkBool32 
+                          , multiDrawIndirect :: VkBool32 
+                          , drawIndirectFirstInstance :: VkBool32 
+                          , depthClamp :: VkBool32 
+                          , depthBiasClamp :: VkBool32 
+                          , fillModeNonSolid :: VkBool32 
+                          , depthBounds :: VkBool32 
+                          , wideLines :: VkBool32 
+                          , largePoints :: VkBool32 
+                          , alphaToOne :: VkBool32 
+                          , multiViewport :: VkBool32 
+                          , samplerAnisotropy :: VkBool32 
+                          , textureCompressionETC2 :: VkBool32 
+                          , textureCompressionASTC_LDR :: VkBool32 
+                          , textureCompressionBC :: VkBool32 
+                          , occlusionQueryPrecise :: VkBool32 
+                          , pipelineStatisticsQuery :: VkBool32 
+                          , vertexPipelineStoresAndAtomics :: VkBool32 
+                          , fragmentStoresAndAtomics :: VkBool32 
+                          , shaderTessellationAndGeometryPointSize :: VkBool32 
+                          , shaderImageGatherExtended :: VkBool32 
+                          , shaderStorageImageExtendedFormats :: VkBool32 
+                          , shaderStorageImageMultisample :: VkBool32 
+                          , shaderStorageImageReadWithoutFormat :: VkBool32 
+                          , shaderStorageImageWriteWithoutFormat :: VkBool32 
+                          , shaderUniformBufferArrayDynamicIndexing :: VkBool32 
+                          , shaderSampledImageArrayDynamicIndexing :: VkBool32 
+                          , shaderStorageBufferArrayDynamicIndexing :: VkBool32 
+                          , shaderStorageImageArrayDynamicIndexing :: VkBool32 
+                          , shaderClipDistance :: VkBool32 
+                          , shaderCullDistance :: VkBool32 
+                          , shaderFloat64 :: VkBool32 
+                          , shaderInt64 :: VkBool32 
+                          , shaderInt16 :: VkBool32 
+                          , shaderResourceResidency :: VkBool32 
+                          , shaderResourceMinLod :: VkBool32 
+                          , sparseBinding :: VkBool32 
+                          , sparseResidencyBuffer :: VkBool32 
+                          , sparseResidencyImage2D :: VkBool32 
+                          , sparseResidencyImage3D :: VkBool32 
+                          , sparseResidency2Samples :: VkBool32 
+                          , sparseResidency4Samples :: VkBool32 
+                          , sparseResidency8Samples :: VkBool32 
+                          , sparseResidency16Samples :: VkBool32 
+                          , sparseResidencyAliased :: VkBool32 
+                          , variableMultisampleRate :: VkBool32 
+                          , inheritedQueries :: VkBool32 
                           }
   deriving (Eq)
 
@@ -156,61 +156,61 @@ instance Storable VkPhysicalDeviceFeatures where
                                       <*> peek (ptr `plusPtr` 208)
                                       <*> peek (ptr `plusPtr` 212)
                                       <*> peek (ptr `plusPtr` 216)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkRobustBufferAccess (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 4) (vkFullDrawIndexUint32 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 8) (vkImageCubeArray (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 12) (vkIndependentBlend (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 16) (vkGeometryShader (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 20) (vkTessellationShader (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 24) (vkSampleRateShading (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 28) (vkDualSrcBlend (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 32) (vkLogicOp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 36) (vkMultiDrawIndirect (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 40) (vkDrawIndirectFirstInstance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 44) (vkDepthClamp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 48) (vkDepthBiasClamp (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 52) (vkFillModeNonSolid (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 56) (vkDepthBounds (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 60) (vkWideLines (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 64) (vkLargePoints (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 68) (vkAlphaToOne (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 72) (vkMultiViewport (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 76) (vkSamplerAnisotropy (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 80) (vkTextureCompressionETC2 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 84) (vkTextureCompressionASTC_LDR (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 88) (vkTextureCompressionBC (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 92) (vkOcclusionQueryPrecise (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 96) (vkPipelineStatisticsQuery (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 100) (vkVertexPipelineStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 104) (vkFragmentStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 108) (vkShaderTessellationAndGeometryPointSize (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 112) (vkShaderImageGatherExtended (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 116) (vkShaderStorageImageExtendedFormats (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 120) (vkShaderStorageImageMultisample (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 124) (vkShaderStorageImageReadWithoutFormat (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 128) (vkShaderStorageImageWriteWithoutFormat (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 132) (vkShaderUniformBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 136) (vkShaderSampledImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 140) (vkShaderStorageBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 144) (vkShaderStorageImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 148) (vkShaderClipDistance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 152) (vkShaderCullDistance (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 156) (vkShaderFloat64 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 160) (vkShaderInt64 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 164) (vkShaderInt16 (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 168) (vkShaderResourceResidency (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 172) (vkShaderResourceMinLod (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 176) (vkSparseBinding (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 180) (vkSparseResidencyBuffer (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 184) (vkSparseResidencyImage2D (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 188) (vkSparseResidencyImage3D (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 192) (vkSparseResidency2Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 196) (vkSparseResidency4Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 200) (vkSparseResidency8Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 204) (vkSparseResidency16Samples (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 208) (vkSparseResidencyAliased (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 212) (vkVariableMultisampleRate (poked :: VkPhysicalDeviceFeatures))
-                *> poke (ptr `plusPtr` 216) (vkInheritedQueries (poked :: VkPhysicalDeviceFeatures))
+  poke ptr poked = poke (ptr `plusPtr` 0) (robustBufferAccess (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 4) (fullDrawIndexUint32 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 8) (imageCubeArray (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 12) (independentBlend (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 16) (geometryShader (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 20) (tessellationShader (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 24) (sampleRateShading (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 28) (dualSrcBlend (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 32) (logicOp (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 36) (multiDrawIndirect (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 40) (drawIndirectFirstInstance (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 44) (depthClamp (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 52) (fillModeNonSolid (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 56) (depthBounds (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 60) (wideLines (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 64) (largePoints (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 68) (alphaToOne (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 72) (multiViewport (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 76) (samplerAnisotropy (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 80) (textureCompressionETC2 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 84) (textureCompressionASTC_LDR (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 88) (textureCompressionBC (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 92) (occlusionQueryPrecise (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 96) (pipelineStatisticsQuery (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 100) (vertexPipelineStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 104) (fragmentStoresAndAtomics (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 108) (shaderTessellationAndGeometryPointSize (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 112) (shaderImageGatherExtended (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 116) (shaderStorageImageExtendedFormats (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 120) (shaderStorageImageMultisample (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 124) (shaderStorageImageReadWithoutFormat (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 128) (shaderStorageImageWriteWithoutFormat (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 132) (shaderUniformBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 136) (shaderSampledImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 140) (shaderStorageBufferArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 144) (shaderStorageImageArrayDynamicIndexing (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 148) (shaderClipDistance (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 152) (shaderCullDistance (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 156) (shaderFloat64 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 160) (shaderInt64 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 164) (shaderInt16 (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 168) (shaderResourceResidency (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 172) (shaderResourceMinLod (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 176) (sparseBinding (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 180) (sparseResidencyBuffer (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 184) (sparseResidencyImage2D (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 188) (sparseResidencyImage3D (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 192) (sparseResidency2Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 196) (sparseResidency4Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 200) (sparseResidency8Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 204) (sparseResidency16Samples (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 208) (sparseResidencyAliased (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 212) (variableMultisampleRate (poked :: VkPhysicalDeviceFeatures))
+                *> poke (ptr `plusPtr` 216) (inheritedQueries (poked :: VkPhysicalDeviceFeatures))
 
 
 -- ** VkDeviceCreateFlags
@@ -220,12 +220,12 @@ newtype VkDeviceCreateFlags = VkDeviceCreateFlags VkFlags
 
 
 data VkDeviceQueueCreateInfo =
-  VkDeviceQueueCreateInfo{ vkSType :: VkStructureType 
-                         , vkPNext :: Ptr Void 
-                         , vkFlags :: VkDeviceQueueCreateFlags 
-                         , vkQueueFamilyIndex :: Word32 
-                         , vkQueueCount :: Word32 
-                         , vkPQueuePriorities :: Ptr CFloat 
+  VkDeviceQueueCreateInfo{ sType :: VkStructureType 
+                         , pNext :: Ptr Void 
+                         , flags :: VkDeviceQueueCreateFlags 
+                         , queueFamilyIndex :: Word32 
+                         , queueCount :: Word32 
+                         , pQueuePriorities :: Ptr CFloat 
                          }
   deriving (Eq)
 
@@ -238,12 +238,12 @@ instance Storable VkDeviceQueueCreateInfo where
                                      <*> peek (ptr `plusPtr` 20)
                                      <*> peek (ptr `plusPtr` 24)
                                      <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkQueueFamilyIndex (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkQueueCount (poked :: VkDeviceQueueCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPQueuePriorities (poked :: VkDeviceQueueCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueFamilyIndex (poked :: VkDeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 24) (queueCount (poked :: VkDeviceQueueCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pQueuePriorities (poked :: VkDeviceQueueCreateInfo))
 
 
 -- ** VkDeviceQueueCreateFlags
@@ -253,26 +253,26 @@ newtype VkDeviceQueueCreateFlags = VkDeviceQueueCreateFlags VkFlags
 
 -- ** vkDestroyDevice
 foreign import ccall "vkDestroyDevice" vkDestroyDevice ::
-  VkDevice -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Ptr VkAllocationCallbacks -> IO ()
 
 data VkPhysicalDevice_T
-type VkPhysicalDevice = Ptr VkPhysicalDevice_T
+type PhysicalDevice = Ptr VkPhysicalDevice_T
 
 data VkDevice_T
-type VkDevice = Ptr VkDevice_T
+type Device = Ptr VkDevice_T
 
 
 data VkDeviceCreateInfo =
-  VkDeviceCreateInfo{ vkSType :: VkStructureType 
-                    , vkPNext :: Ptr Void 
-                    , vkFlags :: VkDeviceCreateFlags 
-                    , vkQueueCreateInfoCount :: Word32 
-                    , vkPQueueCreateInfos :: Ptr VkDeviceQueueCreateInfo 
-                    , vkEnabledLayerCount :: Word32 
-                    , vkPpEnabledLayerNames :: Ptr (Ptr CChar) 
-                    , vkEnabledExtensionCount :: Word32 
-                    , vkPpEnabledExtensionNames :: Ptr (Ptr CChar) 
-                    , vkPEnabledFeatures :: Ptr VkPhysicalDeviceFeatures 
+  VkDeviceCreateInfo{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , flags :: VkDeviceCreateFlags 
+                    , queueCreateInfoCount :: Word32 
+                    , pQueueCreateInfos :: Ptr VkDeviceQueueCreateInfo 
+                    , enabledLayerCount :: Word32 
+                    , ppEnabledLayerNames :: Ptr (Ptr CChar) 
+                    , enabledExtensionCount :: Word32 
+                    , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
+                    , pEnabledFeatures :: Ptr VkPhysicalDeviceFeatures 
                     }
   deriving (Eq)
 
@@ -289,15 +289,15 @@ instance Storable VkDeviceCreateInfo where
                                 <*> peek (ptr `plusPtr` 48)
                                 <*> peek (ptr `plusPtr` 56)
                                 <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkQueueCreateInfoCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPQueueCreateInfos (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkEnabledLayerCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPpEnabledLayerNames (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkEnabledExtensionCount (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkPpEnabledExtensionNames (poked :: VkDeviceCreateInfo))
-                *> poke (ptr `plusPtr` 64) (vkPEnabledFeatures (poked :: VkDeviceCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queueCreateInfoCount (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pQueueCreateInfos (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: VkDeviceCreateInfo))
+                *> poke (ptr `plusPtr` 64) (pEnabledFeatures (poked :: VkDeviceCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Device.hs
+++ b/src/Graphics/Vulkan/Device.hs
@@ -15,10 +15,10 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -28,7 +28,7 @@ import Foreign.C.Types( CFloat(..)
 foreign import ccall "vkCreateDevice" vkCreateDevice ::
   PhysicalDevice ->
   Ptr DeviceCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Device -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Device -> IO Result
 
 
 data PhysicalDeviceFeatures =
@@ -205,16 +205,16 @@ instance Storable PhysicalDeviceFeatures where
                 *> poke (ptr `plusPtr` 216) (inheritedQueries (poked :: PhysicalDeviceFeatures))
 
 
--- ** VkDeviceCreateFlags
+-- ** DeviceCreateFlags
 -- | Opaque flag
-newtype VkDeviceCreateFlags = VkDeviceCreateFlags VkFlags
+newtype DeviceCreateFlags = DeviceCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data DeviceQueueCreateInfo =
-  DeviceQueueCreateInfo{ sType :: VkStructureType 
+  DeviceQueueCreateInfo{ sType :: StructureType 
                        , pNext :: Ptr Void 
-                       , flags :: VkDeviceQueueCreateFlags 
+                       , flags :: DeviceQueueCreateFlags 
                        , queueFamilyIndex :: Word32 
                        , queueCount :: Word32 
                        , pQueuePriorities :: Ptr CFloat 
@@ -238,9 +238,9 @@ instance Storable DeviceQueueCreateInfo where
                 *> poke (ptr `plusPtr` 32) (pQueuePriorities (poked :: DeviceQueueCreateInfo))
 
 
--- ** VkDeviceQueueCreateFlags
+-- ** DeviceQueueCreateFlags
 -- | Opaque flag
-newtype VkDeviceQueueCreateFlags = VkDeviceQueueCreateFlags VkFlags
+newtype DeviceQueueCreateFlags = DeviceQueueCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkDestroyDevice
@@ -255,9 +255,9 @@ type Device = Ptr VkDevice_T
 
 
 data DeviceCreateInfo =
-  DeviceCreateInfo{ sType :: VkStructureType 
+  DeviceCreateInfo{ sType :: StructureType 
                   , pNext :: Ptr Void 
-                  , flags :: VkDeviceCreateFlags 
+                  , flags :: DeviceCreateFlags 
                   , queueCreateInfoCount :: Word32 
                   , pQueueCreateInfos :: Ptr DeviceQueueCreateInfo 
                   , enabledLayerCount :: Word32 

--- a/src/Graphics/Vulkan/Device.hs-boot
+++ b/src/Graphics/Vulkan/Device.hs-boot
@@ -5,5 +5,5 @@ import Foreign.Ptr( Ptr
                   )
 
 data VkDevice_T
-type VkDevice = Ptr VkDevice_T
+type Device = Ptr VkDevice_T
 

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -7,17 +7,12 @@ module Graphics.Vulkan.DeviceInitialization where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures(..)
-                             , PhysicalDevice(..)
-                             , Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
 import Data.Word( Word8
-                , Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
@@ -31,22 +26,8 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
-                                , VK_MAX_MEMORY_HEAPS
-                                , VK_UUID_SIZE
-                                , VK_MAX_MEMORY_TYPES
-                                )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -54,29 +35,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
-                              , VkSampleCountFlags(..)
-                              )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , VkImageType(..)
-                            , VkImageUsageFlagBits(..)
-                            , VkImageCreateFlags(..)
-                            , VkImageTiling(..)
-                            , VkImageCreateFlagBits(..)
-                            )
-import Graphics.Vulkan.Core( VkExtent3D(..)
-                           , VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
                       , CFloat
-                      , CFloat(..)
                       , CChar
-                      , CSize(..)
                       )
 
 -- ** VkPhysicalDeviceType

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -8,8 +8,8 @@ module Graphics.Vulkan.DeviceInitialization where
 import Data.Vector.Storable.Sized( Vector
                                  )
 import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures(..)
-                             , VkPhysicalDevice(..)
-                             , VkDevice(..)
+                             , PhysicalDevice(..)
+                             , Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -119,14 +119,14 @@ pattern VK_PHYSICAL_DEVICE_TYPE_CPU = VkPhysicalDeviceType 4
 
 
 data VkInstanceCreateInfo =
-  VkInstanceCreateInfo{ vkSType :: VkStructureType 
-                      , vkPNext :: Ptr Void 
-                      , vkFlags :: VkInstanceCreateFlags 
-                      , vkPApplicationInfo :: Ptr VkApplicationInfo 
-                      , vkEnabledLayerCount :: Word32 
-                      , vkPpEnabledLayerNames :: Ptr (Ptr CChar) 
-                      , vkEnabledExtensionCount :: Word32 
-                      , vkPpEnabledExtensionNames :: Ptr (Ptr CChar) 
+  VkInstanceCreateInfo{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , flags :: VkInstanceCreateFlags 
+                      , pApplicationInfo :: Ptr VkApplicationInfo 
+                      , enabledLayerCount :: Word32 
+                      , ppEnabledLayerNames :: Ptr (Ptr CChar) 
+                      , enabledExtensionCount :: Word32 
+                      , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
                       }
   deriving (Eq)
 
@@ -141,19 +141,19 @@ instance Storable VkInstanceCreateInfo where
                                   <*> peek (ptr `plusPtr` 40)
                                   <*> peek (ptr `plusPtr` 48)
                                   <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPApplicationInfo (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkEnabledLayerCount (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPpEnabledLayerNames (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkEnabledExtensionCount (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkPpEnabledExtensionNames (poked :: VkInstanceCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pApplicationInfo (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: VkInstanceCreateInfo))
+                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: VkInstanceCreateInfo))
 
 
 -- ** vkGetPhysicalDeviceImageFormatProperties
 foreign import ccall "vkGetPhysicalDeviceImageFormatProperties" vkGetPhysicalDeviceImageFormatProperties ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   VkFormat ->
     VkImageType ->
       VkImageTiling ->
@@ -164,13 +164,13 @@ type PFN_vkVoidFunction = FunPtr (IO ())
 
 
 data VkApplicationInfo =
-  VkApplicationInfo{ vkSType :: VkStructureType 
-                   , vkPNext :: Ptr Void 
-                   , vkPApplicationName :: Ptr CChar 
-                   , vkApplicationVersion :: Word32 
-                   , vkPEngineName :: Ptr CChar 
-                   , vkEngineVersion :: Word32 
-                   , vkApiVersion :: Word32 
+  VkApplicationInfo{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , pApplicationName :: Ptr CChar 
+                   , applicationVersion :: Word32 
+                   , pEngineName :: Ptr CChar 
+                   , engineVersion :: Word32 
+                   , apiVersion :: Word32 
                    }
   deriving (Eq)
 
@@ -184,123 +184,123 @@ instance Storable VkApplicationInfo where
                                <*> peek (ptr `plusPtr` 32)
                                <*> peek (ptr `plusPtr` 40)
                                <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 16) (vkPApplicationName (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 24) (vkApplicationVersion (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 32) (vkPEngineName (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 40) (vkEngineVersion (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 44) (vkApiVersion (poked :: VkApplicationInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 16) (pApplicationName (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 24) (applicationVersion (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 32) (pEngineName (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 40) (engineVersion (poked :: VkApplicationInfo))
+                *> poke (ptr `plusPtr` 44) (apiVersion (poked :: VkApplicationInfo))
 
 
 
 data VkPhysicalDeviceLimits =
-  VkPhysicalDeviceLimits{ vkMaxImageDimension1D :: Word32 
-                        , vkMaxImageDimension2D :: Word32 
-                        , vkMaxImageDimension3D :: Word32 
-                        , vkMaxImageDimensionCube :: Word32 
-                        , vkMaxImageArrayLayers :: Word32 
-                        , vkMaxTexelBufferElements :: Word32 
-                        , vkMaxUniformBufferRange :: Word32 
-                        , vkMaxStorageBufferRange :: Word32 
-                        , vkMaxPushConstantsSize :: Word32 
-                        , vkMaxMemoryAllocationCount :: Word32 
-                        , vkMaxSamplerAllocationCount :: Word32 
-                        , vkBufferImageGranularity :: VkDeviceSize 
-                        , vkSparseAddressSpaceSize :: VkDeviceSize 
-                        , vkMaxBoundDescriptorSets :: Word32 
-                        , vkMaxPerStageDescriptorSamplers :: Word32 
-                        , vkMaxPerStageDescriptorUniformBuffers :: Word32 
-                        , vkMaxPerStageDescriptorStorageBuffers :: Word32 
-                        , vkMaxPerStageDescriptorSampledImages :: Word32 
-                        , vkMaxPerStageDescriptorStorageImages :: Word32 
-                        , vkMaxPerStageDescriptorInputAttachments :: Word32 
-                        , vkMaxPerStageResources :: Word32 
-                        , vkMaxDescriptorSetSamplers :: Word32 
-                        , vkMaxDescriptorSetUniformBuffers :: Word32 
-                        , vkMaxDescriptorSetUniformBuffersDynamic :: Word32 
-                        , vkMaxDescriptorSetStorageBuffers :: Word32 
-                        , vkMaxDescriptorSetStorageBuffersDynamic :: Word32 
-                        , vkMaxDescriptorSetSampledImages :: Word32 
-                        , vkMaxDescriptorSetStorageImages :: Word32 
-                        , vkMaxDescriptorSetInputAttachments :: Word32 
-                        , vkMaxVertexInputAttributes :: Word32 
-                        , vkMaxVertexInputBindings :: Word32 
-                        , vkMaxVertexInputAttributeOffset :: Word32 
-                        , vkMaxVertexInputBindingStride :: Word32 
-                        , vkMaxVertexOutputComponents :: Word32 
-                        , vkMaxTessellationGenerationLevel :: Word32 
-                        , vkMaxTessellationPatchSize :: Word32 
-                        , vkMaxTessellationControlPerVertexInputComponents :: Word32 
-                        , vkMaxTessellationControlPerVertexOutputComponents :: Word32 
-                        , vkMaxTessellationControlPerPatchOutputComponents :: Word32 
-                        , vkMaxTessellationControlTotalOutputComponents :: Word32 
-                        , vkMaxTessellationEvaluationInputComponents :: Word32 
-                        , vkMaxTessellationEvaluationOutputComponents :: Word32 
-                        , vkMaxGeometryShaderInvocations :: Word32 
-                        , vkMaxGeometryInputComponents :: Word32 
-                        , vkMaxGeometryOutputComponents :: Word32 
-                        , vkMaxGeometryOutputVertices :: Word32 
-                        , vkMaxGeometryTotalOutputComponents :: Word32 
-                        , vkMaxFragmentInputComponents :: Word32 
-                        , vkMaxFragmentOutputAttachments :: Word32 
-                        , vkMaxFragmentDualSrcAttachments :: Word32 
-                        , vkMaxFragmentCombinedOutputResources :: Word32 
-                        , vkMaxComputeSharedMemorySize :: Word32 
-                        , vkMaxComputeWorkGroupCount :: Vector 3 Word32 
-                        , vkMaxComputeWorkGroupInvocations :: Word32 
-                        , vkMaxComputeWorkGroupSize :: Vector 3 Word32 
-                        , vkSubPixelPrecisionBits :: Word32 
-                        , vkSubTexelPrecisionBits :: Word32 
-                        , vkMipmapPrecisionBits :: Word32 
-                        , vkMaxDrawIndexedIndexValue :: Word32 
-                        , vkMaxDrawIndirectCount :: Word32 
-                        , vkMaxSamplerLodBias :: CFloat 
-                        , vkMaxSamplerAnisotropy :: CFloat 
-                        , vkMaxViewports :: Word32 
-                        , vkMaxViewportDimensions :: Vector 2 Word32 
-                        , vkViewportBoundsRange :: Vector 2 CFloat 
-                        , vkViewportSubPixelBits :: Word32 
-                        , vkMinMemoryMapAlignment :: CSize 
-                        , vkMinTexelBufferOffsetAlignment :: VkDeviceSize 
-                        , vkMinUniformBufferOffsetAlignment :: VkDeviceSize 
-                        , vkMinStorageBufferOffsetAlignment :: VkDeviceSize 
-                        , vkMinTexelOffset :: Int32 
-                        , vkMaxTexelOffset :: Word32 
-                        , vkMinTexelGatherOffset :: Int32 
-                        , vkMaxTexelGatherOffset :: Word32 
-                        , vkMinInterpolationOffset :: CFloat 
-                        , vkMaxInterpolationOffset :: CFloat 
-                        , vkSubPixelInterpolationOffsetBits :: Word32 
-                        , vkMaxFramebufferWidth :: Word32 
-                        , vkMaxFramebufferHeight :: Word32 
-                        , vkMaxFramebufferLayers :: Word32 
-                        , vkFramebufferColorSampleCounts :: VkSampleCountFlags 
-                        , vkFramebufferDepthSampleCounts :: VkSampleCountFlags 
-                        , vkFramebufferStencilSampleCounts :: VkSampleCountFlags 
-                        , vkFramebufferNoAttachmentsSampleCounts :: VkSampleCountFlags 
-                        , vkMaxColorAttachments :: Word32 
-                        , vkSampledImageColorSampleCounts :: VkSampleCountFlags 
-                        , vkSampledImageIntegerSampleCounts :: VkSampleCountFlags 
-                        , vkSampledImageDepthSampleCounts :: VkSampleCountFlags 
-                        , vkSampledImageStencilSampleCounts :: VkSampleCountFlags 
-                        , vkStorageImageSampleCounts :: VkSampleCountFlags 
-                        , vkMaxSampleMaskWords :: Word32 
-                        , vkTimestampComputeAndGraphics :: VkBool32 
-                        , vkTimestampPeriod :: CFloat 
-                        , vkMaxClipDistances :: Word32 
-                        , vkMaxCullDistances :: Word32 
-                        , vkMaxCombinedClipAndCullDistances :: Word32 
-                        , vkDiscreteQueuePriorities :: Word32 
-                        , vkPointSizeRange :: Vector 2 CFloat 
-                        , vkLineWidthRange :: Vector 2 CFloat 
-                        , vkPointSizeGranularity :: CFloat 
-                        , vkLineWidthGranularity :: CFloat 
-                        , vkStrictLines :: VkBool32 
-                        , vkStandardSampleLocations :: VkBool32 
-                        , vkOptimalBufferCopyOffsetAlignment :: VkDeviceSize 
-                        , vkOptimalBufferCopyRowPitchAlignment :: VkDeviceSize 
-                        , vkNonCoherentAtomSize :: VkDeviceSize 
+  VkPhysicalDeviceLimits{ maxImageDimension1D :: Word32 
+                        , maxImageDimension2D :: Word32 
+                        , maxImageDimension3D :: Word32 
+                        , maxImageDimensionCube :: Word32 
+                        , maxImageArrayLayers :: Word32 
+                        , maxTexelBufferElements :: Word32 
+                        , maxUniformBufferRange :: Word32 
+                        , maxStorageBufferRange :: Word32 
+                        , maxPushConstantsSize :: Word32 
+                        , maxMemoryAllocationCount :: Word32 
+                        , maxSamplerAllocationCount :: Word32 
+                        , bufferImageGranularity :: VkDeviceSize 
+                        , sparseAddressSpaceSize :: VkDeviceSize 
+                        , maxBoundDescriptorSets :: Word32 
+                        , maxPerStageDescriptorSamplers :: Word32 
+                        , maxPerStageDescriptorUniformBuffers :: Word32 
+                        , maxPerStageDescriptorStorageBuffers :: Word32 
+                        , maxPerStageDescriptorSampledImages :: Word32 
+                        , maxPerStageDescriptorStorageImages :: Word32 
+                        , maxPerStageDescriptorInputAttachments :: Word32 
+                        , maxPerStageResources :: Word32 
+                        , maxDescriptorSetSamplers :: Word32 
+                        , maxDescriptorSetUniformBuffers :: Word32 
+                        , maxDescriptorSetUniformBuffersDynamic :: Word32 
+                        , maxDescriptorSetStorageBuffers :: Word32 
+                        , maxDescriptorSetStorageBuffersDynamic :: Word32 
+                        , maxDescriptorSetSampledImages :: Word32 
+                        , maxDescriptorSetStorageImages :: Word32 
+                        , maxDescriptorSetInputAttachments :: Word32 
+                        , maxVertexInputAttributes :: Word32 
+                        , maxVertexInputBindings :: Word32 
+                        , maxVertexInputAttributeOffset :: Word32 
+                        , maxVertexInputBindingStride :: Word32 
+                        , maxVertexOutputComponents :: Word32 
+                        , maxTessellationGenerationLevel :: Word32 
+                        , maxTessellationPatchSize :: Word32 
+                        , maxTessellationControlPerVertexInputComponents :: Word32 
+                        , maxTessellationControlPerVertexOutputComponents :: Word32 
+                        , maxTessellationControlPerPatchOutputComponents :: Word32 
+                        , maxTessellationControlTotalOutputComponents :: Word32 
+                        , maxTessellationEvaluationInputComponents :: Word32 
+                        , maxTessellationEvaluationOutputComponents :: Word32 
+                        , maxGeometryShaderInvocations :: Word32 
+                        , maxGeometryInputComponents :: Word32 
+                        , maxGeometryOutputComponents :: Word32 
+                        , maxGeometryOutputVertices :: Word32 
+                        , maxGeometryTotalOutputComponents :: Word32 
+                        , maxFragmentInputComponents :: Word32 
+                        , maxFragmentOutputAttachments :: Word32 
+                        , maxFragmentDualSrcAttachments :: Word32 
+                        , maxFragmentCombinedOutputResources :: Word32 
+                        , maxComputeSharedMemorySize :: Word32 
+                        , maxComputeWorkGroupCount :: Vector 3 Word32 
+                        , maxComputeWorkGroupInvocations :: Word32 
+                        , maxComputeWorkGroupSize :: Vector 3 Word32 
+                        , subPixelPrecisionBits :: Word32 
+                        , subTexelPrecisionBits :: Word32 
+                        , mipmapPrecisionBits :: Word32 
+                        , maxDrawIndexedIndexValue :: Word32 
+                        , maxDrawIndirectCount :: Word32 
+                        , maxSamplerLodBias :: CFloat 
+                        , maxSamplerAnisotropy :: CFloat 
+                        , maxViewports :: Word32 
+                        , maxViewportDimensions :: Vector 2 Word32 
+                        , viewportBoundsRange :: Vector 2 CFloat 
+                        , viewportSubPixelBits :: Word32 
+                        , minMemoryMapAlignment :: CSize 
+                        , minTexelBufferOffsetAlignment :: VkDeviceSize 
+                        , minUniformBufferOffsetAlignment :: VkDeviceSize 
+                        , minStorageBufferOffsetAlignment :: VkDeviceSize 
+                        , minTexelOffset :: Int32 
+                        , maxTexelOffset :: Word32 
+                        , minTexelGatherOffset :: Int32 
+                        , maxTexelGatherOffset :: Word32 
+                        , minInterpolationOffset :: CFloat 
+                        , maxInterpolationOffset :: CFloat 
+                        , subPixelInterpolationOffsetBits :: Word32 
+                        , maxFramebufferWidth :: Word32 
+                        , maxFramebufferHeight :: Word32 
+                        , maxFramebufferLayers :: Word32 
+                        , framebufferColorSampleCounts :: VkSampleCountFlags 
+                        , framebufferDepthSampleCounts :: VkSampleCountFlags 
+                        , framebufferStencilSampleCounts :: VkSampleCountFlags 
+                        , framebufferNoAttachmentsSampleCounts :: VkSampleCountFlags 
+                        , maxColorAttachments :: Word32 
+                        , sampledImageColorSampleCounts :: VkSampleCountFlags 
+                        , sampledImageIntegerSampleCounts :: VkSampleCountFlags 
+                        , sampledImageDepthSampleCounts :: VkSampleCountFlags 
+                        , sampledImageStencilSampleCounts :: VkSampleCountFlags 
+                        , storageImageSampleCounts :: VkSampleCountFlags 
+                        , maxSampleMaskWords :: Word32 
+                        , timestampComputeAndGraphics :: VkBool32 
+                        , timestampPeriod :: CFloat 
+                        , maxClipDistances :: Word32 
+                        , maxCullDistances :: Word32 
+                        , maxCombinedClipAndCullDistances :: Word32 
+                        , discreteQueuePriorities :: Word32 
+                        , pointSizeRange :: Vector 2 CFloat 
+                        , lineWidthRange :: Vector 2 CFloat 
+                        , pointSizeGranularity :: CFloat 
+                        , lineWidthGranularity :: CFloat 
+                        , strictLines :: VkBool32 
+                        , standardSampleLocations :: VkBool32 
+                        , optimalBufferCopyOffsetAlignment :: VkDeviceSize 
+                        , optimalBufferCopyRowPitchAlignment :: VkDeviceSize 
+                        , nonCoherentAtomSize :: VkDeviceSize 
                         }
   deriving (Eq)
 
@@ -413,118 +413,118 @@ instance Storable VkPhysicalDeviceLimits where
                                     <*> peek (ptr `plusPtr` 480)
                                     <*> peek (ptr `plusPtr` 488)
                                     <*> peek (ptr `plusPtr` 496)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMaxImageDimension1D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 4) (vkMaxImageDimension2D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 8) (vkMaxImageDimension3D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 12) (vkMaxImageDimensionCube (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 16) (vkMaxImageArrayLayers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 20) (vkMaxTexelBufferElements (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 24) (vkMaxUniformBufferRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 28) (vkMaxStorageBufferRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 32) (vkMaxPushConstantsSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 36) (vkMaxMemoryAllocationCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 40) (vkMaxSamplerAllocationCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 48) (vkBufferImageGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 56) (vkSparseAddressSpaceSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 64) (vkMaxBoundDescriptorSets (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 68) (vkMaxPerStageDescriptorSamplers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 72) (vkMaxPerStageDescriptorUniformBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 76) (vkMaxPerStageDescriptorStorageBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 80) (vkMaxPerStageDescriptorSampledImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 84) (vkMaxPerStageDescriptorStorageImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 88) (vkMaxPerStageDescriptorInputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 92) (vkMaxPerStageResources (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 96) (vkMaxDescriptorSetSamplers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 100) (vkMaxDescriptorSetUniformBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 104) (vkMaxDescriptorSetUniformBuffersDynamic (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 108) (vkMaxDescriptorSetStorageBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 112) (vkMaxDescriptorSetStorageBuffersDynamic (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 116) (vkMaxDescriptorSetSampledImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 120) (vkMaxDescriptorSetStorageImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 124) (vkMaxDescriptorSetInputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 128) (vkMaxVertexInputAttributes (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 132) (vkMaxVertexInputBindings (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 136) (vkMaxVertexInputAttributeOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 140) (vkMaxVertexInputBindingStride (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 144) (vkMaxVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 148) (vkMaxTessellationGenerationLevel (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 152) (vkMaxTessellationPatchSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 156) (vkMaxTessellationControlPerVertexInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 160) (vkMaxTessellationControlPerVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 164) (vkMaxTessellationControlPerPatchOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 168) (vkMaxTessellationControlTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 172) (vkMaxTessellationEvaluationInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 176) (vkMaxTessellationEvaluationOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 180) (vkMaxGeometryShaderInvocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 184) (vkMaxGeometryInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 188) (vkMaxGeometryOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 192) (vkMaxGeometryOutputVertices (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 196) (vkMaxGeometryTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 200) (vkMaxFragmentInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 204) (vkMaxFragmentOutputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 208) (vkMaxFragmentDualSrcAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 212) (vkMaxFragmentCombinedOutputResources (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 216) (vkMaxComputeSharedMemorySize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 220) (vkMaxComputeWorkGroupCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 232) (vkMaxComputeWorkGroupInvocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 236) (vkMaxComputeWorkGroupSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 248) (vkSubPixelPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 252) (vkSubTexelPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 256) (vkMipmapPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 260) (vkMaxDrawIndexedIndexValue (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 264) (vkMaxDrawIndirectCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 268) (vkMaxSamplerLodBias (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 272) (vkMaxSamplerAnisotropy (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 276) (vkMaxViewports (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 280) (vkMaxViewportDimensions (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 288) (vkViewportBoundsRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 296) (vkViewportSubPixelBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 304) (vkMinMemoryMapAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 312) (vkMinTexelBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 320) (vkMinUniformBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 328) (vkMinStorageBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 336) (vkMinTexelOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 340) (vkMaxTexelOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 344) (vkMinTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 348) (vkMaxTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 352) (vkMinInterpolationOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 356) (vkMaxInterpolationOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 360) (vkSubPixelInterpolationOffsetBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 364) (vkMaxFramebufferWidth (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 368) (vkMaxFramebufferHeight (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 372) (vkMaxFramebufferLayers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 376) (vkFramebufferColorSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 380) (vkFramebufferDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 384) (vkFramebufferStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 388) (vkFramebufferNoAttachmentsSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 392) (vkMaxColorAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 396) (vkSampledImageColorSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 400) (vkSampledImageIntegerSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 404) (vkSampledImageDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 408) (vkSampledImageStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 412) (vkStorageImageSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 416) (vkMaxSampleMaskWords (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 420) (vkTimestampComputeAndGraphics (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 424) (vkTimestampPeriod (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 428) (vkMaxClipDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 432) (vkMaxCullDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 436) (vkMaxCombinedClipAndCullDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 440) (vkDiscreteQueuePriorities (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 444) (vkPointSizeRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 452) (vkLineWidthRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 460) (vkPointSizeGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 464) (vkLineWidthGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 468) (vkStrictLines (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 472) (vkStandardSampleLocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 480) (vkOptimalBufferCopyOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 488) (vkOptimalBufferCopyRowPitchAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 496) (vkNonCoherentAtomSize (poked :: VkPhysicalDeviceLimits))
+  poke ptr poked = poke (ptr `plusPtr` 0) (maxImageDimension1D (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 4) (maxImageDimension2D (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 8) (maxImageDimension3D (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 12) (maxImageDimensionCube (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 16) (maxImageArrayLayers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 20) (maxTexelBufferElements (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 24) (maxUniformBufferRange (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 28) (maxStorageBufferRange (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 32) (maxPushConstantsSize (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 36) (maxMemoryAllocationCount (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 40) (maxSamplerAllocationCount (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 48) (bufferImageGranularity (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 56) (sparseAddressSpaceSize (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 64) (maxBoundDescriptorSets (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 68) (maxPerStageDescriptorSamplers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 72) (maxPerStageDescriptorUniformBuffers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 76) (maxPerStageDescriptorStorageBuffers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 80) (maxPerStageDescriptorSampledImages (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 84) (maxPerStageDescriptorStorageImages (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 88) (maxPerStageDescriptorInputAttachments (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 92) (maxPerStageResources (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 96) (maxDescriptorSetSamplers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 100) (maxDescriptorSetUniformBuffers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 104) (maxDescriptorSetUniformBuffersDynamic (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 108) (maxDescriptorSetStorageBuffers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 112) (maxDescriptorSetStorageBuffersDynamic (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 116) (maxDescriptorSetSampledImages (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 120) (maxDescriptorSetStorageImages (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 124) (maxDescriptorSetInputAttachments (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 128) (maxVertexInputAttributes (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 132) (maxVertexInputBindings (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 136) (maxVertexInputAttributeOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 140) (maxVertexInputBindingStride (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 144) (maxVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 148) (maxTessellationGenerationLevel (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 152) (maxTessellationPatchSize (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 156) (maxTessellationControlPerVertexInputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 160) (maxTessellationControlPerVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 164) (maxTessellationControlPerPatchOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 168) (maxTessellationControlTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 172) (maxTessellationEvaluationInputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 176) (maxTessellationEvaluationOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 180) (maxGeometryShaderInvocations (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 184) (maxGeometryInputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 188) (maxGeometryOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 192) (maxGeometryOutputVertices (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 196) (maxGeometryTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 200) (maxFragmentInputComponents (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 204) (maxFragmentOutputAttachments (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 208) (maxFragmentDualSrcAttachments (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 212) (maxFragmentCombinedOutputResources (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 216) (maxComputeSharedMemorySize (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 220) (maxComputeWorkGroupCount (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 232) (maxComputeWorkGroupInvocations (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 236) (maxComputeWorkGroupSize (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 248) (subPixelPrecisionBits (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 252) (subTexelPrecisionBits (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 256) (mipmapPrecisionBits (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 260) (maxDrawIndexedIndexValue (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 264) (maxDrawIndirectCount (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 268) (maxSamplerLodBias (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 272) (maxSamplerAnisotropy (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 276) (maxViewports (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 280) (maxViewportDimensions (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 288) (viewportBoundsRange (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 296) (viewportSubPixelBits (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 304) (minMemoryMapAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 312) (minTexelBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 320) (minUniformBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 328) (minStorageBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 336) (minTexelOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 340) (maxTexelOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 344) (minTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 348) (maxTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 352) (minInterpolationOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 356) (maxInterpolationOffset (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 360) (subPixelInterpolationOffsetBits (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 364) (maxFramebufferWidth (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 368) (maxFramebufferHeight (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 372) (maxFramebufferLayers (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 376) (framebufferColorSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 380) (framebufferDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 384) (framebufferStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 388) (framebufferNoAttachmentsSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 392) (maxColorAttachments (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 396) (sampledImageColorSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 400) (sampledImageIntegerSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 404) (sampledImageDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 408) (sampledImageStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 412) (storageImageSampleCounts (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 416) (maxSampleMaskWords (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 420) (timestampComputeAndGraphics (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 424) (timestampPeriod (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 428) (maxClipDistances (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 432) (maxCullDistances (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 436) (maxCombinedClipAndCullDistances (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 440) (discreteQueuePriorities (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 444) (pointSizeRange (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 452) (lineWidthRange (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 460) (pointSizeGranularity (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 464) (lineWidthGranularity (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 468) (strictLines (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 472) (standardSampleLocations (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 480) (optimalBufferCopyOffsetAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 488) (optimalBufferCopyRowPitchAlignment (poked :: VkPhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 496) (nonCoherentAtomSize (poked :: VkPhysicalDeviceLimits))
 
 
 
 data VkMemoryHeap =
-  VkMemoryHeap{ vkSize :: VkDeviceSize 
-              , vkFlags :: VkMemoryHeapFlags 
+  VkMemoryHeap{ size :: VkDeviceSize 
+              , flags :: VkMemoryHeapFlags 
               }
   deriving (Eq)
 
@@ -533,22 +533,22 @@ instance Storable VkMemoryHeap where
   alignment ~_ = 8
   peek ptr = VkMemoryHeap <$> peek (ptr `plusPtr` 0)
                           <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSize (poked :: VkMemoryHeap))
-                *> poke (ptr `plusPtr` 8) (vkFlags (poked :: VkMemoryHeap))
+  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: VkMemoryHeap))
+                *> poke (ptr `plusPtr` 8) (flags (poked :: VkMemoryHeap))
 
 
 -- ** vkEnumeratePhysicalDevices
 foreign import ccall "vkEnumeratePhysicalDevices" vkEnumeratePhysicalDevices ::
-  VkInstance -> Ptr Word32 -> Ptr VkPhysicalDevice -> IO VkResult
+  Instance -> Ptr Word32 -> Ptr PhysicalDevice -> IO VkResult
 
 -- ** vkGetDeviceProcAddr
 foreign import ccall "vkGetDeviceProcAddr" vkGetDeviceProcAddr ::
-  VkDevice -> Ptr CChar -> IO PFN_vkVoidFunction
+  Device -> Ptr CChar -> IO PFN_vkVoidFunction
 
 -- ** vkCreateInstance
 foreign import ccall "vkCreateInstance" vkCreateInstance ::
   Ptr VkInstanceCreateInfo ->
-  Ptr VkAllocationCallbacks -> Ptr VkInstance -> IO VkResult
+  Ptr VkAllocationCallbacks -> Ptr Instance -> IO VkResult
 
 -- ** VkFormatFeatureFlags
 
@@ -627,10 +627,10 @@ pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlagB
 
 
 data VkPhysicalDeviceMemoryProperties =
-  VkPhysicalDeviceMemoryProperties{ vkMemoryTypeCount :: Word32 
-                                  , vkMemoryTypes :: Vector VK_MAX_MEMORY_TYPES VkMemoryType 
-                                  , vkMemoryHeapCount :: Word32 
-                                  , vkMemoryHeaps :: Vector VK_MAX_MEMORY_HEAPS VkMemoryHeap 
+  VkPhysicalDeviceMemoryProperties{ memoryTypeCount :: Word32 
+                                  , memoryTypes :: Vector VK_MAX_MEMORY_TYPES VkMemoryType 
+                                  , memoryHeapCount :: Word32 
+                                  , memoryHeaps :: Vector VK_MAX_MEMORY_HEAPS VkMemoryHeap 
                                   }
   deriving (Eq)
 
@@ -641,14 +641,14 @@ instance Storable VkPhysicalDeviceMemoryProperties where
                                               <*> peek (ptr `plusPtr` 4)
                                               <*> peek (ptr `plusPtr` 260)
                                               <*> peek (ptr `plusPtr` 264)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMemoryTypeCount (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 4) (vkMemoryTypes (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 260) (vkMemoryHeapCount (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 264) (vkMemoryHeaps (poked :: VkPhysicalDeviceMemoryProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (memoryTypeCount (poked :: VkPhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 4) (memoryTypes (poked :: VkPhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 260) (memoryHeapCount (poked :: VkPhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 264) (memoryHeaps (poked :: VkPhysicalDeviceMemoryProperties))
 
 
 data VkInstance_T
-type VkInstance = Ptr VkInstance_T
+type Instance = Ptr VkInstance_T
 
 -- ** VkMemoryHeapFlags
 
@@ -679,10 +679,10 @@ pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlagBits 0x1
 
 
 data VkQueueFamilyProperties =
-  VkQueueFamilyProperties{ vkQueueFlags :: VkQueueFlags 
-                         , vkQueueCount :: Word32 
-                         , vkTimestampValidBits :: Word32 
-                         , vkMinImageTransferGranularity :: VkExtent3D 
+  VkQueueFamilyProperties{ queueFlags :: VkQueueFlags 
+                         , queueCount :: Word32 
+                         , timestampValidBits :: Word32 
+                         , minImageTransferGranularity :: VkExtent3D 
                          }
   deriving (Eq)
 
@@ -693,19 +693,19 @@ instance Storable VkQueueFamilyProperties where
                                      <*> peek (ptr `plusPtr` 4)
                                      <*> peek (ptr `plusPtr` 8)
                                      <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkQueueFlags (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 4) (vkQueueCount (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 8) (vkTimestampValidBits (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 12) (vkMinImageTransferGranularity (poked :: VkQueueFamilyProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (queueFlags (poked :: VkQueueFamilyProperties))
+                *> poke (ptr `plusPtr` 4) (queueCount (poked :: VkQueueFamilyProperties))
+                *> poke (ptr `plusPtr` 8) (timestampValidBits (poked :: VkQueueFamilyProperties))
+                *> poke (ptr `plusPtr` 12) (minImageTransferGranularity (poked :: VkQueueFamilyProperties))
 
 
 
 data VkImageFormatProperties =
-  VkImageFormatProperties{ vkMaxExtent :: VkExtent3D 
-                         , vkMaxMipLevels :: Word32 
-                         , vkMaxArrayLayers :: Word32 
-                         , vkSampleCounts :: VkSampleCountFlags 
-                         , vkMaxResourceSize :: VkDeviceSize 
+  VkImageFormatProperties{ maxExtent :: VkExtent3D 
+                         , maxMipLevels :: Word32 
+                         , maxArrayLayers :: Word32 
+                         , sampleCounts :: VkSampleCountFlags 
+                         , maxResourceSize :: VkDeviceSize 
                          }
   deriving (Eq)
 
@@ -717,20 +717,20 @@ instance Storable VkImageFormatProperties where
                                      <*> peek (ptr `plusPtr` 16)
                                      <*> peek (ptr `plusPtr` 20)
                                      <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMaxExtent (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 12) (vkMaxMipLevels (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 16) (vkMaxArrayLayers (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 20) (vkSampleCounts (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 24) (vkMaxResourceSize (poked :: VkImageFormatProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (maxExtent (poked :: VkImageFormatProperties))
+                *> poke (ptr `plusPtr` 12) (maxMipLevels (poked :: VkImageFormatProperties))
+                *> poke (ptr `plusPtr` 16) (maxArrayLayers (poked :: VkImageFormatProperties))
+                *> poke (ptr `plusPtr` 20) (sampleCounts (poked :: VkImageFormatProperties))
+                *> poke (ptr `plusPtr` 24) (maxResourceSize (poked :: VkImageFormatProperties))
 
 
 
 data VkPhysicalDeviceSparseProperties =
-  VkPhysicalDeviceSparseProperties{ vkResidencyStandard2DBlockShape :: VkBool32 
-                                  , vkResidencyStandard2DMultisampleBlockShape :: VkBool32 
-                                  , vkResidencyStandard3DBlockShape :: VkBool32 
-                                  , vkResidencyAlignedMipSize :: VkBool32 
-                                  , vkResidencyNonResidentStrict :: VkBool32 
+  VkPhysicalDeviceSparseProperties{ residencyStandard2DBlockShape :: VkBool32 
+                                  , residencyStandard2DMultisampleBlockShape :: VkBool32 
+                                  , residencyStandard3DBlockShape :: VkBool32 
+                                  , residencyAlignedMipSize :: VkBool32 
+                                  , residencyNonResidentStrict :: VkBool32 
                                   }
   deriving (Eq)
 
@@ -742,32 +742,32 @@ instance Storable VkPhysicalDeviceSparseProperties where
                                               <*> peek (ptr `plusPtr` 8)
                                               <*> peek (ptr `plusPtr` 12)
                                               <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkResidencyStandard2DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 4) (vkResidencyStandard2DMultisampleBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 8) (vkResidencyStandard3DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 12) (vkResidencyAlignedMipSize (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 16) (vkResidencyNonResidentStrict (poked :: VkPhysicalDeviceSparseProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (residencyStandard2DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 4) (residencyStandard2DMultisampleBlockShape (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 8) (residencyStandard3DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 12) (residencyAlignedMipSize (poked :: VkPhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 16) (residencyNonResidentStrict (poked :: VkPhysicalDeviceSparseProperties))
 
 
 -- ** vkGetPhysicalDeviceFeatures
 foreign import ccall "vkGetPhysicalDeviceFeatures" vkGetPhysicalDeviceFeatures ::
-  VkPhysicalDevice -> Ptr VkPhysicalDeviceFeatures -> IO ()
+  PhysicalDevice -> Ptr VkPhysicalDeviceFeatures -> IO ()
 
 -- ** vkGetPhysicalDeviceMemoryProperties
 foreign import ccall "vkGetPhysicalDeviceMemoryProperties" vkGetPhysicalDeviceMemoryProperties ::
-  VkPhysicalDevice -> Ptr VkPhysicalDeviceMemoryProperties -> IO ()
+  PhysicalDevice -> Ptr VkPhysicalDeviceMemoryProperties -> IO ()
 
 
 data VkPhysicalDeviceProperties =
-  VkPhysicalDeviceProperties{ vkApiVersion :: Word32 
-                            , vkDriverVersion :: Word32 
-                            , vkVendorID :: Word32 
-                            , vkDeviceID :: Word32 
-                            , vkDeviceType :: VkPhysicalDeviceType 
-                            , vkDeviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
-                            , vkPipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
-                            , vkLimits :: VkPhysicalDeviceLimits 
-                            , vkSparseProperties :: VkPhysicalDeviceSparseProperties 
+  VkPhysicalDeviceProperties{ apiVersion :: Word32 
+                            , driverVersion :: Word32 
+                            , vendorID :: Word32 
+                            , deviceID :: Word32 
+                            , deviceType :: VkPhysicalDeviceType 
+                            , deviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
+                            , pipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
+                            , limits :: VkPhysicalDeviceLimits 
+                            , sparseProperties :: VkPhysicalDeviceSparseProperties 
                             }
   deriving (Eq)
 
@@ -783,26 +783,26 @@ instance Storable VkPhysicalDeviceProperties where
                                         <*> peek (ptr `plusPtr` 276)
                                         <*> peek (ptr `plusPtr` 296)
                                         <*> peek (ptr `plusPtr` 800)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkApiVersion (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 4) (vkDriverVersion (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 8) (vkVendorID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 12) (vkDeviceID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 16) (vkDeviceType (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 20) (vkDeviceName (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 276) (vkPipelineCacheUUID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 296) (vkLimits (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 800) (vkSparseProperties (poked :: VkPhysicalDeviceProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (apiVersion (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 4) (driverVersion (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 8) (vendorID (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 12) (deviceID (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 16) (deviceType (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 20) (deviceName (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 276) (pipelineCacheUUID (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 296) (limits (poked :: VkPhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 800) (sparseProperties (poked :: VkPhysicalDeviceProperties))
 
 
 -- ** vkGetPhysicalDeviceQueueFamilyProperties
 foreign import ccall "vkGetPhysicalDeviceQueueFamilyProperties" vkGetPhysicalDeviceQueueFamilyProperties ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr Word32 -> Ptr VkQueueFamilyProperties -> IO ()
 
 
 data VkMemoryType =
-  VkMemoryType{ vkPropertyFlags :: VkMemoryPropertyFlags 
-              , vkHeapIndex :: Word32 
+  VkMemoryType{ propertyFlags :: VkMemoryPropertyFlags 
+              , heapIndex :: Word32 
               }
   deriving (Eq)
 
@@ -811,13 +811,13 @@ instance Storable VkMemoryType where
   alignment ~_ = 4
   peek ptr = VkMemoryType <$> peek (ptr `plusPtr` 0)
                           <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkPropertyFlags (poked :: VkMemoryType))
-                *> poke (ptr `plusPtr` 4) (vkHeapIndex (poked :: VkMemoryType))
+  poke ptr poked = poke (ptr `plusPtr` 0) (propertyFlags (poked :: VkMemoryType))
+                *> poke (ptr `plusPtr` 4) (heapIndex (poked :: VkMemoryType))
 
 
 -- ** vkGetInstanceProcAddr
 foreign import ccall "vkGetInstanceProcAddr" vkGetInstanceProcAddr ::
-  VkInstance -> Ptr CChar -> IO PFN_vkVoidFunction
+  Instance -> Ptr CChar -> IO PFN_vkVoidFunction
 
 -- ** VkMemoryPropertyFlags
 
@@ -864,7 +864,7 @@ pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = VkMemoryPropertyFlagBits 0x10
 
 -- ** vkDestroyInstance
 foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
-  VkInstance -> Ptr VkAllocationCallbacks -> IO ()
+  Instance -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkQueueFlags
 
@@ -907,7 +907,7 @@ pattern VK_QUEUE_SPARSE_BINDING_BIT = VkQueueFlagBits 0x8
 
 -- ** vkGetPhysicalDeviceProperties
 foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperties ::
-  VkPhysicalDevice -> Ptr VkPhysicalDeviceProperties -> IO ()
+  PhysicalDevice -> Ptr VkPhysicalDeviceProperties -> IO ()
 
 -- ** VkInstanceCreateFlags
 -- | Opaque flag
@@ -916,13 +916,13 @@ newtype VkInstanceCreateFlags = VkInstanceCreateFlags VkFlags
 
 -- ** vkGetPhysicalDeviceFormatProperties
 foreign import ccall "vkGetPhysicalDeviceFormatProperties" vkGetPhysicalDeviceFormatProperties ::
-  VkPhysicalDevice -> VkFormat -> Ptr VkFormatProperties -> IO ()
+  PhysicalDevice -> VkFormat -> Ptr VkFormatProperties -> IO ()
 
 
 data VkFormatProperties =
-  VkFormatProperties{ vkLinearTilingFeatures :: VkFormatFeatureFlags 
-                    , vkOptimalTilingFeatures :: VkFormatFeatureFlags 
-                    , vkBufferFeatures :: VkFormatFeatureFlags 
+  VkFormatProperties{ linearTilingFeatures :: VkFormatFeatureFlags 
+                    , optimalTilingFeatures :: VkFormatFeatureFlags 
+                    , bufferFeatures :: VkFormatFeatureFlags 
                     }
   deriving (Eq)
 
@@ -932,8 +932,8 @@ instance Storable VkFormatProperties where
   peek ptr = VkFormatProperties <$> peek (ptr `plusPtr` 0)
                                 <*> peek (ptr `plusPtr` 4)
                                 <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkLinearTilingFeatures (poked :: VkFormatProperties))
-                *> poke (ptr `plusPtr` 4) (vkOptimalTilingFeatures (poked :: VkFormatProperties))
-                *> poke (ptr `plusPtr` 8) (vkBufferFeatures (poked :: VkFormatProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (linearTilingFeatures (poked :: VkFormatProperties))
+                *> poke (ptr `plusPtr` 4) (optimalTilingFeatures (poked :: VkFormatProperties))
+                *> poke (ptr `plusPtr` 8) (bufferFeatures (poked :: VkFormatProperties))
 
 

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -55,13 +55,13 @@ import Graphics.Vulkan.Image( ImageUsageFlags(..)
                             , ImageTiling(..)
                             , ImageType(..)
                             )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Format(..)
                            , Extent3D(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -195,8 +195,8 @@ data PhysicalDeviceLimits =
                       , maxPushConstantsSize :: Word32 
                       , maxMemoryAllocationCount :: Word32 
                       , maxSamplerAllocationCount :: Word32 
-                      , bufferImageGranularity :: VkDeviceSize 
-                      , sparseAddressSpaceSize :: VkDeviceSize 
+                      , bufferImageGranularity :: DeviceSize 
+                      , sparseAddressSpaceSize :: DeviceSize 
                       , maxBoundDescriptorSets :: Word32 
                       , maxPerStageDescriptorSamplers :: Word32 
                       , maxPerStageDescriptorUniformBuffers :: Word32 
@@ -251,9 +251,9 @@ data PhysicalDeviceLimits =
                       , viewportBoundsRange :: Vector 2 CFloat 
                       , viewportSubPixelBits :: Word32 
                       , minMemoryMapAlignment :: CSize 
-                      , minTexelBufferOffsetAlignment :: VkDeviceSize 
-                      , minUniformBufferOffsetAlignment :: VkDeviceSize 
-                      , minStorageBufferOffsetAlignment :: VkDeviceSize 
+                      , minTexelBufferOffsetAlignment :: DeviceSize 
+                      , minUniformBufferOffsetAlignment :: DeviceSize 
+                      , minStorageBufferOffsetAlignment :: DeviceSize 
                       , minTexelOffset :: Int32 
                       , maxTexelOffset :: Word32 
                       , minTexelGatherOffset :: Int32 
@@ -275,7 +275,7 @@ data PhysicalDeviceLimits =
                       , sampledImageStencilSampleCounts :: SampleCountFlags 
                       , storageImageSampleCounts :: SampleCountFlags 
                       , maxSampleMaskWords :: Word32 
-                      , timestampComputeAndGraphics :: VkBool32 
+                      , timestampComputeAndGraphics :: Bool32 
                       , timestampPeriod :: CFloat 
                       , maxClipDistances :: Word32 
                       , maxCullDistances :: Word32 
@@ -285,11 +285,11 @@ data PhysicalDeviceLimits =
                       , lineWidthRange :: Vector 2 CFloat 
                       , pointSizeGranularity :: CFloat 
                       , lineWidthGranularity :: CFloat 
-                      , strictLines :: VkBool32 
-                      , standardSampleLocations :: VkBool32 
-                      , optimalBufferCopyOffsetAlignment :: VkDeviceSize 
-                      , optimalBufferCopyRowPitchAlignment :: VkDeviceSize 
-                      , nonCoherentAtomSize :: VkDeviceSize 
+                      , strictLines :: Bool32 
+                      , standardSampleLocations :: Bool32 
+                      , optimalBufferCopyOffsetAlignment :: DeviceSize 
+                      , optimalBufferCopyRowPitchAlignment :: DeviceSize 
+                      , nonCoherentAtomSize :: DeviceSize 
                       }
   deriving (Eq)
 
@@ -512,7 +512,7 @@ instance Storable PhysicalDeviceLimits where
 
 
 data MemoryHeap =
-  MemoryHeap{ size :: VkDeviceSize 
+  MemoryHeap{ size :: DeviceSize 
             , flags :: MemoryHeapFlags 
             }
   deriving (Eq)
@@ -541,7 +541,7 @@ foreign import ccall "vkCreateInstance" vkCreateInstance ::
 
 -- ** VkFormatFeatureFlags
 
-newtype FormatFeatureFlags = FormatFeatureFlags VkFlags
+newtype FormatFeatureFlags = FormatFeatureFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show FormatFeatureFlags where
@@ -638,7 +638,7 @@ type Instance = Ptr VkInstance_T
 
 -- ** VkMemoryHeapFlags
 
-newtype MemoryHeapFlags = MemoryHeapFlags VkFlags
+newtype MemoryHeapFlags = MemoryHeapFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show MemoryHeapFlags where
@@ -688,7 +688,7 @@ data ImageFormatProperties =
                        , maxMipLevels :: Word32 
                        , maxArrayLayers :: Word32 
                        , sampleCounts :: SampleCountFlags 
-                       , maxResourceSize :: VkDeviceSize 
+                       , maxResourceSize :: DeviceSize 
                        }
   deriving (Eq)
 
@@ -709,11 +709,11 @@ instance Storable ImageFormatProperties where
 
 
 data PhysicalDeviceSparseProperties =
-  PhysicalDeviceSparseProperties{ residencyStandard2DBlockShape :: VkBool32 
-                                , residencyStandard2DMultisampleBlockShape :: VkBool32 
-                                , residencyStandard3DBlockShape :: VkBool32 
-                                , residencyAlignedMipSize :: VkBool32 
-                                , residencyNonResidentStrict :: VkBool32 
+  PhysicalDeviceSparseProperties{ residencyStandard2DBlockShape :: Bool32 
+                                , residencyStandard2DMultisampleBlockShape :: Bool32 
+                                , residencyStandard3DBlockShape :: Bool32 
+                                , residencyAlignedMipSize :: Bool32 
+                                , residencyNonResidentStrict :: Bool32 
                                 }
   deriving (Eq)
 
@@ -803,7 +803,7 @@ foreign import ccall "vkGetInstanceProcAddr" vkGetInstanceProcAddr ::
 
 -- ** VkMemoryPropertyFlags
 
-newtype MemoryPropertyFlags = MemoryPropertyFlags VkFlags
+newtype MemoryPropertyFlags = MemoryPropertyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show MemoryPropertyFlags where
@@ -847,7 +847,7 @@ foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
 
 -- ** VkQueueFlags
 
-newtype QueueFlags = QueueFlags VkFlags
+newtype QueueFlags = QueueFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueueFlags where
@@ -887,7 +887,7 @@ foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperti
 
 -- ** InstanceCreateFlags
 -- | Opaque flag
-newtype InstanceCreateFlags = InstanceCreateFlags VkFlags
+newtype InstanceCreateFlags = InstanceCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkGetPhysicalDeviceFormatProperties

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -7,6 +7,10 @@ module Graphics.Vulkan.DeviceInitialization where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
+import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures
+                             , Device
+                             , PhysicalDevice
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -28,6 +32,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -35,6 +41,41 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Sampler( VkSampleCountFlags
+                              )
+import Graphics.Vulkan.Image( VkImageType
+                            , VkImageCreateFlags
+                            , VkImageTiling
+                            , VkImageUsageFlags
+                            )
+import Graphics.Vulkan.DeviceInitialization( VkQueueFlags
+                                           , VkMemoryPropertyFlags
+                                           , VkPhysicalDeviceProperties
+                                           , VkApplicationInfo
+                                           , VkPhysicalDeviceMemoryProperties
+                                           , VkInstanceCreateFlags
+                                           , VkPhysicalDeviceSparseProperties
+                                           , VkFormatFeatureFlags
+                                           , VkMemoryType
+                                           , VkInstanceCreateInfo
+                                           , VkMemoryHeap
+                                           , VkImageFormatProperties
+                                           , VkMemoryHeapFlags
+                                           , VkPhysicalDeviceType
+                                           , Instance
+                                           , VkFormatProperties
+                                           , PFN_vkVoidFunction
+                                           , VkQueueFamilyProperties
+                                           , VkPhysicalDeviceLimits
+                                           )
+import Graphics.Vulkan.Core( VkResult
+                           , VkExtent3D
+                           , VkDeviceSize
+                           , VkBool32
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       , CFloat
                       , CChar

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -48,19 +48,19 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
+import Graphics.Vulkan.Sampler( SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( VkImageCreateFlags(..)
-                            , VkImageType(..)
-                            , VkImageUsageFlags(..)
-                            , VkImageTiling(..)
+import Graphics.Vulkan.Image( ImageUsageFlags(..)
+                            , ImageCreateFlags(..)
+                            , ImageTiling(..)
+                            , ImageType(..)
                             )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
+                           , Format(..)
                            , Extent3D(..)
-                           , VkResult(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 import Foreign.C.Types( CFloat(..)
@@ -68,20 +68,20 @@ import Foreign.C.Types( CFloat(..)
                       , CSize(..)
                       )
 
--- ** VkPhysicalDeviceType
+-- ** PhysicalDeviceType
 
-newtype VkPhysicalDeviceType = VkPhysicalDeviceType Int32
+newtype PhysicalDeviceType = PhysicalDeviceType Int32
   deriving (Eq, Storable)
 
-instance Show VkPhysicalDeviceType where
+instance Show PhysicalDeviceType where
   showsPrec _ VK_PHYSICAL_DEVICE_TYPE_OTHER = showString "VK_PHYSICAL_DEVICE_TYPE_OTHER"
   showsPrec _ VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU"
   showsPrec _ VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU"
   showsPrec _ VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
   showsPrec _ VK_PHYSICAL_DEVICE_TYPE_CPU = showString "VK_PHYSICAL_DEVICE_TYPE_CPU"
-  showsPrec p (VkPhysicalDeviceType x) = showParen (p >= 11) (showString "VkPhysicalDeviceType " . showsPrec 11 x)
+  showsPrec p (PhysicalDeviceType x) = showParen (p >= 11) (showString "PhysicalDeviceType " . showsPrec 11 x)
 
-instance Read VkPhysicalDeviceType where
+instance Read PhysicalDeviceType where
   readPrec = parens ( choose [ ("VK_PHYSICAL_DEVICE_TYPE_OTHER", pure VK_PHYSICAL_DEVICE_TYPE_OTHER)
                              , ("VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU", pure VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
                              , ("VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU", pure VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
@@ -89,28 +89,28 @@ instance Read VkPhysicalDeviceType where
                              , ("VK_PHYSICAL_DEVICE_TYPE_CPU", pure VK_PHYSICAL_DEVICE_TYPE_CPU)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPhysicalDeviceType")
+                        expectP (Ident "PhysicalDeviceType")
                         v <- step readPrec
-                        pure (VkPhysicalDeviceType v)
+                        pure (PhysicalDeviceType v)
                         )
                     )
 
 
-pattern VK_PHYSICAL_DEVICE_TYPE_OTHER = VkPhysicalDeviceType 0
+pattern VK_PHYSICAL_DEVICE_TYPE_OTHER = PhysicalDeviceType 0
 
-pattern VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = VkPhysicalDeviceType 1
+pattern VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = PhysicalDeviceType 1
 
-pattern VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = VkPhysicalDeviceType 2
+pattern VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = PhysicalDeviceType 2
 
-pattern VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = VkPhysicalDeviceType 3
+pattern VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = PhysicalDeviceType 3
 
-pattern VK_PHYSICAL_DEVICE_TYPE_CPU = VkPhysicalDeviceType 4
+pattern VK_PHYSICAL_DEVICE_TYPE_CPU = PhysicalDeviceType 4
 
 
 data InstanceCreateInfo =
-  InstanceCreateInfo{ sType :: VkStructureType 
+  InstanceCreateInfo{ sType :: StructureType 
                     , pNext :: Ptr Void 
-                    , flags :: VkInstanceCreateFlags 
+                    , flags :: InstanceCreateFlags 
                     , pApplicationInfo :: Ptr ApplicationInfo 
                     , enabledLayerCount :: Word32 
                     , ppEnabledLayerNames :: Ptr (Ptr CChar) 
@@ -143,17 +143,17 @@ instance Storable InstanceCreateInfo where
 -- ** vkGetPhysicalDeviceImageFormatProperties
 foreign import ccall "vkGetPhysicalDeviceImageFormatProperties" vkGetPhysicalDeviceImageFormatProperties ::
   PhysicalDevice ->
-  VkFormat ->
-    VkImageType ->
-      VkImageTiling ->
-        VkImageUsageFlags ->
-          VkImageCreateFlags -> Ptr ImageFormatProperties -> IO VkResult
+  Format ->
+    ImageType ->
+      ImageTiling ->
+        ImageUsageFlags ->
+          ImageCreateFlags -> Ptr ImageFormatProperties -> IO Result
 
 type PFN_vkVoidFunction = FunPtr (IO ())
 
 
 data ApplicationInfo =
-  ApplicationInfo{ sType :: VkStructureType 
+  ApplicationInfo{ sType :: StructureType 
                  , pNext :: Ptr Void 
                  , pApplicationName :: Ptr CChar 
                  , applicationVersion :: Word32 
@@ -264,16 +264,16 @@ data PhysicalDeviceLimits =
                       , maxFramebufferWidth :: Word32 
                       , maxFramebufferHeight :: Word32 
                       , maxFramebufferLayers :: Word32 
-                      , framebufferColorSampleCounts :: VkSampleCountFlags 
-                      , framebufferDepthSampleCounts :: VkSampleCountFlags 
-                      , framebufferStencilSampleCounts :: VkSampleCountFlags 
-                      , framebufferNoAttachmentsSampleCounts :: VkSampleCountFlags 
+                      , framebufferColorSampleCounts :: SampleCountFlags 
+                      , framebufferDepthSampleCounts :: SampleCountFlags 
+                      , framebufferStencilSampleCounts :: SampleCountFlags 
+                      , framebufferNoAttachmentsSampleCounts :: SampleCountFlags 
                       , maxColorAttachments :: Word32 
-                      , sampledImageColorSampleCounts :: VkSampleCountFlags 
-                      , sampledImageIntegerSampleCounts :: VkSampleCountFlags 
-                      , sampledImageDepthSampleCounts :: VkSampleCountFlags 
-                      , sampledImageStencilSampleCounts :: VkSampleCountFlags 
-                      , storageImageSampleCounts :: VkSampleCountFlags 
+                      , sampledImageColorSampleCounts :: SampleCountFlags 
+                      , sampledImageIntegerSampleCounts :: SampleCountFlags 
+                      , sampledImageDepthSampleCounts :: SampleCountFlags 
+                      , sampledImageStencilSampleCounts :: SampleCountFlags 
+                      , storageImageSampleCounts :: SampleCountFlags 
                       , maxSampleMaskWords :: Word32 
                       , timestampComputeAndGraphics :: VkBool32 
                       , timestampPeriod :: CFloat 
@@ -513,7 +513,7 @@ instance Storable PhysicalDeviceLimits where
 
 data MemoryHeap =
   MemoryHeap{ size :: VkDeviceSize 
-            , flags :: VkMemoryHeapFlags 
+            , flags :: MemoryHeapFlags 
             }
   deriving (Eq)
 
@@ -528,7 +528,7 @@ instance Storable MemoryHeap where
 
 -- ** vkEnumeratePhysicalDevices
 foreign import ccall "vkEnumeratePhysicalDevices" vkEnumeratePhysicalDevices ::
-  Instance -> Ptr Word32 -> Ptr PhysicalDevice -> IO VkResult
+  Instance -> Ptr Word32 -> Ptr PhysicalDevice -> IO Result
 
 -- ** vkGetDeviceProcAddr
 foreign import ccall "vkGetDeviceProcAddr" vkGetDeviceProcAddr ::
@@ -537,14 +537,14 @@ foreign import ccall "vkGetDeviceProcAddr" vkGetDeviceProcAddr ::
 -- ** vkCreateInstance
 foreign import ccall "vkCreateInstance" vkCreateInstance ::
   Ptr InstanceCreateInfo ->
-  Ptr AllocationCallbacks -> Ptr Instance -> IO VkResult
+  Ptr AllocationCallbacks -> Ptr Instance -> IO Result
 
 -- ** VkFormatFeatureFlags
 
-newtype VkFormatFeatureFlags = VkFormatFeatureFlags VkFlags
+newtype FormatFeatureFlags = FormatFeatureFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkFormatFeatureFlags where
+instance Show FormatFeatureFlags where
   showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"
   showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"
   showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT"
@@ -559,9 +559,9 @@ instance Show VkFormatFeatureFlags where
   showsPrec _ VK_FORMAT_FEATURE_BLIT_DST_BIT = showString "VK_FORMAT_FEATURE_BLIT_DST_BIT"
   showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT"
   
-  showsPrec p (VkFormatFeatureFlags x) = showParen (p >= 11) (showString "VkFormatFeatureFlags " . showsPrec 11 x)
+  showsPrec p (FormatFeatureFlags x) = showParen (p >= 11) (showString "FormatFeatureFlags " . showsPrec 11 x)
 
-instance Read VkFormatFeatureFlags where
+instance Read FormatFeatureFlags where
   readPrec = parens ( choose [ ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
                              , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)
                              , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)
@@ -577,38 +577,38 @@ instance Read VkFormatFeatureFlags where
                              , ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFormatFeatureFlags")
+                        expectP (Ident "FormatFeatureFlags")
                         v <- step readPrec
-                        pure (VkFormatFeatureFlags v)
+                        pure (FormatFeatureFlags v)
                         )
                     )
 
 -- | Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = VkFormatFeatureFlags 0x1
+pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = FormatFeatureFlags 0x1
 -- | Format can be used for storage images (STORAGE_IMAGE descriptor type)
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = VkFormatFeatureFlags 0x2
+pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = FormatFeatureFlags 0x2
 -- | Format supports atomic operations in case it's used for storage images
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = VkFormatFeatureFlags 0x4
+pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = FormatFeatureFlags 0x4
 -- | Format can be used for uniform texel buffers (TBOs)
-pattern VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = VkFormatFeatureFlags 0x8
+pattern VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = FormatFeatureFlags 0x8
 -- | Format can be used for storage texel buffers (IBOs)
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = VkFormatFeatureFlags 0x10
+pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = FormatFeatureFlags 0x10
 -- | Format supports atomic operations in case it's used for storage texel buffers
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = VkFormatFeatureFlags 0x20
+pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = FormatFeatureFlags 0x20
 -- | Format can be used for vertex buffers (VBOs)
-pattern VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = VkFormatFeatureFlags 0x40
+pattern VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = FormatFeatureFlags 0x40
 -- | Format can be used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = VkFormatFeatureFlags 0x80
+pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = FormatFeatureFlags 0x80
 -- | Format supports blending in case it's used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = VkFormatFeatureFlags 0x100
+pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = FormatFeatureFlags 0x100
 -- | Format can be used for depth/stencil attachment images
-pattern VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = VkFormatFeatureFlags 0x200
+pattern VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = FormatFeatureFlags 0x200
 -- | Format can be used as the source image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_SRC_BIT = VkFormatFeatureFlags 0x400
+pattern VK_FORMAT_FEATURE_BLIT_SRC_BIT = FormatFeatureFlags 0x400
 -- | Format can be used as the destination image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_DST_BIT = VkFormatFeatureFlags 0x800
+pattern VK_FORMAT_FEATURE_BLIT_DST_BIT = FormatFeatureFlags 0x800
 -- | Format can be filtered with VK_FILTER_LINEAR when being sampled
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlags 0x1000
+pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = FormatFeatureFlags 0x1000
 
 
 
@@ -638,31 +638,31 @@ type Instance = Ptr VkInstance_T
 
 -- ** VkMemoryHeapFlags
 
-newtype VkMemoryHeapFlags = VkMemoryHeapFlags VkFlags
+newtype MemoryHeapFlags = MemoryHeapFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkMemoryHeapFlags where
+instance Show MemoryHeapFlags where
   showsPrec _ VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = showString "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT"
   
-  showsPrec p (VkMemoryHeapFlags x) = showParen (p >= 11) (showString "VkMemoryHeapFlags " . showsPrec 11 x)
+  showsPrec p (MemoryHeapFlags x) = showParen (p >= 11) (showString "MemoryHeapFlags " . showsPrec 11 x)
 
-instance Read VkMemoryHeapFlags where
+instance Read MemoryHeapFlags where
   readPrec = parens ( choose [ ("VK_MEMORY_HEAP_DEVICE_LOCAL_BIT", pure VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkMemoryHeapFlags")
+                        expectP (Ident "MemoryHeapFlags")
                         v <- step readPrec
-                        pure (VkMemoryHeapFlags v)
+                        pure (MemoryHeapFlags v)
                         )
                     )
 
 -- | If set, heap represents device memory
-pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlags 0x1
+pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = MemoryHeapFlags 0x1
 
 
 
 data QueueFamilyProperties =
-  QueueFamilyProperties{ queueFlags :: VkQueueFlags 
+  QueueFamilyProperties{ queueFlags :: QueueFlags 
                        , queueCount :: Word32 
                        , timestampValidBits :: Word32 
                        , minImageTransferGranularity :: Extent3D 
@@ -687,7 +687,7 @@ data ImageFormatProperties =
   ImageFormatProperties{ maxExtent :: Extent3D 
                        , maxMipLevels :: Word32 
                        , maxArrayLayers :: Word32 
-                       , sampleCounts :: VkSampleCountFlags 
+                       , sampleCounts :: SampleCountFlags 
                        , maxResourceSize :: VkDeviceSize 
                        }
   deriving (Eq)
@@ -746,7 +746,7 @@ data PhysicalDeviceProperties =
                           , driverVersion :: Word32 
                           , vendorID :: Word32 
                           , deviceID :: Word32 
-                          , deviceType :: VkPhysicalDeviceType 
+                          , deviceType :: PhysicalDeviceType 
                           , deviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
                           , pipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
                           , limits :: PhysicalDeviceLimits 
@@ -783,7 +783,7 @@ foreign import ccall "vkGetPhysicalDeviceQueueFamilyProperties" vkGetPhysicalDev
 
 
 data MemoryType =
-  MemoryType{ propertyFlags :: VkMemoryPropertyFlags 
+  MemoryType{ propertyFlags :: MemoryPropertyFlags 
             , heapIndex :: Word32 
             }
   deriving (Eq)
@@ -803,19 +803,19 @@ foreign import ccall "vkGetInstanceProcAddr" vkGetInstanceProcAddr ::
 
 -- ** VkMemoryPropertyFlags
 
-newtype VkMemoryPropertyFlags = VkMemoryPropertyFlags VkFlags
+newtype MemoryPropertyFlags = MemoryPropertyFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkMemoryPropertyFlags where
+instance Show MemoryPropertyFlags where
   showsPrec _ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = showString "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = showString "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = showString "VK_MEMORY_PROPERTY_HOST_COHERENT_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_CACHED_BIT = showString "VK_MEMORY_PROPERTY_HOST_CACHED_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = showString "VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT"
   
-  showsPrec p (VkMemoryPropertyFlags x) = showParen (p >= 11) (showString "VkMemoryPropertyFlags " . showsPrec 11 x)
+  showsPrec p (MemoryPropertyFlags x) = showParen (p >= 11) (showString "MemoryPropertyFlags " . showsPrec 11 x)
 
-instance Read VkMemoryPropertyFlags where
+instance Read MemoryPropertyFlags where
   readPrec = parens ( choose [ ("VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT", pure VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
                              , ("VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT", pure VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
                              , ("VK_MEMORY_PROPERTY_HOST_COHERENT_BIT", pure VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
@@ -823,22 +823,22 @@ instance Read VkMemoryPropertyFlags where
                              , ("VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT", pure VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkMemoryPropertyFlags")
+                        expectP (Ident "MemoryPropertyFlags")
                         v <- step readPrec
-                        pure (VkMemoryPropertyFlags v)
+                        pure (MemoryPropertyFlags v)
                         )
                     )
 
 -- | If otherwise stated, then allocate memory on device
-pattern VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = VkMemoryPropertyFlags 0x1
+pattern VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = MemoryPropertyFlags 0x1
 -- | Memory is mappable by host
-pattern VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = VkMemoryPropertyFlags 0x2
+pattern VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = MemoryPropertyFlags 0x2
 -- | Memory will have i/o coherency. If not set, application may need to use vkFlushMappedMemoryRanges and vkInvalidateMappedMemoryRanges to flush/invalidate host cache
-pattern VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = VkMemoryPropertyFlags 0x4
+pattern VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = MemoryPropertyFlags 0x4
 -- | Memory will be cached by the host
-pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = VkMemoryPropertyFlags 0x8
+pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = MemoryPropertyFlags 0x8
 -- | Memory may be allocated by the driver when it is required
-pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = VkMemoryPropertyFlags 0x10
+pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = MemoryPropertyFlags 0x10
 
 
 -- ** vkDestroyInstance
@@ -847,58 +847,58 @@ foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
 
 -- ** VkQueueFlags
 
-newtype VkQueueFlags = VkQueueFlags VkFlags
+newtype QueueFlags = QueueFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkQueueFlags where
+instance Show QueueFlags where
   showsPrec _ VK_QUEUE_GRAPHICS_BIT = showString "VK_QUEUE_GRAPHICS_BIT"
   showsPrec _ VK_QUEUE_COMPUTE_BIT = showString "VK_QUEUE_COMPUTE_BIT"
   showsPrec _ VK_QUEUE_TRANSFER_BIT = showString "VK_QUEUE_TRANSFER_BIT"
   showsPrec _ VK_QUEUE_SPARSE_BINDING_BIT = showString "VK_QUEUE_SPARSE_BINDING_BIT"
   
-  showsPrec p (VkQueueFlags x) = showParen (p >= 11) (showString "VkQueueFlags " . showsPrec 11 x)
+  showsPrec p (QueueFlags x) = showParen (p >= 11) (showString "QueueFlags " . showsPrec 11 x)
 
-instance Read VkQueueFlags where
+instance Read QueueFlags where
   readPrec = parens ( choose [ ("VK_QUEUE_GRAPHICS_BIT", pure VK_QUEUE_GRAPHICS_BIT)
                              , ("VK_QUEUE_COMPUTE_BIT", pure VK_QUEUE_COMPUTE_BIT)
                              , ("VK_QUEUE_TRANSFER_BIT", pure VK_QUEUE_TRANSFER_BIT)
                              , ("VK_QUEUE_SPARSE_BINDING_BIT", pure VK_QUEUE_SPARSE_BINDING_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueueFlags")
+                        expectP (Ident "QueueFlags")
                         v <- step readPrec
-                        pure (VkQueueFlags v)
+                        pure (QueueFlags v)
                         )
                     )
 
 -- | Queue supports graphics operations
-pattern VK_QUEUE_GRAPHICS_BIT = VkQueueFlags 0x1
+pattern VK_QUEUE_GRAPHICS_BIT = QueueFlags 0x1
 -- | Queue supports compute operations
-pattern VK_QUEUE_COMPUTE_BIT = VkQueueFlags 0x2
+pattern VK_QUEUE_COMPUTE_BIT = QueueFlags 0x2
 -- | Queue supports transfer operations
-pattern VK_QUEUE_TRANSFER_BIT = VkQueueFlags 0x4
+pattern VK_QUEUE_TRANSFER_BIT = QueueFlags 0x4
 -- | Queue supports sparse resource memory management operations
-pattern VK_QUEUE_SPARSE_BINDING_BIT = VkQueueFlags 0x8
+pattern VK_QUEUE_SPARSE_BINDING_BIT = QueueFlags 0x8
 
 
 -- ** vkGetPhysicalDeviceProperties
 foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperties ::
   PhysicalDevice -> Ptr PhysicalDeviceProperties -> IO ()
 
--- ** VkInstanceCreateFlags
+-- ** InstanceCreateFlags
 -- | Opaque flag
-newtype VkInstanceCreateFlags = VkInstanceCreateFlags VkFlags
+newtype InstanceCreateFlags = InstanceCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkGetPhysicalDeviceFormatProperties
 foreign import ccall "vkGetPhysicalDeviceFormatProperties" vkGetPhysicalDeviceFormatProperties ::
-  PhysicalDevice -> VkFormat -> Ptr FormatProperties -> IO ()
+  PhysicalDevice -> Format -> Ptr FormatProperties -> IO ()
 
 
 data FormatProperties =
-  FormatProperties{ linearTilingFeatures :: VkFormatFeatureFlags 
-                  , optimalTilingFeatures :: VkFormatFeatureFlags 
-                  , bufferFeatures :: VkFormatFeatureFlags 
+  FormatProperties{ linearTilingFeatures :: FormatFeatureFlags 
+                  , optimalTilingFeatures :: FormatFeatureFlags 
+                  , bufferFeatures :: FormatFeatureFlags 
                   }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -74,19 +74,19 @@ newtype PhysicalDeviceType = PhysicalDeviceType Int32
   deriving (Eq, Storable)
 
 instance Show PhysicalDeviceType where
-  showsPrec _ VK_PHYSICAL_DEVICE_TYPE_OTHER = showString "VK_PHYSICAL_DEVICE_TYPE_OTHER"
-  showsPrec _ VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU"
-  showsPrec _ VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU"
-  showsPrec _ VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = showString "VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU"
-  showsPrec _ VK_PHYSICAL_DEVICE_TYPE_CPU = showString "VK_PHYSICAL_DEVICE_TYPE_CPU"
+  showsPrec _ PhysicalDeviceTypeOther = showString "PhysicalDeviceTypeOther"
+  showsPrec _ PhysicalDeviceTypeIntegratedGpu = showString "PhysicalDeviceTypeIntegratedGpu"
+  showsPrec _ PhysicalDeviceTypeDiscreteGpu = showString "PhysicalDeviceTypeDiscreteGpu"
+  showsPrec _ PhysicalDeviceTypeVirtualGpu = showString "PhysicalDeviceTypeVirtualGpu"
+  showsPrec _ PhysicalDeviceTypeCpu = showString "PhysicalDeviceTypeCpu"
   showsPrec p (PhysicalDeviceType x) = showParen (p >= 11) (showString "PhysicalDeviceType " . showsPrec 11 x)
 
 instance Read PhysicalDeviceType where
-  readPrec = parens ( choose [ ("VK_PHYSICAL_DEVICE_TYPE_OTHER", pure VK_PHYSICAL_DEVICE_TYPE_OTHER)
-                             , ("VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU", pure VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
-                             , ("VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU", pure VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-                             , ("VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU", pure VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU)
-                             , ("VK_PHYSICAL_DEVICE_TYPE_CPU", pure VK_PHYSICAL_DEVICE_TYPE_CPU)
+  readPrec = parens ( choose [ ("PhysicalDeviceTypeOther", pure PhysicalDeviceTypeOther)
+                             , ("PhysicalDeviceTypeIntegratedGpu", pure PhysicalDeviceTypeIntegratedGpu)
+                             , ("PhysicalDeviceTypeDiscreteGpu", pure PhysicalDeviceTypeDiscreteGpu)
+                             , ("PhysicalDeviceTypeVirtualGpu", pure PhysicalDeviceTypeVirtualGpu)
+                             , ("PhysicalDeviceTypeCpu", pure PhysicalDeviceTypeCpu)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PhysicalDeviceType")
@@ -96,15 +96,15 @@ instance Read PhysicalDeviceType where
                     )
 
 
-pattern VK_PHYSICAL_DEVICE_TYPE_OTHER = PhysicalDeviceType 0
+pattern PhysicalDeviceTypeOther = PhysicalDeviceType 0
 
-pattern VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU = PhysicalDeviceType 1
+pattern PhysicalDeviceTypeIntegratedGpu = PhysicalDeviceType 1
 
-pattern VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU = PhysicalDeviceType 2
+pattern PhysicalDeviceTypeDiscreteGpu = PhysicalDeviceType 2
 
-pattern VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = PhysicalDeviceType 3
+pattern PhysicalDeviceTypeVirtualGpu = PhysicalDeviceType 3
 
-pattern VK_PHYSICAL_DEVICE_TYPE_CPU = PhysicalDeviceType 4
+pattern PhysicalDeviceTypeCpu = PhysicalDeviceType 4
 
 
 data InstanceCreateInfo =

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -5,34 +5,41 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.DeviceInitialization where
 
-import Data.Vector.Storable.Sized( Vector
+import Data.Vector.Storable.Sized( Vector(..)
                                  )
-import Graphics.Vulkan.Device( VkPhysicalDeviceFeatures
-                             , Device
-                             , PhysicalDevice
+import Graphics.Vulkan.Device( Device(..)
+                             , PhysicalDevice(..)
+                             , VkPhysicalDeviceFeatures(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word8
-                , Word32
+import Data.Word( Word8(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
-                  , FunPtr
+import Foreign.Ptr( Ptr(..)
+                  , FunPtr(..)
+                  , Ptr
                   , plusPtr
                   )
-import Data.Int( Int32
+import Data.Int( Int32(..)
+               , Int32
                )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Graphics.Vulkan.Constants( VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
+                                , VK_UUID_SIZE
+                                , VK_MAX_MEMORY_TYPES
+                                , VK_MAX_MEMORY_HEAPS
+                                )
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -41,44 +48,24 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlags
+import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( VkImageType
-                            , VkImageCreateFlags
-                            , VkImageTiling
-                            , VkImageUsageFlags
+import Graphics.Vulkan.Image( VkImageCreateFlags(..)
+                            , VkImageType(..)
+                            , VkImageUsageFlags(..)
+                            , VkImageTiling(..)
                             )
-import Graphics.Vulkan.DeviceInitialization( VkQueueFlags
-                                           , VkMemoryPropertyFlags
-                                           , VkPhysicalDeviceProperties
-                                           , VkApplicationInfo
-                                           , VkPhysicalDeviceMemoryProperties
-                                           , VkInstanceCreateFlags
-                                           , VkPhysicalDeviceSparseProperties
-                                           , VkFormatFeatureFlags
-                                           , VkMemoryType
-                                           , VkInstanceCreateInfo
-                                           , VkMemoryHeap
-                                           , VkImageFormatProperties
-                                           , VkMemoryHeapFlags
-                                           , VkPhysicalDeviceType
-                                           , Instance
-                                           , VkFormatProperties
-                                           , PFN_vkVoidFunction
-                                           , VkQueueFamilyProperties
-                                           , VkPhysicalDeviceLimits
-                                           )
-import Graphics.Vulkan.Core( VkResult
-                           , VkExtent3D
-                           , VkDeviceSize
-                           , VkBool32
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
+                           , VkExtent3D(..)
                            )
-import Foreign.C.Types( CSize
-                      , CFloat
-                      , CChar
+import Foreign.C.Types( CFloat(..)
+                      , CChar(..)
+                      , CSize(..)
                       )
 
 -- ** VkPhysicalDeviceType
@@ -554,13 +541,10 @@ foreign import ccall "vkCreateInstance" vkCreateInstance ::
 
 -- ** VkFormatFeatureFlags
 
-newtype VkFormatFeatureFlagBits = VkFormatFeatureFlagBits VkFlags
+newtype VkFormatFeatureFlags = VkFormatFeatureFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkFormatFeatureFlagBits
-type VkFormatFeatureFlags = VkFormatFeatureFlagBits
-
-instance Show VkFormatFeatureFlagBits where
+instance Show VkFormatFeatureFlags where
   showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"
   showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"
   showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT"
@@ -575,9 +559,9 @@ instance Show VkFormatFeatureFlagBits where
   showsPrec _ VK_FORMAT_FEATURE_BLIT_DST_BIT = showString "VK_FORMAT_FEATURE_BLIT_DST_BIT"
   showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT"
   
-  showsPrec p (VkFormatFeatureFlagBits x) = showParen (p >= 11) (showString "VkFormatFeatureFlagBits " . showsPrec 11 x)
+  showsPrec p (VkFormatFeatureFlags x) = showParen (p >= 11) (showString "VkFormatFeatureFlags " . showsPrec 11 x)
 
-instance Read VkFormatFeatureFlagBits where
+instance Read VkFormatFeatureFlags where
   readPrec = parens ( choose [ ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
                              , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)
                              , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)
@@ -593,38 +577,38 @@ instance Read VkFormatFeatureFlagBits where
                              , ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFormatFeatureFlagBits")
+                        expectP (Ident "VkFormatFeatureFlags")
                         v <- step readPrec
-                        pure (VkFormatFeatureFlagBits v)
+                        pure (VkFormatFeatureFlags v)
                         )
                     )
 
 -- | Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = VkFormatFeatureFlagBits 0x1
+pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = VkFormatFeatureFlags 0x1
 -- | Format can be used for storage images (STORAGE_IMAGE descriptor type)
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = VkFormatFeatureFlagBits 0x2
+pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = VkFormatFeatureFlags 0x2
 -- | Format supports atomic operations in case it's used for storage images
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = VkFormatFeatureFlagBits 0x4
+pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = VkFormatFeatureFlags 0x4
 -- | Format can be used for uniform texel buffers (TBOs)
-pattern VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = VkFormatFeatureFlagBits 0x8
+pattern VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = VkFormatFeatureFlags 0x8
 -- | Format can be used for storage texel buffers (IBOs)
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = VkFormatFeatureFlagBits 0x10
+pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = VkFormatFeatureFlags 0x10
 -- | Format supports atomic operations in case it's used for storage texel buffers
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = VkFormatFeatureFlagBits 0x20
+pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = VkFormatFeatureFlags 0x20
 -- | Format can be used for vertex buffers (VBOs)
-pattern VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = VkFormatFeatureFlagBits 0x40
+pattern VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = VkFormatFeatureFlags 0x40
 -- | Format can be used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = VkFormatFeatureFlagBits 0x80
+pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = VkFormatFeatureFlags 0x80
 -- | Format supports blending in case it's used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = VkFormatFeatureFlagBits 0x100
+pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = VkFormatFeatureFlags 0x100
 -- | Format can be used for depth/stencil attachment images
-pattern VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = VkFormatFeatureFlagBits 0x200
+pattern VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = VkFormatFeatureFlags 0x200
 -- | Format can be used as the source image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_SRC_BIT = VkFormatFeatureFlagBits 0x400
+pattern VK_FORMAT_FEATURE_BLIT_SRC_BIT = VkFormatFeatureFlags 0x400
 -- | Format can be used as the destination image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_DST_BIT = VkFormatFeatureFlagBits 0x800
+pattern VK_FORMAT_FEATURE_BLIT_DST_BIT = VkFormatFeatureFlags 0x800
 -- | Format can be filtered with VK_FILTER_LINEAR when being sampled
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlagBits 0x1000
+pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlags 0x1000
 
 
 
@@ -654,29 +638,26 @@ type Instance = Ptr VkInstance_T
 
 -- ** VkMemoryHeapFlags
 
-newtype VkMemoryHeapFlagBits = VkMemoryHeapFlagBits VkFlags
+newtype VkMemoryHeapFlags = VkMemoryHeapFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkMemoryHeapFlagBits
-type VkMemoryHeapFlags = VkMemoryHeapFlagBits
-
-instance Show VkMemoryHeapFlagBits where
+instance Show VkMemoryHeapFlags where
   showsPrec _ VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = showString "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT"
   
-  showsPrec p (VkMemoryHeapFlagBits x) = showParen (p >= 11) (showString "VkMemoryHeapFlagBits " . showsPrec 11 x)
+  showsPrec p (VkMemoryHeapFlags x) = showParen (p >= 11) (showString "VkMemoryHeapFlags " . showsPrec 11 x)
 
-instance Read VkMemoryHeapFlagBits where
+instance Read VkMemoryHeapFlags where
   readPrec = parens ( choose [ ("VK_MEMORY_HEAP_DEVICE_LOCAL_BIT", pure VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkMemoryHeapFlagBits")
+                        expectP (Ident "VkMemoryHeapFlags")
                         v <- step readPrec
-                        pure (VkMemoryHeapFlagBits v)
+                        pure (VkMemoryHeapFlags v)
                         )
                     )
 
 -- | If set, heap represents device memory
-pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlagBits 0x1
+pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlags 0x1
 
 
 
@@ -823,22 +804,19 @@ foreign import ccall "vkGetInstanceProcAddr" vkGetInstanceProcAddr ::
 
 -- ** VkMemoryPropertyFlags
 
-newtype VkMemoryPropertyFlagBits = VkMemoryPropertyFlagBits VkFlags
+newtype VkMemoryPropertyFlags = VkMemoryPropertyFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkMemoryPropertyFlagBits
-type VkMemoryPropertyFlags = VkMemoryPropertyFlagBits
-
-instance Show VkMemoryPropertyFlagBits where
+instance Show VkMemoryPropertyFlags where
   showsPrec _ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = showString "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = showString "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = showString "VK_MEMORY_PROPERTY_HOST_COHERENT_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_HOST_CACHED_BIT = showString "VK_MEMORY_PROPERTY_HOST_CACHED_BIT"
   showsPrec _ VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = showString "VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT"
   
-  showsPrec p (VkMemoryPropertyFlagBits x) = showParen (p >= 11) (showString "VkMemoryPropertyFlagBits " . showsPrec 11 x)
+  showsPrec p (VkMemoryPropertyFlags x) = showParen (p >= 11) (showString "VkMemoryPropertyFlags " . showsPrec 11 x)
 
-instance Read VkMemoryPropertyFlagBits where
+instance Read VkMemoryPropertyFlags where
   readPrec = parens ( choose [ ("VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT", pure VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
                              , ("VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT", pure VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
                              , ("VK_MEMORY_PROPERTY_HOST_COHERENT_BIT", pure VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
@@ -846,22 +824,22 @@ instance Read VkMemoryPropertyFlagBits where
                              , ("VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT", pure VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkMemoryPropertyFlagBits")
+                        expectP (Ident "VkMemoryPropertyFlags")
                         v <- step readPrec
-                        pure (VkMemoryPropertyFlagBits v)
+                        pure (VkMemoryPropertyFlags v)
                         )
                     )
 
 -- | If otherwise stated, then allocate memory on device
-pattern VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = VkMemoryPropertyFlagBits 0x1
+pattern VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = VkMemoryPropertyFlags 0x1
 -- | Memory is mappable by host
-pattern VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = VkMemoryPropertyFlagBits 0x2
+pattern VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = VkMemoryPropertyFlags 0x2
 -- | Memory will have i/o coherency. If not set, application may need to use vkFlushMappedMemoryRanges and vkInvalidateMappedMemoryRanges to flush/invalidate host cache
-pattern VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = VkMemoryPropertyFlagBits 0x4
+pattern VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = VkMemoryPropertyFlags 0x4
 -- | Memory will be cached by the host
-pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = VkMemoryPropertyFlagBits 0x8
+pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = VkMemoryPropertyFlags 0x8
 -- | Memory may be allocated by the driver when it is required
-pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = VkMemoryPropertyFlagBits 0x10
+pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = VkMemoryPropertyFlags 0x10
 
 
 -- ** vkDestroyInstance
@@ -870,41 +848,38 @@ foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
 
 -- ** VkQueueFlags
 
-newtype VkQueueFlagBits = VkQueueFlagBits VkFlags
+newtype VkQueueFlags = VkQueueFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkQueueFlagBits
-type VkQueueFlags = VkQueueFlagBits
-
-instance Show VkQueueFlagBits where
+instance Show VkQueueFlags where
   showsPrec _ VK_QUEUE_GRAPHICS_BIT = showString "VK_QUEUE_GRAPHICS_BIT"
   showsPrec _ VK_QUEUE_COMPUTE_BIT = showString "VK_QUEUE_COMPUTE_BIT"
   showsPrec _ VK_QUEUE_TRANSFER_BIT = showString "VK_QUEUE_TRANSFER_BIT"
   showsPrec _ VK_QUEUE_SPARSE_BINDING_BIT = showString "VK_QUEUE_SPARSE_BINDING_BIT"
   
-  showsPrec p (VkQueueFlagBits x) = showParen (p >= 11) (showString "VkQueueFlagBits " . showsPrec 11 x)
+  showsPrec p (VkQueueFlags x) = showParen (p >= 11) (showString "VkQueueFlags " . showsPrec 11 x)
 
-instance Read VkQueueFlagBits where
+instance Read VkQueueFlags where
   readPrec = parens ( choose [ ("VK_QUEUE_GRAPHICS_BIT", pure VK_QUEUE_GRAPHICS_BIT)
                              , ("VK_QUEUE_COMPUTE_BIT", pure VK_QUEUE_COMPUTE_BIT)
                              , ("VK_QUEUE_TRANSFER_BIT", pure VK_QUEUE_TRANSFER_BIT)
                              , ("VK_QUEUE_SPARSE_BINDING_BIT", pure VK_QUEUE_SPARSE_BINDING_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueueFlagBits")
+                        expectP (Ident "VkQueueFlags")
                         v <- step readPrec
-                        pure (VkQueueFlagBits v)
+                        pure (VkQueueFlags v)
                         )
                     )
 
 -- | Queue supports graphics operations
-pattern VK_QUEUE_GRAPHICS_BIT = VkQueueFlagBits 0x1
+pattern VK_QUEUE_GRAPHICS_BIT = VkQueueFlags 0x1
 -- | Queue supports compute operations
-pattern VK_QUEUE_COMPUTE_BIT = VkQueueFlagBits 0x2
+pattern VK_QUEUE_COMPUTE_BIT = VkQueueFlags 0x2
 -- | Queue supports transfer operations
-pattern VK_QUEUE_TRANSFER_BIT = VkQueueFlagBits 0x4
+pattern VK_QUEUE_TRANSFER_BIT = VkQueueFlags 0x4
 -- | Queue supports sparse resource memory management operations
-pattern VK_QUEUE_SPARSE_BINDING_BIT = VkQueueFlagBits 0x8
+pattern VK_QUEUE_SPARSE_BINDING_BIT = VkQueueFlags 0x8
 
 
 -- ** vkGetPhysicalDeviceProperties

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -9,7 +9,7 @@ import Data.Vector.Storable.Sized( Vector(..)
                                  )
 import Graphics.Vulkan.Device( Device(..)
                              , PhysicalDevice(..)
-                             , VkPhysicalDeviceFeatures(..)
+                             , PhysicalDeviceFeatures(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -39,7 +39,7 @@ import Graphics.Vulkan.Constants( VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
                                 )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -59,9 +59,9 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
                            , VkFlags(..)
                            , VkBool32(..)
+                           , Extent3D(..)
                            , VkResult(..)
                            , VkDeviceSize(..)
-                           , VkExtent3D(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -107,37 +107,37 @@ pattern VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU = VkPhysicalDeviceType 3
 pattern VK_PHYSICAL_DEVICE_TYPE_CPU = VkPhysicalDeviceType 4
 
 
-data VkInstanceCreateInfo =
-  VkInstanceCreateInfo{ sType :: VkStructureType 
-                      , pNext :: Ptr Void 
-                      , flags :: VkInstanceCreateFlags 
-                      , pApplicationInfo :: Ptr VkApplicationInfo 
-                      , enabledLayerCount :: Word32 
-                      , ppEnabledLayerNames :: Ptr (Ptr CChar) 
-                      , enabledExtensionCount :: Word32 
-                      , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
-                      }
+data InstanceCreateInfo =
+  InstanceCreateInfo{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , flags :: VkInstanceCreateFlags 
+                    , pApplicationInfo :: Ptr ApplicationInfo 
+                    , enabledLayerCount :: Word32 
+                    , ppEnabledLayerNames :: Ptr (Ptr CChar) 
+                    , enabledExtensionCount :: Word32 
+                    , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
+                    }
   deriving (Eq)
 
-instance Storable VkInstanceCreateInfo where
+instance Storable InstanceCreateInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkInstanceCreateInfo <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-                                  <*> peek (ptr `plusPtr` 32)
-                                  <*> peek (ptr `plusPtr` 40)
-                                  <*> peek (ptr `plusPtr` 48)
-                                  <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pApplicationInfo (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: VkInstanceCreateInfo))
-                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: VkInstanceCreateInfo))
+  peek ptr = InstanceCreateInfo <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 24)
+                                <*> peek (ptr `plusPtr` 32)
+                                <*> peek (ptr `plusPtr` 40)
+                                <*> peek (ptr `plusPtr` 48)
+                                <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pApplicationInfo (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 32) (enabledLayerCount (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 40) (ppEnabledLayerNames (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 48) (enabledExtensionCount (poked :: InstanceCreateInfo))
+                *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: InstanceCreateInfo))
 
 
 -- ** vkGetPhysicalDeviceImageFormatProperties
@@ -147,383 +147,383 @@ foreign import ccall "vkGetPhysicalDeviceImageFormatProperties" vkGetPhysicalDev
     VkImageType ->
       VkImageTiling ->
         VkImageUsageFlags ->
-          VkImageCreateFlags -> Ptr VkImageFormatProperties -> IO VkResult
+          VkImageCreateFlags -> Ptr ImageFormatProperties -> IO VkResult
 
 type PFN_vkVoidFunction = FunPtr (IO ())
 
 
-data VkApplicationInfo =
-  VkApplicationInfo{ sType :: VkStructureType 
-                   , pNext :: Ptr Void 
-                   , pApplicationName :: Ptr CChar 
-                   , applicationVersion :: Word32 
-                   , pEngineName :: Ptr CChar 
-                   , engineVersion :: Word32 
-                   , apiVersion :: Word32 
-                   }
+data ApplicationInfo =
+  ApplicationInfo{ sType :: VkStructureType 
+                 , pNext :: Ptr Void 
+                 , pApplicationName :: Ptr CChar 
+                 , applicationVersion :: Word32 
+                 , pEngineName :: Ptr CChar 
+                 , engineVersion :: Word32 
+                 , apiVersion :: Word32 
+                 }
   deriving (Eq)
 
-instance Storable VkApplicationInfo where
+instance Storable ApplicationInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkApplicationInfo <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 8)
-                               <*> peek (ptr `plusPtr` 16)
-                               <*> peek (ptr `plusPtr` 24)
-                               <*> peek (ptr `plusPtr` 32)
-                               <*> peek (ptr `plusPtr` 40)
-                               <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 16) (pApplicationName (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 24) (applicationVersion (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 32) (pEngineName (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 40) (engineVersion (poked :: VkApplicationInfo))
-                *> poke (ptr `plusPtr` 44) (apiVersion (poked :: VkApplicationInfo))
+  peek ptr = ApplicationInfo <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 8)
+                             <*> peek (ptr `plusPtr` 16)
+                             <*> peek (ptr `plusPtr` 24)
+                             <*> peek (ptr `plusPtr` 32)
+                             <*> peek (ptr `plusPtr` 40)
+                             <*> peek (ptr `plusPtr` 44)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 16) (pApplicationName (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 24) (applicationVersion (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 32) (pEngineName (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 40) (engineVersion (poked :: ApplicationInfo))
+                *> poke (ptr `plusPtr` 44) (apiVersion (poked :: ApplicationInfo))
 
 
 
-data VkPhysicalDeviceLimits =
-  VkPhysicalDeviceLimits{ maxImageDimension1D :: Word32 
-                        , maxImageDimension2D :: Word32 
-                        , maxImageDimension3D :: Word32 
-                        , maxImageDimensionCube :: Word32 
-                        , maxImageArrayLayers :: Word32 
-                        , maxTexelBufferElements :: Word32 
-                        , maxUniformBufferRange :: Word32 
-                        , maxStorageBufferRange :: Word32 
-                        , maxPushConstantsSize :: Word32 
-                        , maxMemoryAllocationCount :: Word32 
-                        , maxSamplerAllocationCount :: Word32 
-                        , bufferImageGranularity :: VkDeviceSize 
-                        , sparseAddressSpaceSize :: VkDeviceSize 
-                        , maxBoundDescriptorSets :: Word32 
-                        , maxPerStageDescriptorSamplers :: Word32 
-                        , maxPerStageDescriptorUniformBuffers :: Word32 
-                        , maxPerStageDescriptorStorageBuffers :: Word32 
-                        , maxPerStageDescriptorSampledImages :: Word32 
-                        , maxPerStageDescriptorStorageImages :: Word32 
-                        , maxPerStageDescriptorInputAttachments :: Word32 
-                        , maxPerStageResources :: Word32 
-                        , maxDescriptorSetSamplers :: Word32 
-                        , maxDescriptorSetUniformBuffers :: Word32 
-                        , maxDescriptorSetUniformBuffersDynamic :: Word32 
-                        , maxDescriptorSetStorageBuffers :: Word32 
-                        , maxDescriptorSetStorageBuffersDynamic :: Word32 
-                        , maxDescriptorSetSampledImages :: Word32 
-                        , maxDescriptorSetStorageImages :: Word32 
-                        , maxDescriptorSetInputAttachments :: Word32 
-                        , maxVertexInputAttributes :: Word32 
-                        , maxVertexInputBindings :: Word32 
-                        , maxVertexInputAttributeOffset :: Word32 
-                        , maxVertexInputBindingStride :: Word32 
-                        , maxVertexOutputComponents :: Word32 
-                        , maxTessellationGenerationLevel :: Word32 
-                        , maxTessellationPatchSize :: Word32 
-                        , maxTessellationControlPerVertexInputComponents :: Word32 
-                        , maxTessellationControlPerVertexOutputComponents :: Word32 
-                        , maxTessellationControlPerPatchOutputComponents :: Word32 
-                        , maxTessellationControlTotalOutputComponents :: Word32 
-                        , maxTessellationEvaluationInputComponents :: Word32 
-                        , maxTessellationEvaluationOutputComponents :: Word32 
-                        , maxGeometryShaderInvocations :: Word32 
-                        , maxGeometryInputComponents :: Word32 
-                        , maxGeometryOutputComponents :: Word32 
-                        , maxGeometryOutputVertices :: Word32 
-                        , maxGeometryTotalOutputComponents :: Word32 
-                        , maxFragmentInputComponents :: Word32 
-                        , maxFragmentOutputAttachments :: Word32 
-                        , maxFragmentDualSrcAttachments :: Word32 
-                        , maxFragmentCombinedOutputResources :: Word32 
-                        , maxComputeSharedMemorySize :: Word32 
-                        , maxComputeWorkGroupCount :: Vector 3 Word32 
-                        , maxComputeWorkGroupInvocations :: Word32 
-                        , maxComputeWorkGroupSize :: Vector 3 Word32 
-                        , subPixelPrecisionBits :: Word32 
-                        , subTexelPrecisionBits :: Word32 
-                        , mipmapPrecisionBits :: Word32 
-                        , maxDrawIndexedIndexValue :: Word32 
-                        , maxDrawIndirectCount :: Word32 
-                        , maxSamplerLodBias :: CFloat 
-                        , maxSamplerAnisotropy :: CFloat 
-                        , maxViewports :: Word32 
-                        , maxViewportDimensions :: Vector 2 Word32 
-                        , viewportBoundsRange :: Vector 2 CFloat 
-                        , viewportSubPixelBits :: Word32 
-                        , minMemoryMapAlignment :: CSize 
-                        , minTexelBufferOffsetAlignment :: VkDeviceSize 
-                        , minUniformBufferOffsetAlignment :: VkDeviceSize 
-                        , minStorageBufferOffsetAlignment :: VkDeviceSize 
-                        , minTexelOffset :: Int32 
-                        , maxTexelOffset :: Word32 
-                        , minTexelGatherOffset :: Int32 
-                        , maxTexelGatherOffset :: Word32 
-                        , minInterpolationOffset :: CFloat 
-                        , maxInterpolationOffset :: CFloat 
-                        , subPixelInterpolationOffsetBits :: Word32 
-                        , maxFramebufferWidth :: Word32 
-                        , maxFramebufferHeight :: Word32 
-                        , maxFramebufferLayers :: Word32 
-                        , framebufferColorSampleCounts :: VkSampleCountFlags 
-                        , framebufferDepthSampleCounts :: VkSampleCountFlags 
-                        , framebufferStencilSampleCounts :: VkSampleCountFlags 
-                        , framebufferNoAttachmentsSampleCounts :: VkSampleCountFlags 
-                        , maxColorAttachments :: Word32 
-                        , sampledImageColorSampleCounts :: VkSampleCountFlags 
-                        , sampledImageIntegerSampleCounts :: VkSampleCountFlags 
-                        , sampledImageDepthSampleCounts :: VkSampleCountFlags 
-                        , sampledImageStencilSampleCounts :: VkSampleCountFlags 
-                        , storageImageSampleCounts :: VkSampleCountFlags 
-                        , maxSampleMaskWords :: Word32 
-                        , timestampComputeAndGraphics :: VkBool32 
-                        , timestampPeriod :: CFloat 
-                        , maxClipDistances :: Word32 
-                        , maxCullDistances :: Word32 
-                        , maxCombinedClipAndCullDistances :: Word32 
-                        , discreteQueuePriorities :: Word32 
-                        , pointSizeRange :: Vector 2 CFloat 
-                        , lineWidthRange :: Vector 2 CFloat 
-                        , pointSizeGranularity :: CFloat 
-                        , lineWidthGranularity :: CFloat 
-                        , strictLines :: VkBool32 
-                        , standardSampleLocations :: VkBool32 
-                        , optimalBufferCopyOffsetAlignment :: VkDeviceSize 
-                        , optimalBufferCopyRowPitchAlignment :: VkDeviceSize 
-                        , nonCoherentAtomSize :: VkDeviceSize 
-                        }
+data PhysicalDeviceLimits =
+  PhysicalDeviceLimits{ maxImageDimension1D :: Word32 
+                      , maxImageDimension2D :: Word32 
+                      , maxImageDimension3D :: Word32 
+                      , maxImageDimensionCube :: Word32 
+                      , maxImageArrayLayers :: Word32 
+                      , maxTexelBufferElements :: Word32 
+                      , maxUniformBufferRange :: Word32 
+                      , maxStorageBufferRange :: Word32 
+                      , maxPushConstantsSize :: Word32 
+                      , maxMemoryAllocationCount :: Word32 
+                      , maxSamplerAllocationCount :: Word32 
+                      , bufferImageGranularity :: VkDeviceSize 
+                      , sparseAddressSpaceSize :: VkDeviceSize 
+                      , maxBoundDescriptorSets :: Word32 
+                      , maxPerStageDescriptorSamplers :: Word32 
+                      , maxPerStageDescriptorUniformBuffers :: Word32 
+                      , maxPerStageDescriptorStorageBuffers :: Word32 
+                      , maxPerStageDescriptorSampledImages :: Word32 
+                      , maxPerStageDescriptorStorageImages :: Word32 
+                      , maxPerStageDescriptorInputAttachments :: Word32 
+                      , maxPerStageResources :: Word32 
+                      , maxDescriptorSetSamplers :: Word32 
+                      , maxDescriptorSetUniformBuffers :: Word32 
+                      , maxDescriptorSetUniformBuffersDynamic :: Word32 
+                      , maxDescriptorSetStorageBuffers :: Word32 
+                      , maxDescriptorSetStorageBuffersDynamic :: Word32 
+                      , maxDescriptorSetSampledImages :: Word32 
+                      , maxDescriptorSetStorageImages :: Word32 
+                      , maxDescriptorSetInputAttachments :: Word32 
+                      , maxVertexInputAttributes :: Word32 
+                      , maxVertexInputBindings :: Word32 
+                      , maxVertexInputAttributeOffset :: Word32 
+                      , maxVertexInputBindingStride :: Word32 
+                      , maxVertexOutputComponents :: Word32 
+                      , maxTessellationGenerationLevel :: Word32 
+                      , maxTessellationPatchSize :: Word32 
+                      , maxTessellationControlPerVertexInputComponents :: Word32 
+                      , maxTessellationControlPerVertexOutputComponents :: Word32 
+                      , maxTessellationControlPerPatchOutputComponents :: Word32 
+                      , maxTessellationControlTotalOutputComponents :: Word32 
+                      , maxTessellationEvaluationInputComponents :: Word32 
+                      , maxTessellationEvaluationOutputComponents :: Word32 
+                      , maxGeometryShaderInvocations :: Word32 
+                      , maxGeometryInputComponents :: Word32 
+                      , maxGeometryOutputComponents :: Word32 
+                      , maxGeometryOutputVertices :: Word32 
+                      , maxGeometryTotalOutputComponents :: Word32 
+                      , maxFragmentInputComponents :: Word32 
+                      , maxFragmentOutputAttachments :: Word32 
+                      , maxFragmentDualSrcAttachments :: Word32 
+                      , maxFragmentCombinedOutputResources :: Word32 
+                      , maxComputeSharedMemorySize :: Word32 
+                      , maxComputeWorkGroupCount :: Vector 3 Word32 
+                      , maxComputeWorkGroupInvocations :: Word32 
+                      , maxComputeWorkGroupSize :: Vector 3 Word32 
+                      , subPixelPrecisionBits :: Word32 
+                      , subTexelPrecisionBits :: Word32 
+                      , mipmapPrecisionBits :: Word32 
+                      , maxDrawIndexedIndexValue :: Word32 
+                      , maxDrawIndirectCount :: Word32 
+                      , maxSamplerLodBias :: CFloat 
+                      , maxSamplerAnisotropy :: CFloat 
+                      , maxViewports :: Word32 
+                      , maxViewportDimensions :: Vector 2 Word32 
+                      , viewportBoundsRange :: Vector 2 CFloat 
+                      , viewportSubPixelBits :: Word32 
+                      , minMemoryMapAlignment :: CSize 
+                      , minTexelBufferOffsetAlignment :: VkDeviceSize 
+                      , minUniformBufferOffsetAlignment :: VkDeviceSize 
+                      , minStorageBufferOffsetAlignment :: VkDeviceSize 
+                      , minTexelOffset :: Int32 
+                      , maxTexelOffset :: Word32 
+                      , minTexelGatherOffset :: Int32 
+                      , maxTexelGatherOffset :: Word32 
+                      , minInterpolationOffset :: CFloat 
+                      , maxInterpolationOffset :: CFloat 
+                      , subPixelInterpolationOffsetBits :: Word32 
+                      , maxFramebufferWidth :: Word32 
+                      , maxFramebufferHeight :: Word32 
+                      , maxFramebufferLayers :: Word32 
+                      , framebufferColorSampleCounts :: VkSampleCountFlags 
+                      , framebufferDepthSampleCounts :: VkSampleCountFlags 
+                      , framebufferStencilSampleCounts :: VkSampleCountFlags 
+                      , framebufferNoAttachmentsSampleCounts :: VkSampleCountFlags 
+                      , maxColorAttachments :: Word32 
+                      , sampledImageColorSampleCounts :: VkSampleCountFlags 
+                      , sampledImageIntegerSampleCounts :: VkSampleCountFlags 
+                      , sampledImageDepthSampleCounts :: VkSampleCountFlags 
+                      , sampledImageStencilSampleCounts :: VkSampleCountFlags 
+                      , storageImageSampleCounts :: VkSampleCountFlags 
+                      , maxSampleMaskWords :: Word32 
+                      , timestampComputeAndGraphics :: VkBool32 
+                      , timestampPeriod :: CFloat 
+                      , maxClipDistances :: Word32 
+                      , maxCullDistances :: Word32 
+                      , maxCombinedClipAndCullDistances :: Word32 
+                      , discreteQueuePriorities :: Word32 
+                      , pointSizeRange :: Vector 2 CFloat 
+                      , lineWidthRange :: Vector 2 CFloat 
+                      , pointSizeGranularity :: CFloat 
+                      , lineWidthGranularity :: CFloat 
+                      , strictLines :: VkBool32 
+                      , standardSampleLocations :: VkBool32 
+                      , optimalBufferCopyOffsetAlignment :: VkDeviceSize 
+                      , optimalBufferCopyRowPitchAlignment :: VkDeviceSize 
+                      , nonCoherentAtomSize :: VkDeviceSize 
+                      }
   deriving (Eq)
 
-instance Storable VkPhysicalDeviceLimits where
+instance Storable PhysicalDeviceLimits where
   sizeOf ~_ = 504
   alignment ~_ = 8
-  peek ptr = VkPhysicalDeviceLimits <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 4)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 12)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 20)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 28)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 36)
-                                    <*> peek (ptr `plusPtr` 40)
-                                    <*> peek (ptr `plusPtr` 48)
-                                    <*> peek (ptr `plusPtr` 56)
-                                    <*> peek (ptr `plusPtr` 64)
-                                    <*> peek (ptr `plusPtr` 68)
-                                    <*> peek (ptr `plusPtr` 72)
-                                    <*> peek (ptr `plusPtr` 76)
-                                    <*> peek (ptr `plusPtr` 80)
-                                    <*> peek (ptr `plusPtr` 84)
-                                    <*> peek (ptr `plusPtr` 88)
-                                    <*> peek (ptr `plusPtr` 92)
-                                    <*> peek (ptr `plusPtr` 96)
-                                    <*> peek (ptr `plusPtr` 100)
-                                    <*> peek (ptr `plusPtr` 104)
-                                    <*> peek (ptr `plusPtr` 108)
-                                    <*> peek (ptr `plusPtr` 112)
-                                    <*> peek (ptr `plusPtr` 116)
-                                    <*> peek (ptr `plusPtr` 120)
-                                    <*> peek (ptr `plusPtr` 124)
-                                    <*> peek (ptr `plusPtr` 128)
-                                    <*> peek (ptr `plusPtr` 132)
-                                    <*> peek (ptr `plusPtr` 136)
-                                    <*> peek (ptr `plusPtr` 140)
-                                    <*> peek (ptr `plusPtr` 144)
-                                    <*> peek (ptr `plusPtr` 148)
-                                    <*> peek (ptr `plusPtr` 152)
-                                    <*> peek (ptr `plusPtr` 156)
-                                    <*> peek (ptr `plusPtr` 160)
-                                    <*> peek (ptr `plusPtr` 164)
-                                    <*> peek (ptr `plusPtr` 168)
-                                    <*> peek (ptr `plusPtr` 172)
-                                    <*> peek (ptr `plusPtr` 176)
-                                    <*> peek (ptr `plusPtr` 180)
-                                    <*> peek (ptr `plusPtr` 184)
-                                    <*> peek (ptr `plusPtr` 188)
-                                    <*> peek (ptr `plusPtr` 192)
-                                    <*> peek (ptr `plusPtr` 196)
-                                    <*> peek (ptr `plusPtr` 200)
-                                    <*> peek (ptr `plusPtr` 204)
-                                    <*> peek (ptr `plusPtr` 208)
-                                    <*> peek (ptr `plusPtr` 212)
-                                    <*> peek (ptr `plusPtr` 216)
-                                    <*> peek (ptr `plusPtr` 220)
-                                    <*> peek (ptr `plusPtr` 232)
-                                    <*> peek (ptr `plusPtr` 236)
-                                    <*> peek (ptr `plusPtr` 248)
-                                    <*> peek (ptr `plusPtr` 252)
-                                    <*> peek (ptr `plusPtr` 256)
-                                    <*> peek (ptr `plusPtr` 260)
-                                    <*> peek (ptr `plusPtr` 264)
-                                    <*> peek (ptr `plusPtr` 268)
-                                    <*> peek (ptr `plusPtr` 272)
-                                    <*> peek (ptr `plusPtr` 276)
-                                    <*> peek (ptr `plusPtr` 280)
-                                    <*> peek (ptr `plusPtr` 288)
-                                    <*> peek (ptr `plusPtr` 296)
-                                    <*> peek (ptr `plusPtr` 304)
-                                    <*> peek (ptr `plusPtr` 312)
-                                    <*> peek (ptr `plusPtr` 320)
-                                    <*> peek (ptr `plusPtr` 328)
-                                    <*> peek (ptr `plusPtr` 336)
-                                    <*> peek (ptr `plusPtr` 340)
-                                    <*> peek (ptr `plusPtr` 344)
-                                    <*> peek (ptr `plusPtr` 348)
-                                    <*> peek (ptr `plusPtr` 352)
-                                    <*> peek (ptr `plusPtr` 356)
-                                    <*> peek (ptr `plusPtr` 360)
-                                    <*> peek (ptr `plusPtr` 364)
-                                    <*> peek (ptr `plusPtr` 368)
-                                    <*> peek (ptr `plusPtr` 372)
-                                    <*> peek (ptr `plusPtr` 376)
-                                    <*> peek (ptr `plusPtr` 380)
-                                    <*> peek (ptr `plusPtr` 384)
-                                    <*> peek (ptr `plusPtr` 388)
-                                    <*> peek (ptr `plusPtr` 392)
-                                    <*> peek (ptr `plusPtr` 396)
-                                    <*> peek (ptr `plusPtr` 400)
-                                    <*> peek (ptr `plusPtr` 404)
-                                    <*> peek (ptr `plusPtr` 408)
-                                    <*> peek (ptr `plusPtr` 412)
-                                    <*> peek (ptr `plusPtr` 416)
-                                    <*> peek (ptr `plusPtr` 420)
-                                    <*> peek (ptr `plusPtr` 424)
-                                    <*> peek (ptr `plusPtr` 428)
-                                    <*> peek (ptr `plusPtr` 432)
-                                    <*> peek (ptr `plusPtr` 436)
-                                    <*> peek (ptr `plusPtr` 440)
-                                    <*> peek (ptr `plusPtr` 444)
-                                    <*> peek (ptr `plusPtr` 452)
-                                    <*> peek (ptr `plusPtr` 460)
-                                    <*> peek (ptr `plusPtr` 464)
-                                    <*> peek (ptr `plusPtr` 468)
-                                    <*> peek (ptr `plusPtr` 472)
-                                    <*> peek (ptr `plusPtr` 480)
-                                    <*> peek (ptr `plusPtr` 488)
-                                    <*> peek (ptr `plusPtr` 496)
-  poke ptr poked = poke (ptr `plusPtr` 0) (maxImageDimension1D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 4) (maxImageDimension2D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 8) (maxImageDimension3D (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 12) (maxImageDimensionCube (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 16) (maxImageArrayLayers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 20) (maxTexelBufferElements (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 24) (maxUniformBufferRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 28) (maxStorageBufferRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 32) (maxPushConstantsSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 36) (maxMemoryAllocationCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 40) (maxSamplerAllocationCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 48) (bufferImageGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 56) (sparseAddressSpaceSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 64) (maxBoundDescriptorSets (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 68) (maxPerStageDescriptorSamplers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 72) (maxPerStageDescriptorUniformBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 76) (maxPerStageDescriptorStorageBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 80) (maxPerStageDescriptorSampledImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 84) (maxPerStageDescriptorStorageImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 88) (maxPerStageDescriptorInputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 92) (maxPerStageResources (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 96) (maxDescriptorSetSamplers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 100) (maxDescriptorSetUniformBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 104) (maxDescriptorSetUniformBuffersDynamic (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 108) (maxDescriptorSetStorageBuffers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 112) (maxDescriptorSetStorageBuffersDynamic (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 116) (maxDescriptorSetSampledImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 120) (maxDescriptorSetStorageImages (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 124) (maxDescriptorSetInputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 128) (maxVertexInputAttributes (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 132) (maxVertexInputBindings (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 136) (maxVertexInputAttributeOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 140) (maxVertexInputBindingStride (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 144) (maxVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 148) (maxTessellationGenerationLevel (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 152) (maxTessellationPatchSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 156) (maxTessellationControlPerVertexInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 160) (maxTessellationControlPerVertexOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 164) (maxTessellationControlPerPatchOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 168) (maxTessellationControlTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 172) (maxTessellationEvaluationInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 176) (maxTessellationEvaluationOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 180) (maxGeometryShaderInvocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 184) (maxGeometryInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 188) (maxGeometryOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 192) (maxGeometryOutputVertices (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 196) (maxGeometryTotalOutputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 200) (maxFragmentInputComponents (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 204) (maxFragmentOutputAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 208) (maxFragmentDualSrcAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 212) (maxFragmentCombinedOutputResources (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 216) (maxComputeSharedMemorySize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 220) (maxComputeWorkGroupCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 232) (maxComputeWorkGroupInvocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 236) (maxComputeWorkGroupSize (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 248) (subPixelPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 252) (subTexelPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 256) (mipmapPrecisionBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 260) (maxDrawIndexedIndexValue (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 264) (maxDrawIndirectCount (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 268) (maxSamplerLodBias (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 272) (maxSamplerAnisotropy (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 276) (maxViewports (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 280) (maxViewportDimensions (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 288) (viewportBoundsRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 296) (viewportSubPixelBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 304) (minMemoryMapAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 312) (minTexelBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 320) (minUniformBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 328) (minStorageBufferOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 336) (minTexelOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 340) (maxTexelOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 344) (minTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 348) (maxTexelGatherOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 352) (minInterpolationOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 356) (maxInterpolationOffset (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 360) (subPixelInterpolationOffsetBits (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 364) (maxFramebufferWidth (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 368) (maxFramebufferHeight (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 372) (maxFramebufferLayers (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 376) (framebufferColorSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 380) (framebufferDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 384) (framebufferStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 388) (framebufferNoAttachmentsSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 392) (maxColorAttachments (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 396) (sampledImageColorSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 400) (sampledImageIntegerSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 404) (sampledImageDepthSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 408) (sampledImageStencilSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 412) (storageImageSampleCounts (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 416) (maxSampleMaskWords (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 420) (timestampComputeAndGraphics (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 424) (timestampPeriod (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 428) (maxClipDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 432) (maxCullDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 436) (maxCombinedClipAndCullDistances (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 440) (discreteQueuePriorities (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 444) (pointSizeRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 452) (lineWidthRange (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 460) (pointSizeGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 464) (lineWidthGranularity (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 468) (strictLines (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 472) (standardSampleLocations (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 480) (optimalBufferCopyOffsetAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 488) (optimalBufferCopyRowPitchAlignment (poked :: VkPhysicalDeviceLimits))
-                *> poke (ptr `plusPtr` 496) (nonCoherentAtomSize (poked :: VkPhysicalDeviceLimits))
+  peek ptr = PhysicalDeviceLimits <$> peek (ptr `plusPtr` 0)
+                                  <*> peek (ptr `plusPtr` 4)
+                                  <*> peek (ptr `plusPtr` 8)
+                                  <*> peek (ptr `plusPtr` 12)
+                                  <*> peek (ptr `plusPtr` 16)
+                                  <*> peek (ptr `plusPtr` 20)
+                                  <*> peek (ptr `plusPtr` 24)
+                                  <*> peek (ptr `plusPtr` 28)
+                                  <*> peek (ptr `plusPtr` 32)
+                                  <*> peek (ptr `plusPtr` 36)
+                                  <*> peek (ptr `plusPtr` 40)
+                                  <*> peek (ptr `plusPtr` 48)
+                                  <*> peek (ptr `plusPtr` 56)
+                                  <*> peek (ptr `plusPtr` 64)
+                                  <*> peek (ptr `plusPtr` 68)
+                                  <*> peek (ptr `plusPtr` 72)
+                                  <*> peek (ptr `plusPtr` 76)
+                                  <*> peek (ptr `plusPtr` 80)
+                                  <*> peek (ptr `plusPtr` 84)
+                                  <*> peek (ptr `plusPtr` 88)
+                                  <*> peek (ptr `plusPtr` 92)
+                                  <*> peek (ptr `plusPtr` 96)
+                                  <*> peek (ptr `plusPtr` 100)
+                                  <*> peek (ptr `plusPtr` 104)
+                                  <*> peek (ptr `plusPtr` 108)
+                                  <*> peek (ptr `plusPtr` 112)
+                                  <*> peek (ptr `plusPtr` 116)
+                                  <*> peek (ptr `plusPtr` 120)
+                                  <*> peek (ptr `plusPtr` 124)
+                                  <*> peek (ptr `plusPtr` 128)
+                                  <*> peek (ptr `plusPtr` 132)
+                                  <*> peek (ptr `plusPtr` 136)
+                                  <*> peek (ptr `plusPtr` 140)
+                                  <*> peek (ptr `plusPtr` 144)
+                                  <*> peek (ptr `plusPtr` 148)
+                                  <*> peek (ptr `plusPtr` 152)
+                                  <*> peek (ptr `plusPtr` 156)
+                                  <*> peek (ptr `plusPtr` 160)
+                                  <*> peek (ptr `plusPtr` 164)
+                                  <*> peek (ptr `plusPtr` 168)
+                                  <*> peek (ptr `plusPtr` 172)
+                                  <*> peek (ptr `plusPtr` 176)
+                                  <*> peek (ptr `plusPtr` 180)
+                                  <*> peek (ptr `plusPtr` 184)
+                                  <*> peek (ptr `plusPtr` 188)
+                                  <*> peek (ptr `plusPtr` 192)
+                                  <*> peek (ptr `plusPtr` 196)
+                                  <*> peek (ptr `plusPtr` 200)
+                                  <*> peek (ptr `plusPtr` 204)
+                                  <*> peek (ptr `plusPtr` 208)
+                                  <*> peek (ptr `plusPtr` 212)
+                                  <*> peek (ptr `plusPtr` 216)
+                                  <*> peek (ptr `plusPtr` 220)
+                                  <*> peek (ptr `plusPtr` 232)
+                                  <*> peek (ptr `plusPtr` 236)
+                                  <*> peek (ptr `plusPtr` 248)
+                                  <*> peek (ptr `plusPtr` 252)
+                                  <*> peek (ptr `plusPtr` 256)
+                                  <*> peek (ptr `plusPtr` 260)
+                                  <*> peek (ptr `plusPtr` 264)
+                                  <*> peek (ptr `plusPtr` 268)
+                                  <*> peek (ptr `plusPtr` 272)
+                                  <*> peek (ptr `plusPtr` 276)
+                                  <*> peek (ptr `plusPtr` 280)
+                                  <*> peek (ptr `plusPtr` 288)
+                                  <*> peek (ptr `plusPtr` 296)
+                                  <*> peek (ptr `plusPtr` 304)
+                                  <*> peek (ptr `plusPtr` 312)
+                                  <*> peek (ptr `plusPtr` 320)
+                                  <*> peek (ptr `plusPtr` 328)
+                                  <*> peek (ptr `plusPtr` 336)
+                                  <*> peek (ptr `plusPtr` 340)
+                                  <*> peek (ptr `plusPtr` 344)
+                                  <*> peek (ptr `plusPtr` 348)
+                                  <*> peek (ptr `plusPtr` 352)
+                                  <*> peek (ptr `plusPtr` 356)
+                                  <*> peek (ptr `plusPtr` 360)
+                                  <*> peek (ptr `plusPtr` 364)
+                                  <*> peek (ptr `plusPtr` 368)
+                                  <*> peek (ptr `plusPtr` 372)
+                                  <*> peek (ptr `plusPtr` 376)
+                                  <*> peek (ptr `plusPtr` 380)
+                                  <*> peek (ptr `plusPtr` 384)
+                                  <*> peek (ptr `plusPtr` 388)
+                                  <*> peek (ptr `plusPtr` 392)
+                                  <*> peek (ptr `plusPtr` 396)
+                                  <*> peek (ptr `plusPtr` 400)
+                                  <*> peek (ptr `plusPtr` 404)
+                                  <*> peek (ptr `plusPtr` 408)
+                                  <*> peek (ptr `plusPtr` 412)
+                                  <*> peek (ptr `plusPtr` 416)
+                                  <*> peek (ptr `plusPtr` 420)
+                                  <*> peek (ptr `plusPtr` 424)
+                                  <*> peek (ptr `plusPtr` 428)
+                                  <*> peek (ptr `plusPtr` 432)
+                                  <*> peek (ptr `plusPtr` 436)
+                                  <*> peek (ptr `plusPtr` 440)
+                                  <*> peek (ptr `plusPtr` 444)
+                                  <*> peek (ptr `plusPtr` 452)
+                                  <*> peek (ptr `plusPtr` 460)
+                                  <*> peek (ptr `plusPtr` 464)
+                                  <*> peek (ptr `plusPtr` 468)
+                                  <*> peek (ptr `plusPtr` 472)
+                                  <*> peek (ptr `plusPtr` 480)
+                                  <*> peek (ptr `plusPtr` 488)
+                                  <*> peek (ptr `plusPtr` 496)
+  poke ptr poked = poke (ptr `plusPtr` 0) (maxImageDimension1D (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 4) (maxImageDimension2D (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 8) (maxImageDimension3D (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 12) (maxImageDimensionCube (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 16) (maxImageArrayLayers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 20) (maxTexelBufferElements (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 24) (maxUniformBufferRange (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 28) (maxStorageBufferRange (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 32) (maxPushConstantsSize (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 36) (maxMemoryAllocationCount (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 40) (maxSamplerAllocationCount (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 48) (bufferImageGranularity (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 56) (sparseAddressSpaceSize (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 64) (maxBoundDescriptorSets (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 68) (maxPerStageDescriptorSamplers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 72) (maxPerStageDescriptorUniformBuffers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 76) (maxPerStageDescriptorStorageBuffers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 80) (maxPerStageDescriptorSampledImages (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 84) (maxPerStageDescriptorStorageImages (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 88) (maxPerStageDescriptorInputAttachments (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 92) (maxPerStageResources (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 96) (maxDescriptorSetSamplers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 100) (maxDescriptorSetUniformBuffers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 104) (maxDescriptorSetUniformBuffersDynamic (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 108) (maxDescriptorSetStorageBuffers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 112) (maxDescriptorSetStorageBuffersDynamic (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 116) (maxDescriptorSetSampledImages (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 120) (maxDescriptorSetStorageImages (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 124) (maxDescriptorSetInputAttachments (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 128) (maxVertexInputAttributes (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 132) (maxVertexInputBindings (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 136) (maxVertexInputAttributeOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 140) (maxVertexInputBindingStride (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 144) (maxVertexOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 148) (maxTessellationGenerationLevel (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 152) (maxTessellationPatchSize (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 156) (maxTessellationControlPerVertexInputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 160) (maxTessellationControlPerVertexOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 164) (maxTessellationControlPerPatchOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 168) (maxTessellationControlTotalOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 172) (maxTessellationEvaluationInputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 176) (maxTessellationEvaluationOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 180) (maxGeometryShaderInvocations (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 184) (maxGeometryInputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 188) (maxGeometryOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 192) (maxGeometryOutputVertices (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 196) (maxGeometryTotalOutputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 200) (maxFragmentInputComponents (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 204) (maxFragmentOutputAttachments (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 208) (maxFragmentDualSrcAttachments (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 212) (maxFragmentCombinedOutputResources (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 216) (maxComputeSharedMemorySize (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 220) (maxComputeWorkGroupCount (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 232) (maxComputeWorkGroupInvocations (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 236) (maxComputeWorkGroupSize (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 248) (subPixelPrecisionBits (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 252) (subTexelPrecisionBits (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 256) (mipmapPrecisionBits (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 260) (maxDrawIndexedIndexValue (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 264) (maxDrawIndirectCount (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 268) (maxSamplerLodBias (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 272) (maxSamplerAnisotropy (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 276) (maxViewports (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 280) (maxViewportDimensions (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 288) (viewportBoundsRange (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 296) (viewportSubPixelBits (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 304) (minMemoryMapAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 312) (minTexelBufferOffsetAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 320) (minUniformBufferOffsetAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 328) (minStorageBufferOffsetAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 336) (minTexelOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 340) (maxTexelOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 344) (minTexelGatherOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 348) (maxTexelGatherOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 352) (minInterpolationOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 356) (maxInterpolationOffset (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 360) (subPixelInterpolationOffsetBits (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 364) (maxFramebufferWidth (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 368) (maxFramebufferHeight (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 372) (maxFramebufferLayers (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 376) (framebufferColorSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 380) (framebufferDepthSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 384) (framebufferStencilSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 388) (framebufferNoAttachmentsSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 392) (maxColorAttachments (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 396) (sampledImageColorSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 400) (sampledImageIntegerSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 404) (sampledImageDepthSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 408) (sampledImageStencilSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 412) (storageImageSampleCounts (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 416) (maxSampleMaskWords (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 420) (timestampComputeAndGraphics (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 424) (timestampPeriod (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 428) (maxClipDistances (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 432) (maxCullDistances (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 436) (maxCombinedClipAndCullDistances (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 440) (discreteQueuePriorities (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 444) (pointSizeRange (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 452) (lineWidthRange (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 460) (pointSizeGranularity (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 464) (lineWidthGranularity (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 468) (strictLines (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 472) (standardSampleLocations (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 480) (optimalBufferCopyOffsetAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 488) (optimalBufferCopyRowPitchAlignment (poked :: PhysicalDeviceLimits))
+                *> poke (ptr `plusPtr` 496) (nonCoherentAtomSize (poked :: PhysicalDeviceLimits))
 
 
 
-data VkMemoryHeap =
-  VkMemoryHeap{ size :: VkDeviceSize 
-              , flags :: VkMemoryHeapFlags 
-              }
+data MemoryHeap =
+  MemoryHeap{ size :: VkDeviceSize 
+            , flags :: VkMemoryHeapFlags 
+            }
   deriving (Eq)
 
-instance Storable VkMemoryHeap where
+instance Storable MemoryHeap where
   sizeOf ~_ = 16
   alignment ~_ = 8
-  peek ptr = VkMemoryHeap <$> peek (ptr `plusPtr` 0)
-                          <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: VkMemoryHeap))
-                *> poke (ptr `plusPtr` 8) (flags (poked :: VkMemoryHeap))
+  peek ptr = MemoryHeap <$> peek (ptr `plusPtr` 0)
+                        <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: MemoryHeap))
+                *> poke (ptr `plusPtr` 8) (flags (poked :: MemoryHeap))
 
 
 -- ** vkEnumeratePhysicalDevices
@@ -536,8 +536,8 @@ foreign import ccall "vkGetDeviceProcAddr" vkGetDeviceProcAddr ::
 
 -- ** vkCreateInstance
 foreign import ccall "vkCreateInstance" vkCreateInstance ::
-  Ptr VkInstanceCreateInfo ->
-  Ptr VkAllocationCallbacks -> Ptr Instance -> IO VkResult
+  Ptr InstanceCreateInfo ->
+  Ptr AllocationCallbacks -> Ptr Instance -> IO VkResult
 
 -- ** VkFormatFeatureFlags
 
@@ -612,25 +612,25 @@ pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = VkFormatFeatureFlags
 
 
 
-data VkPhysicalDeviceMemoryProperties =
-  VkPhysicalDeviceMemoryProperties{ memoryTypeCount :: Word32 
-                                  , memoryTypes :: Vector VK_MAX_MEMORY_TYPES VkMemoryType 
-                                  , memoryHeapCount :: Word32 
-                                  , memoryHeaps :: Vector VK_MAX_MEMORY_HEAPS VkMemoryHeap 
-                                  }
+data PhysicalDeviceMemoryProperties =
+  PhysicalDeviceMemoryProperties{ memoryTypeCount :: Word32 
+                                , memoryTypes :: Vector VK_MAX_MEMORY_TYPES MemoryType 
+                                , memoryHeapCount :: Word32 
+                                , memoryHeaps :: Vector VK_MAX_MEMORY_HEAPS MemoryHeap 
+                                }
   deriving (Eq)
 
-instance Storable VkPhysicalDeviceMemoryProperties where
+instance Storable PhysicalDeviceMemoryProperties where
   sizeOf ~_ = 520
   alignment ~_ = 8
-  peek ptr = VkPhysicalDeviceMemoryProperties <$> peek (ptr `plusPtr` 0)
-                                              <*> peek (ptr `plusPtr` 4)
-                                              <*> peek (ptr `plusPtr` 260)
-                                              <*> peek (ptr `plusPtr` 264)
-  poke ptr poked = poke (ptr `plusPtr` 0) (memoryTypeCount (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 4) (memoryTypes (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 260) (memoryHeapCount (poked :: VkPhysicalDeviceMemoryProperties))
-                *> poke (ptr `plusPtr` 264) (memoryHeaps (poked :: VkPhysicalDeviceMemoryProperties))
+  peek ptr = PhysicalDeviceMemoryProperties <$> peek (ptr `plusPtr` 0)
+                                            <*> peek (ptr `plusPtr` 4)
+                                            <*> peek (ptr `plusPtr` 260)
+                                            <*> peek (ptr `plusPtr` 264)
+  poke ptr poked = poke (ptr `plusPtr` 0) (memoryTypeCount (poked :: PhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 4) (memoryTypes (poked :: PhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 260) (memoryHeapCount (poked :: PhysicalDeviceMemoryProperties))
+                *> poke (ptr `plusPtr` 264) (memoryHeaps (poked :: PhysicalDeviceMemoryProperties))
 
 
 data VkInstance_T
@@ -661,141 +661,140 @@ pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = VkMemoryHeapFlags 0x1
 
 
 
-data VkQueueFamilyProperties =
-  VkQueueFamilyProperties{ queueFlags :: VkQueueFlags 
-                         , queueCount :: Word32 
-                         , timestampValidBits :: Word32 
-                         , minImageTransferGranularity :: VkExtent3D 
-                         }
+data QueueFamilyProperties =
+  QueueFamilyProperties{ queueFlags :: VkQueueFlags 
+                       , queueCount :: Word32 
+                       , timestampValidBits :: Word32 
+                       , minImageTransferGranularity :: Extent3D 
+                       }
   deriving (Eq)
 
-instance Storable VkQueueFamilyProperties where
+instance Storable QueueFamilyProperties where
   sizeOf ~_ = 24
   alignment ~_ = 4
-  peek ptr = VkQueueFamilyProperties <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 4)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (queueFlags (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 4) (queueCount (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 8) (timestampValidBits (poked :: VkQueueFamilyProperties))
-                *> poke (ptr `plusPtr` 12) (minImageTransferGranularity (poked :: VkQueueFamilyProperties))
+  peek ptr = QueueFamilyProperties <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 4)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (queueFlags (poked :: QueueFamilyProperties))
+                *> poke (ptr `plusPtr` 4) (queueCount (poked :: QueueFamilyProperties))
+                *> poke (ptr `plusPtr` 8) (timestampValidBits (poked :: QueueFamilyProperties))
+                *> poke (ptr `plusPtr` 12) (minImageTransferGranularity (poked :: QueueFamilyProperties))
 
 
 
-data VkImageFormatProperties =
-  VkImageFormatProperties{ maxExtent :: VkExtent3D 
-                         , maxMipLevels :: Word32 
-                         , maxArrayLayers :: Word32 
-                         , sampleCounts :: VkSampleCountFlags 
-                         , maxResourceSize :: VkDeviceSize 
-                         }
+data ImageFormatProperties =
+  ImageFormatProperties{ maxExtent :: Extent3D 
+                       , maxMipLevels :: Word32 
+                       , maxArrayLayers :: Word32 
+                       , sampleCounts :: VkSampleCountFlags 
+                       , maxResourceSize :: VkDeviceSize 
+                       }
   deriving (Eq)
 
-instance Storable VkImageFormatProperties where
+instance Storable ImageFormatProperties where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkImageFormatProperties <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 12)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 20)
-                                     <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (maxExtent (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 12) (maxMipLevels (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 16) (maxArrayLayers (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 20) (sampleCounts (poked :: VkImageFormatProperties))
-                *> poke (ptr `plusPtr` 24) (maxResourceSize (poked :: VkImageFormatProperties))
+  peek ptr = ImageFormatProperties <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 12)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 20)
+                                   <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (maxExtent (poked :: ImageFormatProperties))
+                *> poke (ptr `plusPtr` 12) (maxMipLevels (poked :: ImageFormatProperties))
+                *> poke (ptr `plusPtr` 16) (maxArrayLayers (poked :: ImageFormatProperties))
+                *> poke (ptr `plusPtr` 20) (sampleCounts (poked :: ImageFormatProperties))
+                *> poke (ptr `plusPtr` 24) (maxResourceSize (poked :: ImageFormatProperties))
 
 
 
-data VkPhysicalDeviceSparseProperties =
-  VkPhysicalDeviceSparseProperties{ residencyStandard2DBlockShape :: VkBool32 
-                                  , residencyStandard2DMultisampleBlockShape :: VkBool32 
-                                  , residencyStandard3DBlockShape :: VkBool32 
-                                  , residencyAlignedMipSize :: VkBool32 
-                                  , residencyNonResidentStrict :: VkBool32 
-                                  }
+data PhysicalDeviceSparseProperties =
+  PhysicalDeviceSparseProperties{ residencyStandard2DBlockShape :: VkBool32 
+                                , residencyStandard2DMultisampleBlockShape :: VkBool32 
+                                , residencyStandard3DBlockShape :: VkBool32 
+                                , residencyAlignedMipSize :: VkBool32 
+                                , residencyNonResidentStrict :: VkBool32 
+                                }
   deriving (Eq)
 
-instance Storable VkPhysicalDeviceSparseProperties where
+instance Storable PhysicalDeviceSparseProperties where
   sizeOf ~_ = 20
   alignment ~_ = 4
-  peek ptr = VkPhysicalDeviceSparseProperties <$> peek (ptr `plusPtr` 0)
-                                              <*> peek (ptr `plusPtr` 4)
-                                              <*> peek (ptr `plusPtr` 8)
-                                              <*> peek (ptr `plusPtr` 12)
-                                              <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (residencyStandard2DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 4) (residencyStandard2DMultisampleBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 8) (residencyStandard3DBlockShape (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 12) (residencyAlignedMipSize (poked :: VkPhysicalDeviceSparseProperties))
-                *> poke (ptr `plusPtr` 16) (residencyNonResidentStrict (poked :: VkPhysicalDeviceSparseProperties))
+  peek ptr = PhysicalDeviceSparseProperties <$> peek (ptr `plusPtr` 0)
+                                            <*> peek (ptr `plusPtr` 4)
+                                            <*> peek (ptr `plusPtr` 8)
+                                            <*> peek (ptr `plusPtr` 12)
+                                            <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (residencyStandard2DBlockShape (poked :: PhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 4) (residencyStandard2DMultisampleBlockShape (poked :: PhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 8) (residencyStandard3DBlockShape (poked :: PhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 12) (residencyAlignedMipSize (poked :: PhysicalDeviceSparseProperties))
+                *> poke (ptr `plusPtr` 16) (residencyNonResidentStrict (poked :: PhysicalDeviceSparseProperties))
 
 
 -- ** vkGetPhysicalDeviceFeatures
 foreign import ccall "vkGetPhysicalDeviceFeatures" vkGetPhysicalDeviceFeatures ::
-  PhysicalDevice -> Ptr VkPhysicalDeviceFeatures -> IO ()
+  PhysicalDevice -> Ptr PhysicalDeviceFeatures -> IO ()
 
 -- ** vkGetPhysicalDeviceMemoryProperties
 foreign import ccall "vkGetPhysicalDeviceMemoryProperties" vkGetPhysicalDeviceMemoryProperties ::
-  PhysicalDevice -> Ptr VkPhysicalDeviceMemoryProperties -> IO ()
+  PhysicalDevice -> Ptr PhysicalDeviceMemoryProperties -> IO ()
 
 
-data VkPhysicalDeviceProperties =
-  VkPhysicalDeviceProperties{ apiVersion :: Word32 
-                            , driverVersion :: Word32 
-                            , vendorID :: Word32 
-                            , deviceID :: Word32 
-                            , deviceType :: VkPhysicalDeviceType 
-                            , deviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
-                            , pipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
-                            , limits :: VkPhysicalDeviceLimits 
-                            , sparseProperties :: VkPhysicalDeviceSparseProperties 
-                            }
+data PhysicalDeviceProperties =
+  PhysicalDeviceProperties{ apiVersion :: Word32 
+                          , driverVersion :: Word32 
+                          , vendorID :: Word32 
+                          , deviceID :: Word32 
+                          , deviceType :: VkPhysicalDeviceType 
+                          , deviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
+                          , pipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
+                          , limits :: PhysicalDeviceLimits 
+                          , sparseProperties :: PhysicalDeviceSparseProperties 
+                          }
   deriving (Eq)
 
-instance Storable VkPhysicalDeviceProperties where
+instance Storable PhysicalDeviceProperties where
   sizeOf ~_ = 824
   alignment ~_ = 8
-  peek ptr = VkPhysicalDeviceProperties <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 4)
-                                        <*> peek (ptr `plusPtr` 8)
-                                        <*> peek (ptr `plusPtr` 12)
-                                        <*> peek (ptr `plusPtr` 16)
-                                        <*> peek (ptr `plusPtr` 20)
-                                        <*> peek (ptr `plusPtr` 276)
-                                        <*> peek (ptr `plusPtr` 296)
-                                        <*> peek (ptr `plusPtr` 800)
-  poke ptr poked = poke (ptr `plusPtr` 0) (apiVersion (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 4) (driverVersion (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 8) (vendorID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 12) (deviceID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 16) (deviceType (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 20) (deviceName (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 276) (pipelineCacheUUID (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 296) (limits (poked :: VkPhysicalDeviceProperties))
-                *> poke (ptr `plusPtr` 800) (sparseProperties (poked :: VkPhysicalDeviceProperties))
+  peek ptr = PhysicalDeviceProperties <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 4)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 12)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 20)
+                                      <*> peek (ptr `plusPtr` 276)
+                                      <*> peek (ptr `plusPtr` 296)
+                                      <*> peek (ptr `plusPtr` 800)
+  poke ptr poked = poke (ptr `plusPtr` 0) (apiVersion (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 4) (driverVersion (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 8) (vendorID (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 12) (deviceID (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 16) (deviceType (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 20) (deviceName (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 276) (pipelineCacheUUID (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 296) (limits (poked :: PhysicalDeviceProperties))
+                *> poke (ptr `plusPtr` 800) (sparseProperties (poked :: PhysicalDeviceProperties))
 
 
 -- ** vkGetPhysicalDeviceQueueFamilyProperties
 foreign import ccall "vkGetPhysicalDeviceQueueFamilyProperties" vkGetPhysicalDeviceQueueFamilyProperties ::
-  PhysicalDevice ->
-  Ptr Word32 -> Ptr VkQueueFamilyProperties -> IO ()
+  PhysicalDevice -> Ptr Word32 -> Ptr QueueFamilyProperties -> IO ()
 
 
-data VkMemoryType =
-  VkMemoryType{ propertyFlags :: VkMemoryPropertyFlags 
-              , heapIndex :: Word32 
-              }
+data MemoryType =
+  MemoryType{ propertyFlags :: VkMemoryPropertyFlags 
+            , heapIndex :: Word32 
+            }
   deriving (Eq)
 
-instance Storable VkMemoryType where
+instance Storable MemoryType where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkMemoryType <$> peek (ptr `plusPtr` 0)
-                          <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (propertyFlags (poked :: VkMemoryType))
-                *> poke (ptr `plusPtr` 4) (heapIndex (poked :: VkMemoryType))
+  peek ptr = MemoryType <$> peek (ptr `plusPtr` 0)
+                        <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (propertyFlags (poked :: MemoryType))
+                *> poke (ptr `plusPtr` 4) (heapIndex (poked :: MemoryType))
 
 
 -- ** vkGetInstanceProcAddr
@@ -844,7 +843,7 @@ pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = VkMemoryPropertyFlags 0x10
 
 -- ** vkDestroyInstance
 foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
-  Instance -> Ptr VkAllocationCallbacks -> IO ()
+  Instance -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkQueueFlags
 
@@ -884,7 +883,7 @@ pattern VK_QUEUE_SPARSE_BINDING_BIT = VkQueueFlags 0x8
 
 -- ** vkGetPhysicalDeviceProperties
 foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperties ::
-  PhysicalDevice -> Ptr VkPhysicalDeviceProperties -> IO ()
+  PhysicalDevice -> Ptr PhysicalDeviceProperties -> IO ()
 
 -- ** VkInstanceCreateFlags
 -- | Opaque flag
@@ -893,24 +892,24 @@ newtype VkInstanceCreateFlags = VkInstanceCreateFlags VkFlags
 
 -- ** vkGetPhysicalDeviceFormatProperties
 foreign import ccall "vkGetPhysicalDeviceFormatProperties" vkGetPhysicalDeviceFormatProperties ::
-  PhysicalDevice -> VkFormat -> Ptr VkFormatProperties -> IO ()
+  PhysicalDevice -> VkFormat -> Ptr FormatProperties -> IO ()
 
 
-data VkFormatProperties =
-  VkFormatProperties{ linearTilingFeatures :: VkFormatFeatureFlags 
-                    , optimalTilingFeatures :: VkFormatFeatureFlags 
-                    , bufferFeatures :: VkFormatFeatureFlags 
-                    }
+data FormatProperties =
+  FormatProperties{ linearTilingFeatures :: VkFormatFeatureFlags 
+                  , optimalTilingFeatures :: VkFormatFeatureFlags 
+                  , bufferFeatures :: VkFormatFeatureFlags 
+                  }
   deriving (Eq)
 
-instance Storable VkFormatProperties where
+instance Storable FormatProperties where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkFormatProperties <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 4)
-                                <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (linearTilingFeatures (poked :: VkFormatProperties))
-                *> poke (ptr `plusPtr` 4) (optimalTilingFeatures (poked :: VkFormatProperties))
-                *> poke (ptr `plusPtr` 8) (bufferFeatures (poked :: VkFormatProperties))
+  peek ptr = FormatProperties <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 4)
+                              <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (linearTilingFeatures (poked :: FormatProperties))
+                *> poke (ptr `plusPtr` 4) (optimalTilingFeatures (poked :: FormatProperties))
+                *> poke (ptr `plusPtr` 8) (bufferFeatures (poked :: FormatProperties))
 
 

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -71,7 +71,7 @@ import Foreign.C.Types( CFloat(..)
 -- ** PhysicalDeviceType
 
 newtype PhysicalDeviceType = PhysicalDeviceType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PhysicalDeviceType where
   showsPrec _ PhysicalDeviceTypeOther = showString "PhysicalDeviceTypeOther"
@@ -117,7 +117,7 @@ data InstanceCreateInfo =
                     , enabledExtensionCount :: Word32 
                     , ppEnabledExtensionNames :: Ptr (Ptr CChar) 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable InstanceCreateInfo where
   sizeOf ~_ = 64
@@ -161,7 +161,7 @@ data ApplicationInfo =
                  , engineVersion :: Word32 
                  , apiVersion :: Word32 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ApplicationInfo where
   sizeOf ~_ = 48
@@ -291,7 +291,7 @@ data PhysicalDeviceLimits =
                       , optimalBufferCopyRowPitchAlignment :: DeviceSize 
                       , nonCoherentAtomSize :: DeviceSize 
                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PhysicalDeviceLimits where
   sizeOf ~_ = 504
@@ -515,7 +515,7 @@ data MemoryHeap =
   MemoryHeap{ size :: DeviceSize 
             , flags :: MemoryHeapFlags 
             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MemoryHeap where
   sizeOf ~_ = 16
@@ -542,7 +542,7 @@ foreign import ccall "vkCreateInstance" createInstance ::
 -- ** FormatFeatureFlags
 
 newtype FormatFeatureFlags = FormatFeatureFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show FormatFeatureFlags where
   showsPrec _ FormatFeatureSampledImageBit = showString "FormatFeatureSampledImageBit"
@@ -618,7 +618,7 @@ data PhysicalDeviceMemoryProperties =
                                 , memoryHeapCount :: Word32 
                                 , memoryHeaps :: Vector MaxMemoryHeaps MemoryHeap 
                                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PhysicalDeviceMemoryProperties where
   sizeOf ~_ = 520
@@ -639,7 +639,7 @@ type Instance = Ptr VkInstance_T
 -- ** MemoryHeapFlags
 
 newtype MemoryHeapFlags = MemoryHeapFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show MemoryHeapFlags where
   showsPrec _ MemoryHeapDeviceLocalBit = showString "MemoryHeapDeviceLocalBit"
@@ -667,7 +667,7 @@ data QueueFamilyProperties =
                        , timestampValidBits :: Word32 
                        , minImageTransferGranularity :: Extent3D 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable QueueFamilyProperties where
   sizeOf ~_ = 24
@@ -690,7 +690,7 @@ data ImageFormatProperties =
                        , sampleCounts :: SampleCountFlags 
                        , maxResourceSize :: DeviceSize 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageFormatProperties where
   sizeOf ~_ = 32
@@ -715,7 +715,7 @@ data PhysicalDeviceSparseProperties =
                                 , residencyAlignedMipSize :: Bool32 
                                 , residencyNonResidentStrict :: Bool32 
                                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PhysicalDeviceSparseProperties where
   sizeOf ~_ = 20
@@ -752,7 +752,7 @@ data PhysicalDeviceProperties =
                           , limits :: PhysicalDeviceLimits 
                           , sparseProperties :: PhysicalDeviceSparseProperties 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PhysicalDeviceProperties where
   sizeOf ~_ = 824
@@ -786,7 +786,7 @@ data MemoryType =
   MemoryType{ propertyFlags :: MemoryPropertyFlags 
             , heapIndex :: Word32 
             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MemoryType where
   sizeOf ~_ = 8
@@ -804,7 +804,7 @@ foreign import ccall "vkGetInstanceProcAddr" getInstanceProcAddr ::
 -- ** MemoryPropertyFlags
 
 newtype MemoryPropertyFlags = MemoryPropertyFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show MemoryPropertyFlags where
   showsPrec _ MemoryPropertyDeviceLocalBit = showString "MemoryPropertyDeviceLocalBit"
@@ -848,7 +848,7 @@ foreign import ccall "vkDestroyInstance" destroyInstance ::
 -- ** QueueFlags
 
 newtype QueueFlags = QueueFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show QueueFlags where
   showsPrec _ QueueGraphicsBit = showString "QueueGraphicsBit"
@@ -888,7 +888,7 @@ foreign import ccall "vkGetPhysicalDeviceProperties" getPhysicalDeviceProperties
 -- ** InstanceCreateFlags
 -- | Opaque flag
 newtype InstanceCreateFlags = InstanceCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** getPhysicalDeviceFormatProperties
 foreign import ccall "vkGetPhysicalDeviceFormatProperties" getPhysicalDeviceFormatProperties ::
@@ -900,7 +900,7 @@ data FormatProperties =
                   , optimalTilingFeatures :: FormatFeatureFlags 
                   , bufferFeatures :: FormatFeatureFlags 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable FormatProperties where
   sizeOf ~_ = 12

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -32,10 +32,10 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_PHYSICAL_DEVICE_NAME_SIZE
-                                , VK_UUID_SIZE
-                                , VK_MAX_MEMORY_TYPES
-                                , VK_MAX_MEMORY_HEAPS
+import Graphics.Vulkan.Constants( MaxPhysicalDeviceNameSize
+                                , UuidSize
+                                , MaxMemoryTypes
+                                , MaxMemoryHeaps
                                 )
 import Data.Void( Void(..)
                 )
@@ -545,36 +545,36 @@ newtype FormatFeatureFlags = FormatFeatureFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show FormatFeatureFlags where
-  showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = showString "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = showString "VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = showString "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = showString "VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = showString "VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = showString "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = showString "VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = showString "VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_BLIT_SRC_BIT = showString "VK_FORMAT_FEATURE_BLIT_SRC_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_BLIT_DST_BIT = showString "VK_FORMAT_FEATURE_BLIT_DST_BIT"
-  showsPrec _ VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = showString "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT"
+  showsPrec _ FormatFeatureSampledImageBit = showString "FormatFeatureSampledImageBit"
+  showsPrec _ FormatFeatureStorageImageBit = showString "FormatFeatureStorageImageBit"
+  showsPrec _ FormatFeatureStorageImageAtomicBit = showString "FormatFeatureStorageImageAtomicBit"
+  showsPrec _ FormatFeatureUniformTexelBufferBit = showString "FormatFeatureUniformTexelBufferBit"
+  showsPrec _ FormatFeatureStorageTexelBufferBit = showString "FormatFeatureStorageTexelBufferBit"
+  showsPrec _ FormatFeatureStorageTexelBufferAtomicBit = showString "FormatFeatureStorageTexelBufferAtomicBit"
+  showsPrec _ FormatFeatureVertexBufferBit = showString "FormatFeatureVertexBufferBit"
+  showsPrec _ FormatFeatureColorAttachmentBit = showString "FormatFeatureColorAttachmentBit"
+  showsPrec _ FormatFeatureColorAttachmentBlendBit = showString "FormatFeatureColorAttachmentBlendBit"
+  showsPrec _ FormatFeatureDepthStencilAttachmentBit = showString "FormatFeatureDepthStencilAttachmentBit"
+  showsPrec _ FormatFeatureBlitSrcBit = showString "FormatFeatureBlitSrcBit"
+  showsPrec _ FormatFeatureBlitDstBit = showString "FormatFeatureBlitDstBit"
+  showsPrec _ FormatFeatureSampledImageFilterLinearBit = showString "FormatFeatureSampledImageFilterLinearBit"
   
   showsPrec p (FormatFeatureFlags x) = showParen (p >= 11) (showString "FormatFeatureFlags " . showsPrec 11 x)
 
 instance Read FormatFeatureFlags where
-  readPrec = parens ( choose [ ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)
-                             , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)
-                             , ("VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT", pure VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)
-                             , ("VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT", pure VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)
-                             , ("VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT", pure VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)
-                             , ("VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT", pure VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)
-                             , ("VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT", pure VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)
-                             , ("VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT", pure VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)
-                             , ("VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT", pure VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)
-                             , ("VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT", pure VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)
-                             , ("VK_FORMAT_FEATURE_BLIT_SRC_BIT", pure VK_FORMAT_FEATURE_BLIT_SRC_BIT)
-                             , ("VK_FORMAT_FEATURE_BLIT_DST_BIT", pure VK_FORMAT_FEATURE_BLIT_DST_BIT)
-                             , ("VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT", pure VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)
+  readPrec = parens ( choose [ ("FormatFeatureSampledImageBit", pure FormatFeatureSampledImageBit)
+                             , ("FormatFeatureStorageImageBit", pure FormatFeatureStorageImageBit)
+                             , ("FormatFeatureStorageImageAtomicBit", pure FormatFeatureStorageImageAtomicBit)
+                             , ("FormatFeatureUniformTexelBufferBit", pure FormatFeatureUniformTexelBufferBit)
+                             , ("FormatFeatureStorageTexelBufferBit", pure FormatFeatureStorageTexelBufferBit)
+                             , ("FormatFeatureStorageTexelBufferAtomicBit", pure FormatFeatureStorageTexelBufferAtomicBit)
+                             , ("FormatFeatureVertexBufferBit", pure FormatFeatureVertexBufferBit)
+                             , ("FormatFeatureColorAttachmentBit", pure FormatFeatureColorAttachmentBit)
+                             , ("FormatFeatureColorAttachmentBlendBit", pure FormatFeatureColorAttachmentBlendBit)
+                             , ("FormatFeatureDepthStencilAttachmentBit", pure FormatFeatureDepthStencilAttachmentBit)
+                             , ("FormatFeatureBlitSrcBit", pure FormatFeatureBlitSrcBit)
+                             , ("FormatFeatureBlitDstBit", pure FormatFeatureBlitDstBit)
+                             , ("FormatFeatureSampledImageFilterLinearBit", pure FormatFeatureSampledImageFilterLinearBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "FormatFeatureFlags")
@@ -584,39 +584,39 @@ instance Read FormatFeatureFlags where
                     )
 
 -- | Format can be used for sampled images (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT = FormatFeatureFlags 0x1
+pattern FormatFeatureSampledImageBit = FormatFeatureFlags 0x1
 -- | Format can be used for storage images (STORAGE_IMAGE descriptor type)
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT = FormatFeatureFlags 0x2
+pattern FormatFeatureStorageImageBit = FormatFeatureFlags 0x2
 -- | Format supports atomic operations in case it's used for storage images
-pattern VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT = FormatFeatureFlags 0x4
+pattern FormatFeatureStorageImageAtomicBit = FormatFeatureFlags 0x4
 -- | Format can be used for uniform texel buffers (TBOs)
-pattern VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT = FormatFeatureFlags 0x8
+pattern FormatFeatureUniformTexelBufferBit = FormatFeatureFlags 0x8
 -- | Format can be used for storage texel buffers (IBOs)
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT = FormatFeatureFlags 0x10
+pattern FormatFeatureStorageTexelBufferBit = FormatFeatureFlags 0x10
 -- | Format supports atomic operations in case it's used for storage texel buffers
-pattern VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT = FormatFeatureFlags 0x20
+pattern FormatFeatureStorageTexelBufferAtomicBit = FormatFeatureFlags 0x20
 -- | Format can be used for vertex buffers (VBOs)
-pattern VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT = FormatFeatureFlags 0x40
+pattern FormatFeatureVertexBufferBit = FormatFeatureFlags 0x40
 -- | Format can be used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT = FormatFeatureFlags 0x80
+pattern FormatFeatureColorAttachmentBit = FormatFeatureFlags 0x80
 -- | Format supports blending in case it's used for color attachment images
-pattern VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT = FormatFeatureFlags 0x100
+pattern FormatFeatureColorAttachmentBlendBit = FormatFeatureFlags 0x100
 -- | Format can be used for depth/stencil attachment images
-pattern VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT = FormatFeatureFlags 0x200
+pattern FormatFeatureDepthStencilAttachmentBit = FormatFeatureFlags 0x200
 -- | Format can be used as the source image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_SRC_BIT = FormatFeatureFlags 0x400
+pattern FormatFeatureBlitSrcBit = FormatFeatureFlags 0x400
 -- | Format can be used as the destination image of blits with vkCmdBlitImage
-pattern VK_FORMAT_FEATURE_BLIT_DST_BIT = FormatFeatureFlags 0x800
+pattern FormatFeatureBlitDstBit = FormatFeatureFlags 0x800
 -- | Format can be filtered with VK_FILTER_LINEAR when being sampled
-pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT = FormatFeatureFlags 0x1000
+pattern FormatFeatureSampledImageFilterLinearBit = FormatFeatureFlags 0x1000
 
 
 
 data PhysicalDeviceMemoryProperties =
   PhysicalDeviceMemoryProperties{ memoryTypeCount :: Word32 
-                                , memoryTypes :: Vector VK_MAX_MEMORY_TYPES MemoryType 
+                                , memoryTypes :: Vector MaxMemoryTypes MemoryType 
                                 , memoryHeapCount :: Word32 
-                                , memoryHeaps :: Vector VK_MAX_MEMORY_HEAPS MemoryHeap 
+                                , memoryHeaps :: Vector MaxMemoryHeaps MemoryHeap 
                                 }
   deriving (Eq)
 
@@ -642,12 +642,12 @@ newtype MemoryHeapFlags = MemoryHeapFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show MemoryHeapFlags where
-  showsPrec _ VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = showString "VK_MEMORY_HEAP_DEVICE_LOCAL_BIT"
+  showsPrec _ MemoryHeapDeviceLocalBit = showString "MemoryHeapDeviceLocalBit"
   
   showsPrec p (MemoryHeapFlags x) = showParen (p >= 11) (showString "MemoryHeapFlags " . showsPrec 11 x)
 
 instance Read MemoryHeapFlags where
-  readPrec = parens ( choose [ ("VK_MEMORY_HEAP_DEVICE_LOCAL_BIT", pure VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)
+  readPrec = parens ( choose [ ("MemoryHeapDeviceLocalBit", pure MemoryHeapDeviceLocalBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "MemoryHeapFlags")
@@ -657,7 +657,7 @@ instance Read MemoryHeapFlags where
                     )
 
 -- | If set, heap represents device memory
-pattern VK_MEMORY_HEAP_DEVICE_LOCAL_BIT = MemoryHeapFlags 0x1
+pattern MemoryHeapDeviceLocalBit = MemoryHeapFlags 0x1
 
 
 
@@ -747,8 +747,8 @@ data PhysicalDeviceProperties =
                           , vendorID :: Word32 
                           , deviceID :: Word32 
                           , deviceType :: PhysicalDeviceType 
-                          , deviceName :: Vector VK_MAX_PHYSICAL_DEVICE_NAME_SIZE CChar 
-                          , pipelineCacheUUID :: Vector VK_UUID_SIZE Word8 
+                          , deviceName :: Vector MaxPhysicalDeviceNameSize CChar 
+                          , pipelineCacheUUID :: Vector UuidSize Word8 
                           , limits :: PhysicalDeviceLimits 
                           , sparseProperties :: PhysicalDeviceSparseProperties 
                           }
@@ -807,20 +807,20 @@ newtype MemoryPropertyFlags = MemoryPropertyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show MemoryPropertyFlags where
-  showsPrec _ VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = showString "VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT"
-  showsPrec _ VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = showString "VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT"
-  showsPrec _ VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = showString "VK_MEMORY_PROPERTY_HOST_COHERENT_BIT"
-  showsPrec _ VK_MEMORY_PROPERTY_HOST_CACHED_BIT = showString "VK_MEMORY_PROPERTY_HOST_CACHED_BIT"
-  showsPrec _ VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = showString "VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT"
+  showsPrec _ MemoryPropertyDeviceLocalBit = showString "MemoryPropertyDeviceLocalBit"
+  showsPrec _ MemoryPropertyHostVisibleBit = showString "MemoryPropertyHostVisibleBit"
+  showsPrec _ MemoryPropertyHostCoherentBit = showString "MemoryPropertyHostCoherentBit"
+  showsPrec _ MemoryPropertyHostCachedBit = showString "MemoryPropertyHostCachedBit"
+  showsPrec _ MemoryPropertyLazilyAllocatedBit = showString "MemoryPropertyLazilyAllocatedBit"
   
   showsPrec p (MemoryPropertyFlags x) = showParen (p >= 11) (showString "MemoryPropertyFlags " . showsPrec 11 x)
 
 instance Read MemoryPropertyFlags where
-  readPrec = parens ( choose [ ("VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT", pure VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)
-                             , ("VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT", pure VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)
-                             , ("VK_MEMORY_PROPERTY_HOST_COHERENT_BIT", pure VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)
-                             , ("VK_MEMORY_PROPERTY_HOST_CACHED_BIT", pure VK_MEMORY_PROPERTY_HOST_CACHED_BIT)
-                             , ("VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT", pure VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)
+  readPrec = parens ( choose [ ("MemoryPropertyDeviceLocalBit", pure MemoryPropertyDeviceLocalBit)
+                             , ("MemoryPropertyHostVisibleBit", pure MemoryPropertyHostVisibleBit)
+                             , ("MemoryPropertyHostCoherentBit", pure MemoryPropertyHostCoherentBit)
+                             , ("MemoryPropertyHostCachedBit", pure MemoryPropertyHostCachedBit)
+                             , ("MemoryPropertyLazilyAllocatedBit", pure MemoryPropertyLazilyAllocatedBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "MemoryPropertyFlags")
@@ -830,15 +830,15 @@ instance Read MemoryPropertyFlags where
                     )
 
 -- | If otherwise stated, then allocate memory on device
-pattern VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT = MemoryPropertyFlags 0x1
+pattern MemoryPropertyDeviceLocalBit = MemoryPropertyFlags 0x1
 -- | Memory is mappable by host
-pattern VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT = MemoryPropertyFlags 0x2
+pattern MemoryPropertyHostVisibleBit = MemoryPropertyFlags 0x2
 -- | Memory will have i/o coherency. If not set, application may need to use vkFlushMappedMemoryRanges and vkInvalidateMappedMemoryRanges to flush/invalidate host cache
-pattern VK_MEMORY_PROPERTY_HOST_COHERENT_BIT = MemoryPropertyFlags 0x4
+pattern MemoryPropertyHostCoherentBit = MemoryPropertyFlags 0x4
 -- | Memory will be cached by the host
-pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = MemoryPropertyFlags 0x8
+pattern MemoryPropertyHostCachedBit = MemoryPropertyFlags 0x8
 -- | Memory may be allocated by the driver when it is required
-pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = MemoryPropertyFlags 0x10
+pattern MemoryPropertyLazilyAllocatedBit = MemoryPropertyFlags 0x10
 
 
 -- ** destroyInstance
@@ -851,18 +851,18 @@ newtype QueueFlags = QueueFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueueFlags where
-  showsPrec _ VK_QUEUE_GRAPHICS_BIT = showString "VK_QUEUE_GRAPHICS_BIT"
-  showsPrec _ VK_QUEUE_COMPUTE_BIT = showString "VK_QUEUE_COMPUTE_BIT"
-  showsPrec _ VK_QUEUE_TRANSFER_BIT = showString "VK_QUEUE_TRANSFER_BIT"
-  showsPrec _ VK_QUEUE_SPARSE_BINDING_BIT = showString "VK_QUEUE_SPARSE_BINDING_BIT"
+  showsPrec _ QueueGraphicsBit = showString "QueueGraphicsBit"
+  showsPrec _ QueueComputeBit = showString "QueueComputeBit"
+  showsPrec _ QueueTransferBit = showString "QueueTransferBit"
+  showsPrec _ QueueSparseBindingBit = showString "QueueSparseBindingBit"
   
   showsPrec p (QueueFlags x) = showParen (p >= 11) (showString "QueueFlags " . showsPrec 11 x)
 
 instance Read QueueFlags where
-  readPrec = parens ( choose [ ("VK_QUEUE_GRAPHICS_BIT", pure VK_QUEUE_GRAPHICS_BIT)
-                             , ("VK_QUEUE_COMPUTE_BIT", pure VK_QUEUE_COMPUTE_BIT)
-                             , ("VK_QUEUE_TRANSFER_BIT", pure VK_QUEUE_TRANSFER_BIT)
-                             , ("VK_QUEUE_SPARSE_BINDING_BIT", pure VK_QUEUE_SPARSE_BINDING_BIT)
+  readPrec = parens ( choose [ ("QueueGraphicsBit", pure QueueGraphicsBit)
+                             , ("QueueComputeBit", pure QueueComputeBit)
+                             , ("QueueTransferBit", pure QueueTransferBit)
+                             , ("QueueSparseBindingBit", pure QueueSparseBindingBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "QueueFlags")
@@ -872,13 +872,13 @@ instance Read QueueFlags where
                     )
 
 -- | Queue supports graphics operations
-pattern VK_QUEUE_GRAPHICS_BIT = QueueFlags 0x1
+pattern QueueGraphicsBit = QueueFlags 0x1
 -- | Queue supports compute operations
-pattern VK_QUEUE_COMPUTE_BIT = QueueFlags 0x2
+pattern QueueComputeBit = QueueFlags 0x2
 -- | Queue supports transfer operations
-pattern VK_QUEUE_TRANSFER_BIT = QueueFlags 0x4
+pattern QueueTransferBit = QueueFlags 0x4
 -- | Queue supports sparse resource memory management operations
-pattern VK_QUEUE_SPARSE_BINDING_BIT = QueueFlags 0x8
+pattern QueueSparseBindingBit = QueueFlags 0x8
 
 
 -- ** getPhysicalDeviceProperties

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -140,8 +140,8 @@ instance Storable InstanceCreateInfo where
                 *> poke (ptr `plusPtr` 56) (ppEnabledExtensionNames (poked :: InstanceCreateInfo))
 
 
--- ** vkGetPhysicalDeviceImageFormatProperties
-foreign import ccall "vkGetPhysicalDeviceImageFormatProperties" vkGetPhysicalDeviceImageFormatProperties ::
+-- ** getPhysicalDeviceImageFormatProperties
+foreign import ccall "vkGetPhysicalDeviceImageFormatProperties" getPhysicalDeviceImageFormatProperties ::
   PhysicalDevice ->
   Format ->
     ImageType ->
@@ -526,16 +526,16 @@ instance Storable MemoryHeap where
                 *> poke (ptr `plusPtr` 8) (flags (poked :: MemoryHeap))
 
 
--- ** vkEnumeratePhysicalDevices
-foreign import ccall "vkEnumeratePhysicalDevices" vkEnumeratePhysicalDevices ::
+-- ** enumeratePhysicalDevices
+foreign import ccall "vkEnumeratePhysicalDevices" enumeratePhysicalDevices ::
   Instance -> Ptr Word32 -> Ptr PhysicalDevice -> IO Result
 
--- ** vkGetDeviceProcAddr
-foreign import ccall "vkGetDeviceProcAddr" vkGetDeviceProcAddr ::
+-- ** getDeviceProcAddr
+foreign import ccall "vkGetDeviceProcAddr" getDeviceProcAddr ::
   Device -> Ptr CChar -> IO PFN_vkVoidFunction
 
--- ** vkCreateInstance
-foreign import ccall "vkCreateInstance" vkCreateInstance ::
+-- ** createInstance
+foreign import ccall "vkCreateInstance" createInstance ::
   Ptr InstanceCreateInfo ->
   Ptr AllocationCallbacks -> Ptr Instance -> IO Result
 
@@ -732,12 +732,12 @@ instance Storable PhysicalDeviceSparseProperties where
                 *> poke (ptr `plusPtr` 16) (residencyNonResidentStrict (poked :: PhysicalDeviceSparseProperties))
 
 
--- ** vkGetPhysicalDeviceFeatures
-foreign import ccall "vkGetPhysicalDeviceFeatures" vkGetPhysicalDeviceFeatures ::
+-- ** getPhysicalDeviceFeatures
+foreign import ccall "vkGetPhysicalDeviceFeatures" getPhysicalDeviceFeatures ::
   PhysicalDevice -> Ptr PhysicalDeviceFeatures -> IO ()
 
--- ** vkGetPhysicalDeviceMemoryProperties
-foreign import ccall "vkGetPhysicalDeviceMemoryProperties" vkGetPhysicalDeviceMemoryProperties ::
+-- ** getPhysicalDeviceMemoryProperties
+foreign import ccall "vkGetPhysicalDeviceMemoryProperties" getPhysicalDeviceMemoryProperties ::
   PhysicalDevice -> Ptr PhysicalDeviceMemoryProperties -> IO ()
 
 
@@ -777,8 +777,8 @@ instance Storable PhysicalDeviceProperties where
                 *> poke (ptr `plusPtr` 800) (sparseProperties (poked :: PhysicalDeviceProperties))
 
 
--- ** vkGetPhysicalDeviceQueueFamilyProperties
-foreign import ccall "vkGetPhysicalDeviceQueueFamilyProperties" vkGetPhysicalDeviceQueueFamilyProperties ::
+-- ** getPhysicalDeviceQueueFamilyProperties
+foreign import ccall "vkGetPhysicalDeviceQueueFamilyProperties" getPhysicalDeviceQueueFamilyProperties ::
   PhysicalDevice -> Ptr Word32 -> Ptr QueueFamilyProperties -> IO ()
 
 
@@ -797,8 +797,8 @@ instance Storable MemoryType where
                 *> poke (ptr `plusPtr` 4) (heapIndex (poked :: MemoryType))
 
 
--- ** vkGetInstanceProcAddr
-foreign import ccall "vkGetInstanceProcAddr" vkGetInstanceProcAddr ::
+-- ** getInstanceProcAddr
+foreign import ccall "vkGetInstanceProcAddr" getInstanceProcAddr ::
   Instance -> Ptr CChar -> IO PFN_vkVoidFunction
 
 -- ** VkMemoryPropertyFlags
@@ -841,8 +841,8 @@ pattern VK_MEMORY_PROPERTY_HOST_CACHED_BIT = MemoryPropertyFlags 0x8
 pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = MemoryPropertyFlags 0x10
 
 
--- ** vkDestroyInstance
-foreign import ccall "vkDestroyInstance" vkDestroyInstance ::
+-- ** destroyInstance
+foreign import ccall "vkDestroyInstance" destroyInstance ::
   Instance -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkQueueFlags
@@ -881,8 +881,8 @@ pattern VK_QUEUE_TRANSFER_BIT = QueueFlags 0x4
 pattern VK_QUEUE_SPARSE_BINDING_BIT = QueueFlags 0x8
 
 
--- ** vkGetPhysicalDeviceProperties
-foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperties ::
+-- ** getPhysicalDeviceProperties
+foreign import ccall "vkGetPhysicalDeviceProperties" getPhysicalDeviceProperties ::
   PhysicalDevice -> Ptr PhysicalDeviceProperties -> IO ()
 
 -- ** InstanceCreateFlags
@@ -890,8 +890,8 @@ foreign import ccall "vkGetPhysicalDeviceProperties" vkGetPhysicalDeviceProperti
 newtype InstanceCreateFlags = InstanceCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkGetPhysicalDeviceFormatProperties
-foreign import ccall "vkGetPhysicalDeviceFormatProperties" vkGetPhysicalDeviceFormatProperties ::
+-- ** getPhysicalDeviceFormatProperties
+foreign import ccall "vkGetPhysicalDeviceFormatProperties" getPhysicalDeviceFormatProperties ::
   PhysicalDevice -> Format -> Ptr FormatProperties -> IO ()
 
 

--- a/src/Graphics/Vulkan/DeviceInitialization.hs
+++ b/src/Graphics/Vulkan/DeviceInitialization.hs
@@ -539,7 +539,7 @@ foreign import ccall "vkCreateInstance" createInstance ::
   Ptr InstanceCreateInfo ->
   Ptr AllocationCallbacks -> Ptr Instance -> IO Result
 
--- ** VkFormatFeatureFlags
+-- ** FormatFeatureFlags
 
 newtype FormatFeatureFlags = FormatFeatureFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -636,7 +636,7 @@ instance Storable PhysicalDeviceMemoryProperties where
 data VkInstance_T
 type Instance = Ptr VkInstance_T
 
--- ** VkMemoryHeapFlags
+-- ** MemoryHeapFlags
 
 newtype MemoryHeapFlags = MemoryHeapFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -801,7 +801,7 @@ instance Storable MemoryType where
 foreign import ccall "vkGetInstanceProcAddr" getInstanceProcAddr ::
   Instance -> Ptr CChar -> IO PFN_vkVoidFunction
 
--- ** VkMemoryPropertyFlags
+-- ** MemoryPropertyFlags
 
 newtype MemoryPropertyFlags = MemoryPropertyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -845,7 +845,7 @@ pattern VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT = MemoryPropertyFlags 0x10
 foreign import ccall "vkDestroyInstance" destroyInstance ::
   Instance -> Ptr AllocationCallbacks -> IO ()
 
--- ** VkQueueFlags
+-- ** QueueFlags
 
 newtype QueueFlags = QueueFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -38,7 +38,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( VkInstance(..)
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkBool32(..)
@@ -52,12 +52,12 @@ import Foreign.C.Types( CSize
 
 -- ** vkDebugReportMessageEXT
 foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
-  VkInstance ->
+  Instance ->
   VkDebugReportFlagsEXT ->
     VkDebugReportObjectTypeEXT ->
       Word64 -> CSize -> Int32 -> Ptr CChar -> Ptr CChar -> IO ()
 
-newtype VkDebugReportCallbackEXT = VkDebugReportCallbackEXT Word64
+newtype DebugReportCallbackEXT = DebugReportCallbackEXT Word64
   deriving (Eq, Storable)
 
 -- ** VkDebugReportObjectTypeEXT
@@ -222,11 +222,11 @@ pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = VkDebugReportErrorEXT 1
 
 
 data VkDebugReportCallbackCreateInfoEXT =
-  VkDebugReportCallbackCreateInfoEXT{ vkSType :: VkStructureType 
-                                    , vkPNext :: Ptr Void 
-                                    , vkFlags :: VkDebugReportFlagsEXT 
-                                    , vkPfnCallback :: PFN_vkDebugReportCallbackEXT 
-                                    , vkPUserData :: Ptr Void 
+  VkDebugReportCallbackCreateInfoEXT{ sType :: VkStructureType 
+                                    , pNext :: Ptr Void 
+                                    , flags :: VkDebugReportFlagsEXT 
+                                    , pfnCallback :: PFN_vkDebugReportCallbackEXT 
+                                    , pUserData :: Ptr Void 
                                     }
   deriving (Eq)
 
@@ -238,17 +238,17 @@ instance Storable VkDebugReportCallbackCreateInfoEXT where
                                                 <*> peek (ptr `plusPtr` 16)
                                                 <*> peek (ptr `plusPtr` 24)
                                                 <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 24) (vkPfnCallback (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 32) (vkPUserData (poked :: VkDebugReportCallbackCreateInfoEXT))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 24) (pfnCallback (poked :: VkDebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 32) (pUserData (poked :: VkDebugReportCallbackCreateInfoEXT))
 
 
 -- ** vkDestroyDebugReportCallbackEXT
 foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallbackEXT ::
-  VkInstance ->
-  VkDebugReportCallbackEXT -> Ptr VkAllocationCallbacks -> IO ()
+  Instance ->
+  DebugReportCallbackEXT -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkDebugReportFlagsEXT
 -- | Opaque flag
@@ -264,8 +264,8 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
 
 -- ** vkCreateDebugReportCallbackEXT
 foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
-  VkInstance ->
+  Instance ->
   Ptr VkDebugReportCallbackCreateInfoEXT ->
     Ptr VkAllocationCallbacks ->
-      Ptr VkDebugReportCallbackEXT -> IO VkResult
+      Ptr DebugReportCallbackEXT -> IO VkResult
 

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -10,7 +10,6 @@ import GHC.Read( expectP
                , choose
                )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , FunPtr
@@ -22,15 +21,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -38,16 +28,8 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( Instance(..)
-                                           )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
                       , CChar
-                      , CSize(..)
                       )
 
 -- ** vkDebugReportMessageEXT

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -45,8 +45,8 @@ import Foreign.C.Types( CChar(..)
                       , CSize(..)
                       )
 
--- ** vkDebugReportMessageEXT
-foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
+-- ** debugReportMessageEXT
+foreign import ccall "vkDebugReportMessageEXT" debugReportMessageEXT ::
   Instance ->
   DebugReportFlagsEXT ->
     DebugReportObjectTypeEXT ->
@@ -240,8 +240,8 @@ instance Storable DebugReportCallbackCreateInfoEXT where
                 *> poke (ptr `plusPtr` 32) (pUserData (poked :: DebugReportCallbackCreateInfoEXT))
 
 
--- ** vkDestroyDebugReportCallbackEXT
-foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallbackEXT ::
+-- ** destroyDebugReportCallbackEXT
+foreign import ccall "vkDestroyDebugReportCallbackEXT" destroyDebugReportCallbackEXT ::
   Instance ->
   DebugReportCallbackEXT -> Ptr AllocationCallbacks -> IO ()
 
@@ -291,8 +291,8 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
        Word64 ->
          CSize -> Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO Bool32)
 
--- ** vkCreateDebugReportCallbackEXT
-foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
+-- ** createDebugReportCallbackEXT
+foreign import ccall "vkCreateDebugReportCallbackEXT" createDebugReportCallbackEXT ::
   Instance ->
   Ptr DebugReportCallbackCreateInfoEXT ->
     Ptr AllocationCallbacks -> Ptr DebugReportCallbackEXT -> IO Result

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -53,12 +53,12 @@ foreign import ccall "vkDebugReportMessageEXT" debugReportMessageEXT ::
       Word64 -> CSize -> Int32 -> Ptr CChar -> Ptr CChar -> IO ()
 
 newtype DebugReportCallbackEXT = DebugReportCallbackEXT Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** DebugReportObjectTypeEXT
 
 newtype DebugReportObjectTypeEXT = DebugReportObjectTypeEXT Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show DebugReportObjectTypeEXT where
   showsPrec _ DebugReportObjectTypeUnknownExt = showString "DebugReportObjectTypeUnknownExt"
@@ -192,7 +192,7 @@ pattern DebugReportObjectTypeDebugReportExt = DebugReportObjectTypeEXT 28
 -- ** DebugReportErrorEXT
 
 newtype DebugReportErrorEXT = DebugReportErrorEXT Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show DebugReportErrorEXT where
   showsPrec _ DebugReportErrorNoneExt = showString "DebugReportErrorNoneExt"
@@ -223,7 +223,7 @@ data DebugReportCallbackCreateInfoEXT =
                                   , pfnCallback :: PFN_vkDebugReportCallbackEXT 
                                   , pUserData :: Ptr Void 
                                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DebugReportCallbackCreateInfoEXT where
   sizeOf ~_ = 40
@@ -248,7 +248,7 @@ foreign import ccall "vkDestroyDebugReportCallbackEXT" destroyDebugReportCallbac
 -- ** DebugReportFlagsEXT
 
 newtype DebugReportFlagsEXT = DebugReportFlagsEXT Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show DebugReportFlagsEXT where
   showsPrec _ DebugReportInformationBitExt = showString "DebugReportInformationBitExt"

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -36,10 +36,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       )
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CChar(..)
                       , CSize(..)
@@ -247,7 +247,7 @@ foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallb
 
 -- ** VkDebugReportFlagsEXT
 
-newtype DebugReportFlagsEXT = DebugReportFlagsEXT VkFlags
+newtype DebugReportFlagsEXT = DebugReportFlagsEXT Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DebugReportFlagsEXT where
@@ -289,8 +289,7 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
   (DebugReportFlagsEXT ->
      DebugReportObjectTypeEXT ->
        Word64 ->
-         CSize ->
-           Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO VkBool32)
+         CSize -> Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO Bool32)
 
 -- ** vkCreateDebugReportCallbackEXT
 foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -61,67 +61,67 @@ newtype DebugReportObjectTypeEXT = DebugReportObjectTypeEXT Int32
   deriving (Eq, Storable)
 
 instance Show DebugReportObjectTypeEXT where
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"
-  showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"
+  showsPrec _ DebugReportObjectTypeUnknownExt = showString "DebugReportObjectTypeUnknownExt"
+  showsPrec _ DebugReportObjectTypeInstanceExt = showString "DebugReportObjectTypeInstanceExt"
+  showsPrec _ DebugReportObjectTypePhysicalDeviceExt = showString "DebugReportObjectTypePhysicalDeviceExt"
+  showsPrec _ DebugReportObjectTypeDeviceExt = showString "DebugReportObjectTypeDeviceExt"
+  showsPrec _ DebugReportObjectTypeQueueExt = showString "DebugReportObjectTypeQueueExt"
+  showsPrec _ DebugReportObjectTypeSemaphoreExt = showString "DebugReportObjectTypeSemaphoreExt"
+  showsPrec _ DebugReportObjectTypeCommandBufferExt = showString "DebugReportObjectTypeCommandBufferExt"
+  showsPrec _ DebugReportObjectTypeFenceExt = showString "DebugReportObjectTypeFenceExt"
+  showsPrec _ DebugReportObjectTypeDeviceMemoryExt = showString "DebugReportObjectTypeDeviceMemoryExt"
+  showsPrec _ DebugReportObjectTypeBufferExt = showString "DebugReportObjectTypeBufferExt"
+  showsPrec _ DebugReportObjectTypeImageExt = showString "DebugReportObjectTypeImageExt"
+  showsPrec _ DebugReportObjectTypeEventExt = showString "DebugReportObjectTypeEventExt"
+  showsPrec _ DebugReportObjectTypeQueryPoolExt = showString "DebugReportObjectTypeQueryPoolExt"
+  showsPrec _ DebugReportObjectTypeBufferViewExt = showString "DebugReportObjectTypeBufferViewExt"
+  showsPrec _ DebugReportObjectTypeImageViewExt = showString "DebugReportObjectTypeImageViewExt"
+  showsPrec _ DebugReportObjectTypeShaderModuleExt = showString "DebugReportObjectTypeShaderModuleExt"
+  showsPrec _ DebugReportObjectTypePipelineCacheExt = showString "DebugReportObjectTypePipelineCacheExt"
+  showsPrec _ DebugReportObjectTypePipelineLayoutExt = showString "DebugReportObjectTypePipelineLayoutExt"
+  showsPrec _ DebugReportObjectTypeRenderPassExt = showString "DebugReportObjectTypeRenderPassExt"
+  showsPrec _ DebugReportObjectTypePipelineExt = showString "DebugReportObjectTypePipelineExt"
+  showsPrec _ DebugReportObjectTypeDescriptorSetLayoutExt = showString "DebugReportObjectTypeDescriptorSetLayoutExt"
+  showsPrec _ DebugReportObjectTypeSamplerExt = showString "DebugReportObjectTypeSamplerExt"
+  showsPrec _ DebugReportObjectTypeDescriptorPoolExt = showString "DebugReportObjectTypeDescriptorPoolExt"
+  showsPrec _ DebugReportObjectTypeDescriptorSetExt = showString "DebugReportObjectTypeDescriptorSetExt"
+  showsPrec _ DebugReportObjectTypeFramebufferExt = showString "DebugReportObjectTypeFramebufferExt"
+  showsPrec _ DebugReportObjectTypeCommandPoolExt = showString "DebugReportObjectTypeCommandPoolExt"
+  showsPrec _ DebugReportObjectTypeSurfaceKhrExt = showString "DebugReportObjectTypeSurfaceKhrExt"
+  showsPrec _ DebugReportObjectTypeSwapchainKhrExt = showString "DebugReportObjectTypeSwapchainKhrExt"
+  showsPrec _ DebugReportObjectTypeDebugReportExt = showString "DebugReportObjectTypeDebugReportExt"
   showsPrec p (DebugReportObjectTypeEXT x) = showParen (p >= 11) (showString "DebugReportObjectTypeEXT " . showsPrec 11 x)
 
 instance Read DebugReportObjectTypeEXT where
-  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT)
-                             , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT)
+  readPrec = parens ( choose [ ("DebugReportObjectTypeUnknownExt", pure DebugReportObjectTypeUnknownExt)
+                             , ("DebugReportObjectTypeInstanceExt", pure DebugReportObjectTypeInstanceExt)
+                             , ("DebugReportObjectTypePhysicalDeviceExt", pure DebugReportObjectTypePhysicalDeviceExt)
+                             , ("DebugReportObjectTypeDeviceExt", pure DebugReportObjectTypeDeviceExt)
+                             , ("DebugReportObjectTypeQueueExt", pure DebugReportObjectTypeQueueExt)
+                             , ("DebugReportObjectTypeSemaphoreExt", pure DebugReportObjectTypeSemaphoreExt)
+                             , ("DebugReportObjectTypeCommandBufferExt", pure DebugReportObjectTypeCommandBufferExt)
+                             , ("DebugReportObjectTypeFenceExt", pure DebugReportObjectTypeFenceExt)
+                             , ("DebugReportObjectTypeDeviceMemoryExt", pure DebugReportObjectTypeDeviceMemoryExt)
+                             , ("DebugReportObjectTypeBufferExt", pure DebugReportObjectTypeBufferExt)
+                             , ("DebugReportObjectTypeImageExt", pure DebugReportObjectTypeImageExt)
+                             , ("DebugReportObjectTypeEventExt", pure DebugReportObjectTypeEventExt)
+                             , ("DebugReportObjectTypeQueryPoolExt", pure DebugReportObjectTypeQueryPoolExt)
+                             , ("DebugReportObjectTypeBufferViewExt", pure DebugReportObjectTypeBufferViewExt)
+                             , ("DebugReportObjectTypeImageViewExt", pure DebugReportObjectTypeImageViewExt)
+                             , ("DebugReportObjectTypeShaderModuleExt", pure DebugReportObjectTypeShaderModuleExt)
+                             , ("DebugReportObjectTypePipelineCacheExt", pure DebugReportObjectTypePipelineCacheExt)
+                             , ("DebugReportObjectTypePipelineLayoutExt", pure DebugReportObjectTypePipelineLayoutExt)
+                             , ("DebugReportObjectTypeRenderPassExt", pure DebugReportObjectTypeRenderPassExt)
+                             , ("DebugReportObjectTypePipelineExt", pure DebugReportObjectTypePipelineExt)
+                             , ("DebugReportObjectTypeDescriptorSetLayoutExt", pure DebugReportObjectTypeDescriptorSetLayoutExt)
+                             , ("DebugReportObjectTypeSamplerExt", pure DebugReportObjectTypeSamplerExt)
+                             , ("DebugReportObjectTypeDescriptorPoolExt", pure DebugReportObjectTypeDescriptorPoolExt)
+                             , ("DebugReportObjectTypeDescriptorSetExt", pure DebugReportObjectTypeDescriptorSetExt)
+                             , ("DebugReportObjectTypeFramebufferExt", pure DebugReportObjectTypeFramebufferExt)
+                             , ("DebugReportObjectTypeCommandPoolExt", pure DebugReportObjectTypeCommandPoolExt)
+                             , ("DebugReportObjectTypeSurfaceKhrExt", pure DebugReportObjectTypeSurfaceKhrExt)
+                             , ("DebugReportObjectTypeSwapchainKhrExt", pure DebugReportObjectTypeSwapchainKhrExt)
+                             , ("DebugReportObjectTypeDebugReportExt", pure DebugReportObjectTypeDebugReportExt)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DebugReportObjectTypeEXT")
@@ -131,63 +131,63 @@ instance Read DebugReportObjectTypeEXT where
                     )
 
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = DebugReportObjectTypeEXT 0
+pattern DebugReportObjectTypeUnknownExt = DebugReportObjectTypeEXT 0
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = DebugReportObjectTypeEXT 1
+pattern DebugReportObjectTypeInstanceExt = DebugReportObjectTypeEXT 1
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = DebugReportObjectTypeEXT 2
+pattern DebugReportObjectTypePhysicalDeviceExt = DebugReportObjectTypeEXT 2
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = DebugReportObjectTypeEXT 3
+pattern DebugReportObjectTypeDeviceExt = DebugReportObjectTypeEXT 3
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = DebugReportObjectTypeEXT 4
+pattern DebugReportObjectTypeQueueExt = DebugReportObjectTypeEXT 4
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = DebugReportObjectTypeEXT 5
+pattern DebugReportObjectTypeSemaphoreExt = DebugReportObjectTypeEXT 5
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = DebugReportObjectTypeEXT 6
+pattern DebugReportObjectTypeCommandBufferExt = DebugReportObjectTypeEXT 6
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = DebugReportObjectTypeEXT 7
+pattern DebugReportObjectTypeFenceExt = DebugReportObjectTypeEXT 7
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = DebugReportObjectTypeEXT 8
+pattern DebugReportObjectTypeDeviceMemoryExt = DebugReportObjectTypeEXT 8
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = DebugReportObjectTypeEXT 9
+pattern DebugReportObjectTypeBufferExt = DebugReportObjectTypeEXT 9
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = DebugReportObjectTypeEXT 10
+pattern DebugReportObjectTypeImageExt = DebugReportObjectTypeEXT 10
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = DebugReportObjectTypeEXT 11
+pattern DebugReportObjectTypeEventExt = DebugReportObjectTypeEXT 11
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = DebugReportObjectTypeEXT 12
+pattern DebugReportObjectTypeQueryPoolExt = DebugReportObjectTypeEXT 12
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = DebugReportObjectTypeEXT 13
+pattern DebugReportObjectTypeBufferViewExt = DebugReportObjectTypeEXT 13
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = DebugReportObjectTypeEXT 14
+pattern DebugReportObjectTypeImageViewExt = DebugReportObjectTypeEXT 14
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = DebugReportObjectTypeEXT 15
+pattern DebugReportObjectTypeShaderModuleExt = DebugReportObjectTypeEXT 15
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = DebugReportObjectTypeEXT 16
+pattern DebugReportObjectTypePipelineCacheExt = DebugReportObjectTypeEXT 16
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = DebugReportObjectTypeEXT 17
+pattern DebugReportObjectTypePipelineLayoutExt = DebugReportObjectTypeEXT 17
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = DebugReportObjectTypeEXT 18
+pattern DebugReportObjectTypeRenderPassExt = DebugReportObjectTypeEXT 18
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = DebugReportObjectTypeEXT 19
+pattern DebugReportObjectTypePipelineExt = DebugReportObjectTypeEXT 19
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = DebugReportObjectTypeEXT 20
+pattern DebugReportObjectTypeDescriptorSetLayoutExt = DebugReportObjectTypeEXT 20
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = DebugReportObjectTypeEXT 21
+pattern DebugReportObjectTypeSamplerExt = DebugReportObjectTypeEXT 21
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = DebugReportObjectTypeEXT 22
+pattern DebugReportObjectTypeDescriptorPoolExt = DebugReportObjectTypeEXT 22
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = DebugReportObjectTypeEXT 23
+pattern DebugReportObjectTypeDescriptorSetExt = DebugReportObjectTypeEXT 23
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = DebugReportObjectTypeEXT 24
+pattern DebugReportObjectTypeFramebufferExt = DebugReportObjectTypeEXT 24
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = DebugReportObjectTypeEXT 25
+pattern DebugReportObjectTypeCommandPoolExt = DebugReportObjectTypeEXT 25
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = DebugReportObjectTypeEXT 26
+pattern DebugReportObjectTypeSurfaceKhrExt = DebugReportObjectTypeEXT 26
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = DebugReportObjectTypeEXT 27
+pattern DebugReportObjectTypeSwapchainKhrExt = DebugReportObjectTypeEXT 27
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = DebugReportObjectTypeEXT 28
+pattern DebugReportObjectTypeDebugReportExt = DebugReportObjectTypeEXT 28
 
 -- ** DebugReportErrorEXT
 
@@ -195,13 +195,13 @@ newtype DebugReportErrorEXT = DebugReportErrorEXT Int32
   deriving (Eq, Storable)
 
 instance Show DebugReportErrorEXT where
-  showsPrec _ VK_DEBUG_REPORT_ERROR_NONE_EXT = showString "VK_DEBUG_REPORT_ERROR_NONE_EXT"
-  showsPrec _ VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = showString "VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT"
+  showsPrec _ DebugReportErrorNoneExt = showString "DebugReportErrorNoneExt"
+  showsPrec _ DebugReportErrorCallbackRefExt = showString "DebugReportErrorCallbackRefExt"
   showsPrec p (DebugReportErrorEXT x) = showParen (p >= 11) (showString "DebugReportErrorEXT " . showsPrec 11 x)
 
 instance Read DebugReportErrorEXT where
-  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_ERROR_NONE_EXT", pure VK_DEBUG_REPORT_ERROR_NONE_EXT)
-                             , ("VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT", pure VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT)
+  readPrec = parens ( choose [ ("DebugReportErrorNoneExt", pure DebugReportErrorNoneExt)
+                             , ("DebugReportErrorCallbackRefExt", pure DebugReportErrorCallbackRefExt)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DebugReportErrorEXT")
@@ -211,9 +211,9 @@ instance Read DebugReportErrorEXT where
                     )
 
 
-pattern VK_DEBUG_REPORT_ERROR_NONE_EXT = DebugReportErrorEXT 0
+pattern DebugReportErrorNoneExt = DebugReportErrorEXT 0
 
-pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = DebugReportErrorEXT 1
+pattern DebugReportErrorCallbackRefExt = DebugReportErrorEXT 1
 
 
 data DebugReportCallbackCreateInfoEXT =

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -45,255 +45,254 @@ import Foreign.C.Types( CChar(..)
                       , CSize(..)
                       )
 
--- ** debugReportMessageEXT
-foreign import ccall "vkDebugReportMessageEXT" debugReportMessageEXT ::
+-- ** debugReportMessage
+foreign import ccall "vkDebugReportMessageEXT" debugReportMessage ::
   Instance ->
-  DebugReportFlagsEXT ->
-    DebugReportObjectTypeEXT ->
+  DebugReportFlags ->
+    DebugReportObjectType ->
       Word64 -> CSize -> Int32 -> Ptr CChar -> Ptr CChar -> IO ()
 
-newtype DebugReportCallbackEXT = DebugReportCallbackEXT Word64
+newtype DebugReportCallback = DebugReportCallback Word64
   deriving (Eq, Ord, Storable)
 
--- ** DebugReportObjectTypeEXT
+-- ** DebugReportObjectType
 
-newtype DebugReportObjectTypeEXT = DebugReportObjectTypeEXT Int32
+newtype DebugReportObjectType = DebugReportObjectType Int32
   deriving (Eq, Ord, Storable)
 
-instance Show DebugReportObjectTypeEXT where
-  showsPrec _ DebugReportObjectTypeUnknownExt = showString "DebugReportObjectTypeUnknownExt"
-  showsPrec _ DebugReportObjectTypeInstanceExt = showString "DebugReportObjectTypeInstanceExt"
-  showsPrec _ DebugReportObjectTypePhysicalDeviceExt = showString "DebugReportObjectTypePhysicalDeviceExt"
-  showsPrec _ DebugReportObjectTypeDeviceExt = showString "DebugReportObjectTypeDeviceExt"
-  showsPrec _ DebugReportObjectTypeQueueExt = showString "DebugReportObjectTypeQueueExt"
-  showsPrec _ DebugReportObjectTypeSemaphoreExt = showString "DebugReportObjectTypeSemaphoreExt"
-  showsPrec _ DebugReportObjectTypeCommandBufferExt = showString "DebugReportObjectTypeCommandBufferExt"
-  showsPrec _ DebugReportObjectTypeFenceExt = showString "DebugReportObjectTypeFenceExt"
-  showsPrec _ DebugReportObjectTypeDeviceMemoryExt = showString "DebugReportObjectTypeDeviceMemoryExt"
-  showsPrec _ DebugReportObjectTypeBufferExt = showString "DebugReportObjectTypeBufferExt"
-  showsPrec _ DebugReportObjectTypeImageExt = showString "DebugReportObjectTypeImageExt"
-  showsPrec _ DebugReportObjectTypeEventExt = showString "DebugReportObjectTypeEventExt"
-  showsPrec _ DebugReportObjectTypeQueryPoolExt = showString "DebugReportObjectTypeQueryPoolExt"
-  showsPrec _ DebugReportObjectTypeBufferViewExt = showString "DebugReportObjectTypeBufferViewExt"
-  showsPrec _ DebugReportObjectTypeImageViewExt = showString "DebugReportObjectTypeImageViewExt"
-  showsPrec _ DebugReportObjectTypeShaderModuleExt = showString "DebugReportObjectTypeShaderModuleExt"
-  showsPrec _ DebugReportObjectTypePipelineCacheExt = showString "DebugReportObjectTypePipelineCacheExt"
-  showsPrec _ DebugReportObjectTypePipelineLayoutExt = showString "DebugReportObjectTypePipelineLayoutExt"
-  showsPrec _ DebugReportObjectTypeRenderPassExt = showString "DebugReportObjectTypeRenderPassExt"
-  showsPrec _ DebugReportObjectTypePipelineExt = showString "DebugReportObjectTypePipelineExt"
-  showsPrec _ DebugReportObjectTypeDescriptorSetLayoutExt = showString "DebugReportObjectTypeDescriptorSetLayoutExt"
-  showsPrec _ DebugReportObjectTypeSamplerExt = showString "DebugReportObjectTypeSamplerExt"
-  showsPrec _ DebugReportObjectTypeDescriptorPoolExt = showString "DebugReportObjectTypeDescriptorPoolExt"
-  showsPrec _ DebugReportObjectTypeDescriptorSetExt = showString "DebugReportObjectTypeDescriptorSetExt"
-  showsPrec _ DebugReportObjectTypeFramebufferExt = showString "DebugReportObjectTypeFramebufferExt"
-  showsPrec _ DebugReportObjectTypeCommandPoolExt = showString "DebugReportObjectTypeCommandPoolExt"
-  showsPrec _ DebugReportObjectTypeSurfaceKhrExt = showString "DebugReportObjectTypeSurfaceKhrExt"
-  showsPrec _ DebugReportObjectTypeSwapchainKhrExt = showString "DebugReportObjectTypeSwapchainKhrExt"
-  showsPrec _ DebugReportObjectTypeDebugReportExt = showString "DebugReportObjectTypeDebugReportExt"
-  showsPrec p (DebugReportObjectTypeEXT x) = showParen (p >= 11) (showString "DebugReportObjectTypeEXT " . showsPrec 11 x)
+instance Show DebugReportObjectType where
+  showsPrec _ DebugReportObjectTypeUnknown = showString "DebugReportObjectTypeUnknown"
+  showsPrec _ DebugReportObjectTypeInstance = showString "DebugReportObjectTypeInstance"
+  showsPrec _ DebugReportObjectTypePhysicalDevice = showString "DebugReportObjectTypePhysicalDevice"
+  showsPrec _ DebugReportObjectTypeDevice = showString "DebugReportObjectTypeDevice"
+  showsPrec _ DebugReportObjectTypeQueue = showString "DebugReportObjectTypeQueue"
+  showsPrec _ DebugReportObjectTypeSemaphore = showString "DebugReportObjectTypeSemaphore"
+  showsPrec _ DebugReportObjectTypeCommandBuffer = showString "DebugReportObjectTypeCommandBuffer"
+  showsPrec _ DebugReportObjectTypeFence = showString "DebugReportObjectTypeFence"
+  showsPrec _ DebugReportObjectTypeDeviceMemory = showString "DebugReportObjectTypeDeviceMemory"
+  showsPrec _ DebugReportObjectTypeBuffer = showString "DebugReportObjectTypeBuffer"
+  showsPrec _ DebugReportObjectTypeImage = showString "DebugReportObjectTypeImage"
+  showsPrec _ DebugReportObjectTypeEvent = showString "DebugReportObjectTypeEvent"
+  showsPrec _ DebugReportObjectTypeQueryPool = showString "DebugReportObjectTypeQueryPool"
+  showsPrec _ DebugReportObjectTypeBufferView = showString "DebugReportObjectTypeBufferView"
+  showsPrec _ DebugReportObjectTypeImageView = showString "DebugReportObjectTypeImageView"
+  showsPrec _ DebugReportObjectTypeShaderModule = showString "DebugReportObjectTypeShaderModule"
+  showsPrec _ DebugReportObjectTypePipelineCache = showString "DebugReportObjectTypePipelineCache"
+  showsPrec _ DebugReportObjectTypePipelineLayout = showString "DebugReportObjectTypePipelineLayout"
+  showsPrec _ DebugReportObjectTypeRenderPass = showString "DebugReportObjectTypeRenderPass"
+  showsPrec _ DebugReportObjectTypePipeline = showString "DebugReportObjectTypePipeline"
+  showsPrec _ DebugReportObjectTypeDescriptorSetLayout = showString "DebugReportObjectTypeDescriptorSetLayout"
+  showsPrec _ DebugReportObjectTypeSampler = showString "DebugReportObjectTypeSampler"
+  showsPrec _ DebugReportObjectTypeDescriptorPool = showString "DebugReportObjectTypeDescriptorPool"
+  showsPrec _ DebugReportObjectTypeDescriptorSet = showString "DebugReportObjectTypeDescriptorSet"
+  showsPrec _ DebugReportObjectTypeFramebuffer = showString "DebugReportObjectTypeFramebuffer"
+  showsPrec _ DebugReportObjectTypeCommandPool = showString "DebugReportObjectTypeCommandPool"
+  showsPrec _ DebugReportObjectTypeSurfaceKhr = showString "DebugReportObjectTypeSurfaceKhr"
+  showsPrec _ DebugReportObjectTypeSwapchainKhr = showString "DebugReportObjectTypeSwapchainKhr"
+  showsPrec _ DebugReportObjectTypeDebugReport = showString "DebugReportObjectTypeDebugReport"
+  showsPrec p (DebugReportObjectType x) = showParen (p >= 11) (showString "DebugReportObjectType " . showsPrec 11 x)
 
-instance Read DebugReportObjectTypeEXT where
-  readPrec = parens ( choose [ ("DebugReportObjectTypeUnknownExt", pure DebugReportObjectTypeUnknownExt)
-                             , ("DebugReportObjectTypeInstanceExt", pure DebugReportObjectTypeInstanceExt)
-                             , ("DebugReportObjectTypePhysicalDeviceExt", pure DebugReportObjectTypePhysicalDeviceExt)
-                             , ("DebugReportObjectTypeDeviceExt", pure DebugReportObjectTypeDeviceExt)
-                             , ("DebugReportObjectTypeQueueExt", pure DebugReportObjectTypeQueueExt)
-                             , ("DebugReportObjectTypeSemaphoreExt", pure DebugReportObjectTypeSemaphoreExt)
-                             , ("DebugReportObjectTypeCommandBufferExt", pure DebugReportObjectTypeCommandBufferExt)
-                             , ("DebugReportObjectTypeFenceExt", pure DebugReportObjectTypeFenceExt)
-                             , ("DebugReportObjectTypeDeviceMemoryExt", pure DebugReportObjectTypeDeviceMemoryExt)
-                             , ("DebugReportObjectTypeBufferExt", pure DebugReportObjectTypeBufferExt)
-                             , ("DebugReportObjectTypeImageExt", pure DebugReportObjectTypeImageExt)
-                             , ("DebugReportObjectTypeEventExt", pure DebugReportObjectTypeEventExt)
-                             , ("DebugReportObjectTypeQueryPoolExt", pure DebugReportObjectTypeQueryPoolExt)
-                             , ("DebugReportObjectTypeBufferViewExt", pure DebugReportObjectTypeBufferViewExt)
-                             , ("DebugReportObjectTypeImageViewExt", pure DebugReportObjectTypeImageViewExt)
-                             , ("DebugReportObjectTypeShaderModuleExt", pure DebugReportObjectTypeShaderModuleExt)
-                             , ("DebugReportObjectTypePipelineCacheExt", pure DebugReportObjectTypePipelineCacheExt)
-                             , ("DebugReportObjectTypePipelineLayoutExt", pure DebugReportObjectTypePipelineLayoutExt)
-                             , ("DebugReportObjectTypeRenderPassExt", pure DebugReportObjectTypeRenderPassExt)
-                             , ("DebugReportObjectTypePipelineExt", pure DebugReportObjectTypePipelineExt)
-                             , ("DebugReportObjectTypeDescriptorSetLayoutExt", pure DebugReportObjectTypeDescriptorSetLayoutExt)
-                             , ("DebugReportObjectTypeSamplerExt", pure DebugReportObjectTypeSamplerExt)
-                             , ("DebugReportObjectTypeDescriptorPoolExt", pure DebugReportObjectTypeDescriptorPoolExt)
-                             , ("DebugReportObjectTypeDescriptorSetExt", pure DebugReportObjectTypeDescriptorSetExt)
-                             , ("DebugReportObjectTypeFramebufferExt", pure DebugReportObjectTypeFramebufferExt)
-                             , ("DebugReportObjectTypeCommandPoolExt", pure DebugReportObjectTypeCommandPoolExt)
-                             , ("DebugReportObjectTypeSurfaceKhrExt", pure DebugReportObjectTypeSurfaceKhrExt)
-                             , ("DebugReportObjectTypeSwapchainKhrExt", pure DebugReportObjectTypeSwapchainKhrExt)
-                             , ("DebugReportObjectTypeDebugReportExt", pure DebugReportObjectTypeDebugReportExt)
+instance Read DebugReportObjectType where
+  readPrec = parens ( choose [ ("DebugReportObjectTypeUnknown", pure DebugReportObjectTypeUnknown)
+                             , ("DebugReportObjectTypeInstance", pure DebugReportObjectTypeInstance)
+                             , ("DebugReportObjectTypePhysicalDevice", pure DebugReportObjectTypePhysicalDevice)
+                             , ("DebugReportObjectTypeDevice", pure DebugReportObjectTypeDevice)
+                             , ("DebugReportObjectTypeQueue", pure DebugReportObjectTypeQueue)
+                             , ("DebugReportObjectTypeSemaphore", pure DebugReportObjectTypeSemaphore)
+                             , ("DebugReportObjectTypeCommandBuffer", pure DebugReportObjectTypeCommandBuffer)
+                             , ("DebugReportObjectTypeFence", pure DebugReportObjectTypeFence)
+                             , ("DebugReportObjectTypeDeviceMemory", pure DebugReportObjectTypeDeviceMemory)
+                             , ("DebugReportObjectTypeBuffer", pure DebugReportObjectTypeBuffer)
+                             , ("DebugReportObjectTypeImage", pure DebugReportObjectTypeImage)
+                             , ("DebugReportObjectTypeEvent", pure DebugReportObjectTypeEvent)
+                             , ("DebugReportObjectTypeQueryPool", pure DebugReportObjectTypeQueryPool)
+                             , ("DebugReportObjectTypeBufferView", pure DebugReportObjectTypeBufferView)
+                             , ("DebugReportObjectTypeImageView", pure DebugReportObjectTypeImageView)
+                             , ("DebugReportObjectTypeShaderModule", pure DebugReportObjectTypeShaderModule)
+                             , ("DebugReportObjectTypePipelineCache", pure DebugReportObjectTypePipelineCache)
+                             , ("DebugReportObjectTypePipelineLayout", pure DebugReportObjectTypePipelineLayout)
+                             , ("DebugReportObjectTypeRenderPass", pure DebugReportObjectTypeRenderPass)
+                             , ("DebugReportObjectTypePipeline", pure DebugReportObjectTypePipeline)
+                             , ("DebugReportObjectTypeDescriptorSetLayout", pure DebugReportObjectTypeDescriptorSetLayout)
+                             , ("DebugReportObjectTypeSampler", pure DebugReportObjectTypeSampler)
+                             , ("DebugReportObjectTypeDescriptorPool", pure DebugReportObjectTypeDescriptorPool)
+                             , ("DebugReportObjectTypeDescriptorSet", pure DebugReportObjectTypeDescriptorSet)
+                             , ("DebugReportObjectTypeFramebuffer", pure DebugReportObjectTypeFramebuffer)
+                             , ("DebugReportObjectTypeCommandPool", pure DebugReportObjectTypeCommandPool)
+                             , ("DebugReportObjectTypeSurfaceKhr", pure DebugReportObjectTypeSurfaceKhr)
+                             , ("DebugReportObjectTypeSwapchainKhr", pure DebugReportObjectTypeSwapchainKhr)
+                             , ("DebugReportObjectTypeDebugReport", pure DebugReportObjectTypeDebugReport)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "DebugReportObjectTypeEXT")
+                        expectP (Ident "DebugReportObjectType")
                         v <- step readPrec
-                        pure (DebugReportObjectTypeEXT v)
+                        pure (DebugReportObjectType v)
                         )
                     )
 
 
-pattern DebugReportObjectTypeUnknownExt = DebugReportObjectTypeEXT 0
+pattern DebugReportObjectTypeUnknown = DebugReportObjectType 0
 
-pattern DebugReportObjectTypeInstanceExt = DebugReportObjectTypeEXT 1
+pattern DebugReportObjectTypeInstance = DebugReportObjectType 1
 
-pattern DebugReportObjectTypePhysicalDeviceExt = DebugReportObjectTypeEXT 2
+pattern DebugReportObjectTypePhysicalDevice = DebugReportObjectType 2
 
-pattern DebugReportObjectTypeDeviceExt = DebugReportObjectTypeEXT 3
+pattern DebugReportObjectTypeDevice = DebugReportObjectType 3
 
-pattern DebugReportObjectTypeQueueExt = DebugReportObjectTypeEXT 4
+pattern DebugReportObjectTypeQueue = DebugReportObjectType 4
 
-pattern DebugReportObjectTypeSemaphoreExt = DebugReportObjectTypeEXT 5
+pattern DebugReportObjectTypeSemaphore = DebugReportObjectType 5
 
-pattern DebugReportObjectTypeCommandBufferExt = DebugReportObjectTypeEXT 6
+pattern DebugReportObjectTypeCommandBuffer = DebugReportObjectType 6
 
-pattern DebugReportObjectTypeFenceExt = DebugReportObjectTypeEXT 7
+pattern DebugReportObjectTypeFence = DebugReportObjectType 7
 
-pattern DebugReportObjectTypeDeviceMemoryExt = DebugReportObjectTypeEXT 8
+pattern DebugReportObjectTypeDeviceMemory = DebugReportObjectType 8
 
-pattern DebugReportObjectTypeBufferExt = DebugReportObjectTypeEXT 9
+pattern DebugReportObjectTypeBuffer = DebugReportObjectType 9
 
-pattern DebugReportObjectTypeImageExt = DebugReportObjectTypeEXT 10
+pattern DebugReportObjectTypeImage = DebugReportObjectType 10
 
-pattern DebugReportObjectTypeEventExt = DebugReportObjectTypeEXT 11
+pattern DebugReportObjectTypeEvent = DebugReportObjectType 11
 
-pattern DebugReportObjectTypeQueryPoolExt = DebugReportObjectTypeEXT 12
+pattern DebugReportObjectTypeQueryPool = DebugReportObjectType 12
 
-pattern DebugReportObjectTypeBufferViewExt = DebugReportObjectTypeEXT 13
+pattern DebugReportObjectTypeBufferView = DebugReportObjectType 13
 
-pattern DebugReportObjectTypeImageViewExt = DebugReportObjectTypeEXT 14
+pattern DebugReportObjectTypeImageView = DebugReportObjectType 14
 
-pattern DebugReportObjectTypeShaderModuleExt = DebugReportObjectTypeEXT 15
+pattern DebugReportObjectTypeShaderModule = DebugReportObjectType 15
 
-pattern DebugReportObjectTypePipelineCacheExt = DebugReportObjectTypeEXT 16
+pattern DebugReportObjectTypePipelineCache = DebugReportObjectType 16
 
-pattern DebugReportObjectTypePipelineLayoutExt = DebugReportObjectTypeEXT 17
+pattern DebugReportObjectTypePipelineLayout = DebugReportObjectType 17
 
-pattern DebugReportObjectTypeRenderPassExt = DebugReportObjectTypeEXT 18
+pattern DebugReportObjectTypeRenderPass = DebugReportObjectType 18
 
-pattern DebugReportObjectTypePipelineExt = DebugReportObjectTypeEXT 19
+pattern DebugReportObjectTypePipeline = DebugReportObjectType 19
 
-pattern DebugReportObjectTypeDescriptorSetLayoutExt = DebugReportObjectTypeEXT 20
+pattern DebugReportObjectTypeDescriptorSetLayout = DebugReportObjectType 20
 
-pattern DebugReportObjectTypeSamplerExt = DebugReportObjectTypeEXT 21
+pattern DebugReportObjectTypeSampler = DebugReportObjectType 21
 
-pattern DebugReportObjectTypeDescriptorPoolExt = DebugReportObjectTypeEXT 22
+pattern DebugReportObjectTypeDescriptorPool = DebugReportObjectType 22
 
-pattern DebugReportObjectTypeDescriptorSetExt = DebugReportObjectTypeEXT 23
+pattern DebugReportObjectTypeDescriptorSet = DebugReportObjectType 23
 
-pattern DebugReportObjectTypeFramebufferExt = DebugReportObjectTypeEXT 24
+pattern DebugReportObjectTypeFramebuffer = DebugReportObjectType 24
 
-pattern DebugReportObjectTypeCommandPoolExt = DebugReportObjectTypeEXT 25
+pattern DebugReportObjectTypeCommandPool = DebugReportObjectType 25
 
-pattern DebugReportObjectTypeSurfaceKhrExt = DebugReportObjectTypeEXT 26
+pattern DebugReportObjectTypeSurfaceKhr = DebugReportObjectType 26
 
-pattern DebugReportObjectTypeSwapchainKhrExt = DebugReportObjectTypeEXT 27
+pattern DebugReportObjectTypeSwapchainKhr = DebugReportObjectType 27
 
-pattern DebugReportObjectTypeDebugReportExt = DebugReportObjectTypeEXT 28
+pattern DebugReportObjectTypeDebugReport = DebugReportObjectType 28
 
--- ** DebugReportErrorEXT
+-- ** DebugReportError
 
-newtype DebugReportErrorEXT = DebugReportErrorEXT Int32
+newtype DebugReportError = DebugReportError Int32
   deriving (Eq, Ord, Storable)
 
-instance Show DebugReportErrorEXT where
-  showsPrec _ DebugReportErrorNoneExt = showString "DebugReportErrorNoneExt"
-  showsPrec _ DebugReportErrorCallbackRefExt = showString "DebugReportErrorCallbackRefExt"
-  showsPrec p (DebugReportErrorEXT x) = showParen (p >= 11) (showString "DebugReportErrorEXT " . showsPrec 11 x)
+instance Show DebugReportError where
+  showsPrec _ DebugReportErrorNone = showString "DebugReportErrorNone"
+  showsPrec _ DebugReportErrorCallbackRef = showString "DebugReportErrorCallbackRef"
+  showsPrec p (DebugReportError x) = showParen (p >= 11) (showString "DebugReportError " . showsPrec 11 x)
 
-instance Read DebugReportErrorEXT where
-  readPrec = parens ( choose [ ("DebugReportErrorNoneExt", pure DebugReportErrorNoneExt)
-                             , ("DebugReportErrorCallbackRefExt", pure DebugReportErrorCallbackRefExt)
+instance Read DebugReportError where
+  readPrec = parens ( choose [ ("DebugReportErrorNone", pure DebugReportErrorNone)
+                             , ("DebugReportErrorCallbackRef", pure DebugReportErrorCallbackRef)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "DebugReportErrorEXT")
+                        expectP (Ident "DebugReportError")
                         v <- step readPrec
-                        pure (DebugReportErrorEXT v)
+                        pure (DebugReportError v)
                         )
                     )
 
 
-pattern DebugReportErrorNoneExt = DebugReportErrorEXT 0
+pattern DebugReportErrorNone = DebugReportError 0
 
-pattern DebugReportErrorCallbackRefExt = DebugReportErrorEXT 1
+pattern DebugReportErrorCallbackRef = DebugReportError 1
 
 
-data DebugReportCallbackCreateInfoEXT =
-  DebugReportCallbackCreateInfoEXT{ sType :: StructureType 
-                                  , pNext :: Ptr Void 
-                                  , flags :: DebugReportFlagsEXT 
-                                  , pfnCallback :: PFN_vkDebugReportCallbackEXT 
-                                  , pUserData :: Ptr Void 
-                                  }
+data DebugReportCallbackCreateInfo =
+  DebugReportCallbackCreateInfo{ sType :: StructureType 
+                               , pNext :: Ptr Void 
+                               , flags :: DebugReportFlags 
+                               , pfnCallback :: PFN_vkDebugReportCallbackEXT 
+                               , pUserData :: Ptr Void 
+                               }
   deriving (Eq, Ord)
 
-instance Storable DebugReportCallbackCreateInfoEXT where
+instance Storable DebugReportCallbackCreateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = DebugReportCallbackCreateInfoEXT <$> peek (ptr `plusPtr` 0)
-                                              <*> peek (ptr `plusPtr` 8)
-                                              <*> peek (ptr `plusPtr` 16)
-                                              <*> peek (ptr `plusPtr` 24)
-                                              <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: DebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: DebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 24) (pfnCallback (poked :: DebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 32) (pUserData (poked :: DebugReportCallbackCreateInfoEXT))
+  peek ptr = DebugReportCallbackCreateInfo <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 8)
+                                           <*> peek (ptr `plusPtr` 16)
+                                           <*> peek (ptr `plusPtr` 24)
+                                           <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DebugReportCallbackCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DebugReportCallbackCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DebugReportCallbackCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pfnCallback (poked :: DebugReportCallbackCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pUserData (poked :: DebugReportCallbackCreateInfo))
 
 
--- ** destroyDebugReportCallbackEXT
-foreign import ccall "vkDestroyDebugReportCallbackEXT" destroyDebugReportCallbackEXT ::
-  Instance ->
-  DebugReportCallbackEXT -> Ptr AllocationCallbacks -> IO ()
+-- ** destroyDebugReportCallback
+foreign import ccall "vkDestroyDebugReportCallbackEXT" destroyDebugReportCallback ::
+  Instance -> DebugReportCallback -> Ptr AllocationCallbacks -> IO ()
 
--- ** DebugReportFlagsEXT
+-- ** DebugReportFlags
 
-newtype DebugReportFlagsEXT = DebugReportFlagsEXT Flags
+newtype DebugReportFlags = DebugReportFlags Flags
   deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
-instance Show DebugReportFlagsEXT where
-  showsPrec _ DebugReportInformationBitExt = showString "DebugReportInformationBitExt"
-  showsPrec _ DebugReportWarningBitExt = showString "DebugReportWarningBitExt"
-  showsPrec _ DebugReportPerformanceWarningBitExt = showString "DebugReportPerformanceWarningBitExt"
-  showsPrec _ DebugReportErrorBitExt = showString "DebugReportErrorBitExt"
-  showsPrec _ DebugReportDebugBitExt = showString "DebugReportDebugBitExt"
+instance Show DebugReportFlags where
+  showsPrec _ DebugReportInformationBit = showString "DebugReportInformationBit"
+  showsPrec _ DebugReportWarningBit = showString "DebugReportWarningBit"
+  showsPrec _ DebugReportPerformanceWarningBit = showString "DebugReportPerformanceWarningBit"
+  showsPrec _ DebugReportErrorBit = showString "DebugReportErrorBit"
+  showsPrec _ DebugReportDebugBit = showString "DebugReportDebugBit"
   
-  showsPrec p (DebugReportFlagsEXT x) = showParen (p >= 11) (showString "DebugReportFlagsEXT " . showsPrec 11 x)
+  showsPrec p (DebugReportFlags x) = showParen (p >= 11) (showString "DebugReportFlags " . showsPrec 11 x)
 
-instance Read DebugReportFlagsEXT where
-  readPrec = parens ( choose [ ("DebugReportInformationBitExt", pure DebugReportInformationBitExt)
-                             , ("DebugReportWarningBitExt", pure DebugReportWarningBitExt)
-                             , ("DebugReportPerformanceWarningBitExt", pure DebugReportPerformanceWarningBitExt)
-                             , ("DebugReportErrorBitExt", pure DebugReportErrorBitExt)
-                             , ("DebugReportDebugBitExt", pure DebugReportDebugBitExt)
+instance Read DebugReportFlags where
+  readPrec = parens ( choose [ ("DebugReportInformationBit", pure DebugReportInformationBit)
+                             , ("DebugReportWarningBit", pure DebugReportWarningBit)
+                             , ("DebugReportPerformanceWarningBit", pure DebugReportPerformanceWarningBit)
+                             , ("DebugReportErrorBit", pure DebugReportErrorBit)
+                             , ("DebugReportDebugBit", pure DebugReportDebugBit)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "DebugReportFlagsEXT")
+                        expectP (Ident "DebugReportFlags")
                         v <- step readPrec
-                        pure (DebugReportFlagsEXT v)
+                        pure (DebugReportFlags v)
                         )
                     )
 
 
-pattern DebugReportInformationBitExt = DebugReportFlagsEXT 0x1
+pattern DebugReportInformationBit = DebugReportFlags 0x1
 
-pattern DebugReportWarningBitExt = DebugReportFlagsEXT 0x2
+pattern DebugReportWarningBit = DebugReportFlags 0x2
 
-pattern DebugReportPerformanceWarningBitExt = DebugReportFlagsEXT 0x4
+pattern DebugReportPerformanceWarningBit = DebugReportFlags 0x4
 
-pattern DebugReportErrorBitExt = DebugReportFlagsEXT 0x8
+pattern DebugReportErrorBit = DebugReportFlags 0x8
 
-pattern DebugReportDebugBitExt = DebugReportFlagsEXT 0x10
+pattern DebugReportDebugBit = DebugReportFlags 0x10
 
 
 type PFN_vkDebugReportCallbackEXT = FunPtr
-  (DebugReportFlagsEXT ->
-     DebugReportObjectTypeEXT ->
+  (DebugReportFlags ->
+     DebugReportObjectType ->
        Word64 ->
          CSize -> Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO Bool32)
 
--- ** createDebugReportCallbackEXT
-foreign import ccall "vkCreateDebugReportCallbackEXT" createDebugReportCallbackEXT ::
+-- ** createDebugReportCallback
+foreign import ccall "vkCreateDebugReportCallbackEXT" createDebugReportCallback ::
   Instance ->
-  Ptr DebugReportCallbackCreateInfoEXT ->
-    Ptr AllocationCallbacks -> Ptr DebugReportCallbackEXT -> IO Result
+  Ptr DebugReportCallbackCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr DebugReportCallback -> IO Result
 

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -36,10 +36,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       )
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CChar(..)
                       , CSize(..)
@@ -48,19 +48,19 @@ import Foreign.C.Types( CChar(..)
 -- ** vkDebugReportMessageEXT
 foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
   Instance ->
-  VkDebugReportFlagsEXT ->
-    VkDebugReportObjectTypeEXT ->
+  DebugReportFlagsEXT ->
+    DebugReportObjectTypeEXT ->
       Word64 -> CSize -> Int32 -> Ptr CChar -> Ptr CChar -> IO ()
 
 newtype DebugReportCallbackEXT = DebugReportCallbackEXT Word64
   deriving (Eq, Storable)
 
--- ** VkDebugReportObjectTypeEXT
+-- ** DebugReportObjectTypeEXT
 
-newtype VkDebugReportObjectTypeEXT = VkDebugReportObjectTypeEXT Int32
+newtype DebugReportObjectTypeEXT = DebugReportObjectTypeEXT Int32
   deriving (Eq, Storable)
 
-instance Show VkDebugReportObjectTypeEXT where
+instance Show DebugReportObjectTypeEXT where
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT"
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT"
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT"
@@ -90,9 +90,9 @@ instance Show VkDebugReportObjectTypeEXT where
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT"
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT"
   showsPrec _ VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = showString "VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT"
-  showsPrec p (VkDebugReportObjectTypeEXT x) = showParen (p >= 11) (showString "VkDebugReportObjectTypeEXT " . showsPrec 11 x)
+  showsPrec p (DebugReportObjectTypeEXT x) = showParen (p >= 11) (showString "DebugReportObjectTypeEXT " . showsPrec 11 x)
 
-instance Read VkDebugReportObjectTypeEXT where
+instance Read DebugReportObjectTypeEXT where
   readPrec = parens ( choose [ ("VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT)
                              , ("VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT)
                              , ("VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT)
@@ -124,102 +124,102 @@ instance Read VkDebugReportObjectTypeEXT where
                              , ("VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT", pure VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDebugReportObjectTypeEXT")
+                        expectP (Ident "DebugReportObjectTypeEXT")
                         v <- step readPrec
-                        pure (VkDebugReportObjectTypeEXT v)
+                        pure (DebugReportObjectTypeEXT v)
                         )
                     )
 
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = VkDebugReportObjectTypeEXT 0
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT = DebugReportObjectTypeEXT 0
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = VkDebugReportObjectTypeEXT 1
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT = DebugReportObjectTypeEXT 1
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = VkDebugReportObjectTypeEXT 2
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT = DebugReportObjectTypeEXT 2
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = VkDebugReportObjectTypeEXT 3
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT = DebugReportObjectTypeEXT 3
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = VkDebugReportObjectTypeEXT 4
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT = DebugReportObjectTypeEXT 4
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = VkDebugReportObjectTypeEXT 5
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT = DebugReportObjectTypeEXT 5
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = VkDebugReportObjectTypeEXT 6
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT = DebugReportObjectTypeEXT 6
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = VkDebugReportObjectTypeEXT 7
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT = DebugReportObjectTypeEXT 7
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = VkDebugReportObjectTypeEXT 8
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT = DebugReportObjectTypeEXT 8
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = VkDebugReportObjectTypeEXT 9
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT = DebugReportObjectTypeEXT 9
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = VkDebugReportObjectTypeEXT 10
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT = DebugReportObjectTypeEXT 10
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = VkDebugReportObjectTypeEXT 11
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT = DebugReportObjectTypeEXT 11
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = VkDebugReportObjectTypeEXT 12
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT = DebugReportObjectTypeEXT 12
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = VkDebugReportObjectTypeEXT 13
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT = DebugReportObjectTypeEXT 13
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = VkDebugReportObjectTypeEXT 14
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT = DebugReportObjectTypeEXT 14
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = VkDebugReportObjectTypeEXT 15
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT = DebugReportObjectTypeEXT 15
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = VkDebugReportObjectTypeEXT 16
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT = DebugReportObjectTypeEXT 16
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = VkDebugReportObjectTypeEXT 17
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT = DebugReportObjectTypeEXT 17
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = VkDebugReportObjectTypeEXT 18
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT = DebugReportObjectTypeEXT 18
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = VkDebugReportObjectTypeEXT 19
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT = DebugReportObjectTypeEXT 19
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = VkDebugReportObjectTypeEXT 20
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT = DebugReportObjectTypeEXT 20
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = VkDebugReportObjectTypeEXT 21
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT = DebugReportObjectTypeEXT 21
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = VkDebugReportObjectTypeEXT 22
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT = DebugReportObjectTypeEXT 22
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = VkDebugReportObjectTypeEXT 23
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT = DebugReportObjectTypeEXT 23
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = VkDebugReportObjectTypeEXT 24
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT = DebugReportObjectTypeEXT 24
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = VkDebugReportObjectTypeEXT 25
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT = DebugReportObjectTypeEXT 25
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = VkDebugReportObjectTypeEXT 26
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT = DebugReportObjectTypeEXT 26
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = VkDebugReportObjectTypeEXT 27
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT = DebugReportObjectTypeEXT 27
 
-pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = VkDebugReportObjectTypeEXT 28
+pattern VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_EXT = DebugReportObjectTypeEXT 28
 
--- ** VkDebugReportErrorEXT
+-- ** DebugReportErrorEXT
 
-newtype VkDebugReportErrorEXT = VkDebugReportErrorEXT Int32
+newtype DebugReportErrorEXT = DebugReportErrorEXT Int32
   deriving (Eq, Storable)
 
-instance Show VkDebugReportErrorEXT where
+instance Show DebugReportErrorEXT where
   showsPrec _ VK_DEBUG_REPORT_ERROR_NONE_EXT = showString "VK_DEBUG_REPORT_ERROR_NONE_EXT"
   showsPrec _ VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = showString "VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT"
-  showsPrec p (VkDebugReportErrorEXT x) = showParen (p >= 11) (showString "VkDebugReportErrorEXT " . showsPrec 11 x)
+  showsPrec p (DebugReportErrorEXT x) = showParen (p >= 11) (showString "DebugReportErrorEXT " . showsPrec 11 x)
 
-instance Read VkDebugReportErrorEXT where
+instance Read DebugReportErrorEXT where
   readPrec = parens ( choose [ ("VK_DEBUG_REPORT_ERROR_NONE_EXT", pure VK_DEBUG_REPORT_ERROR_NONE_EXT)
                              , ("VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT", pure VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDebugReportErrorEXT")
+                        expectP (Ident "DebugReportErrorEXT")
                         v <- step readPrec
-                        pure (VkDebugReportErrorEXT v)
+                        pure (DebugReportErrorEXT v)
                         )
                     )
 
 
-pattern VK_DEBUG_REPORT_ERROR_NONE_EXT = VkDebugReportErrorEXT 0
+pattern VK_DEBUG_REPORT_ERROR_NONE_EXT = DebugReportErrorEXT 0
 
-pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = VkDebugReportErrorEXT 1
+pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = DebugReportErrorEXT 1
 
 
 data DebugReportCallbackCreateInfoEXT =
-  DebugReportCallbackCreateInfoEXT{ sType :: VkStructureType 
+  DebugReportCallbackCreateInfoEXT{ sType :: StructureType 
                                   , pNext :: Ptr Void 
-                                  , flags :: VkDebugReportFlagsEXT 
+                                  , flags :: DebugReportFlagsEXT 
                                   , pfnCallback :: PFN_vkDebugReportCallbackEXT 
                                   , pUserData :: Ptr Void 
                                   }
@@ -247,19 +247,19 @@ foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallb
 
 -- ** VkDebugReportFlagsEXT
 
-newtype VkDebugReportFlagsEXT = VkDebugReportFlagsEXT VkFlags
+newtype DebugReportFlagsEXT = DebugReportFlagsEXT VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkDebugReportFlagsEXT where
+instance Show DebugReportFlagsEXT where
   showsPrec _ VK_DEBUG_REPORT_INFORMATION_BIT_EXT = showString "VK_DEBUG_REPORT_INFORMATION_BIT_EXT"
   showsPrec _ VK_DEBUG_REPORT_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_WARNING_BIT_EXT"
   showsPrec _ VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT"
   showsPrec _ VK_DEBUG_REPORT_ERROR_BIT_EXT = showString "VK_DEBUG_REPORT_ERROR_BIT_EXT"
   showsPrec _ VK_DEBUG_REPORT_DEBUG_BIT_EXT = showString "VK_DEBUG_REPORT_DEBUG_BIT_EXT"
   
-  showsPrec p (VkDebugReportFlagsEXT x) = showParen (p >= 11) (showString "VkDebugReportFlagsEXT " . showsPrec 11 x)
+  showsPrec p (DebugReportFlagsEXT x) = showParen (p >= 11) (showString "DebugReportFlagsEXT " . showsPrec 11 x)
 
-instance Read VkDebugReportFlagsEXT where
+instance Read DebugReportFlagsEXT where
   readPrec = parens ( choose [ ("VK_DEBUG_REPORT_INFORMATION_BIT_EXT", pure VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
                              , ("VK_DEBUG_REPORT_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_WARNING_BIT_EXT)
                              , ("VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
@@ -267,27 +267,27 @@ instance Read VkDebugReportFlagsEXT where
                              , ("VK_DEBUG_REPORT_DEBUG_BIT_EXT", pure VK_DEBUG_REPORT_DEBUG_BIT_EXT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDebugReportFlagsEXT")
+                        expectP (Ident "DebugReportFlagsEXT")
                         v <- step readPrec
-                        pure (VkDebugReportFlagsEXT v)
+                        pure (DebugReportFlagsEXT v)
                         )
                     )
 
 
-pattern VK_DEBUG_REPORT_INFORMATION_BIT_EXT = VkDebugReportFlagsEXT 0x1
+pattern VK_DEBUG_REPORT_INFORMATION_BIT_EXT = DebugReportFlagsEXT 0x1
 
-pattern VK_DEBUG_REPORT_WARNING_BIT_EXT = VkDebugReportFlagsEXT 0x2
+pattern VK_DEBUG_REPORT_WARNING_BIT_EXT = DebugReportFlagsEXT 0x2
 
-pattern VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = VkDebugReportFlagsEXT 0x4
+pattern VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = DebugReportFlagsEXT 0x4
 
-pattern VK_DEBUG_REPORT_ERROR_BIT_EXT = VkDebugReportFlagsEXT 0x8
+pattern VK_DEBUG_REPORT_ERROR_BIT_EXT = DebugReportFlagsEXT 0x8
 
-pattern VK_DEBUG_REPORT_DEBUG_BIT_EXT = VkDebugReportFlagsEXT 0x10
+pattern VK_DEBUG_REPORT_DEBUG_BIT_EXT = DebugReportFlagsEXT 0x10
 
 
 type PFN_vkDebugReportCallbackEXT = FunPtr
-  (VkDebugReportFlagsEXT ->
-     VkDebugReportObjectTypeEXT ->
+  (DebugReportFlagsEXT ->
+     DebugReportObjectTypeEXT ->
        Word64 ->
          CSize ->
            Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO VkBool32)
@@ -296,6 +296,5 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
 foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
   Instance ->
   Ptr DebugReportCallbackCreateInfoEXT ->
-    Ptr AllocationCallbacks ->
-      Ptr DebugReportCallbackEXT -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr DebugReportCallbackEXT -> IO Result
 

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -25,7 +25,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -216,34 +216,34 @@ pattern VK_DEBUG_REPORT_ERROR_NONE_EXT = VkDebugReportErrorEXT 0
 pattern VK_DEBUG_REPORT_ERROR_CALLBACK_REF_EXT = VkDebugReportErrorEXT 1
 
 
-data VkDebugReportCallbackCreateInfoEXT =
-  VkDebugReportCallbackCreateInfoEXT{ sType :: VkStructureType 
-                                    , pNext :: Ptr Void 
-                                    , flags :: VkDebugReportFlagsEXT 
-                                    , pfnCallback :: PFN_vkDebugReportCallbackEXT 
-                                    , pUserData :: Ptr Void 
-                                    }
+data DebugReportCallbackCreateInfoEXT =
+  DebugReportCallbackCreateInfoEXT{ sType :: VkStructureType 
+                                  , pNext :: Ptr Void 
+                                  , flags :: VkDebugReportFlagsEXT 
+                                  , pfnCallback :: PFN_vkDebugReportCallbackEXT 
+                                  , pUserData :: Ptr Void 
+                                  }
   deriving (Eq)
 
-instance Storable VkDebugReportCallbackCreateInfoEXT where
+instance Storable DebugReportCallbackCreateInfoEXT where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkDebugReportCallbackCreateInfoEXT <$> peek (ptr `plusPtr` 0)
-                                                <*> peek (ptr `plusPtr` 8)
-                                                <*> peek (ptr `plusPtr` 16)
-                                                <*> peek (ptr `plusPtr` 24)
-                                                <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 24) (pfnCallback (poked :: VkDebugReportCallbackCreateInfoEXT))
-                *> poke (ptr `plusPtr` 32) (pUserData (poked :: VkDebugReportCallbackCreateInfoEXT))
+  peek ptr = DebugReportCallbackCreateInfoEXT <$> peek (ptr `plusPtr` 0)
+                                              <*> peek (ptr `plusPtr` 8)
+                                              <*> peek (ptr `plusPtr` 16)
+                                              <*> peek (ptr `plusPtr` 24)
+                                              <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 24) (pfnCallback (poked :: DebugReportCallbackCreateInfoEXT))
+                *> poke (ptr `plusPtr` 32) (pUserData (poked :: DebugReportCallbackCreateInfoEXT))
 
 
 -- ** vkDestroyDebugReportCallbackEXT
 foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallbackEXT ::
   Instance ->
-  DebugReportCallbackEXT -> Ptr VkAllocationCallbacks -> IO ()
+  DebugReportCallbackEXT -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkDebugReportFlagsEXT
 
@@ -295,7 +295,7 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
 -- ** vkCreateDebugReportCallbackEXT
 foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
   Instance ->
-  Ptr VkDebugReportCallbackCreateInfoEXT ->
-    Ptr VkAllocationCallbacks ->
+  Ptr DebugReportCallbackCreateInfoEXT ->
+    Ptr AllocationCallbacks ->
       Ptr DebugReportCallbackEXT -> IO VkResult
 

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -245,7 +245,7 @@ foreign import ccall "vkDestroyDebugReportCallbackEXT" destroyDebugReportCallbac
   Instance ->
   DebugReportCallbackEXT -> Ptr AllocationCallbacks -> IO ()
 
--- ** VkDebugReportFlagsEXT
+-- ** DebugReportFlagsEXT
 
 newtype DebugReportFlagsEXT = DebugReportFlagsEXT Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -17,10 +17,18 @@ import Foreign.Ptr( Ptr
                   )
 import Data.Int( Int32
                )
+import Graphics.Vulkan.EXT.DebugReport( VkDebugReportObjectTypeEXT
+                                      , DebugReportCallbackEXT
+                                      , PFN_vkDebugReportCallbackEXT
+                                      , VkDebugReportCallbackCreateInfoEXT
+                                      , VkDebugReportFlagsEXT
+                                      )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -28,6 +36,13 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.DeviceInitialization( Instance
+                                           )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       , CChar
                       )

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -251,20 +251,20 @@ newtype DebugReportFlagsEXT = DebugReportFlagsEXT Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DebugReportFlagsEXT where
-  showsPrec _ VK_DEBUG_REPORT_INFORMATION_BIT_EXT = showString "VK_DEBUG_REPORT_INFORMATION_BIT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_WARNING_BIT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_ERROR_BIT_EXT = showString "VK_DEBUG_REPORT_ERROR_BIT_EXT"
-  showsPrec _ VK_DEBUG_REPORT_DEBUG_BIT_EXT = showString "VK_DEBUG_REPORT_DEBUG_BIT_EXT"
+  showsPrec _ DebugReportInformationBitExt = showString "DebugReportInformationBitExt"
+  showsPrec _ DebugReportWarningBitExt = showString "DebugReportWarningBitExt"
+  showsPrec _ DebugReportPerformanceWarningBitExt = showString "DebugReportPerformanceWarningBitExt"
+  showsPrec _ DebugReportErrorBitExt = showString "DebugReportErrorBitExt"
+  showsPrec _ DebugReportDebugBitExt = showString "DebugReportDebugBitExt"
   
   showsPrec p (DebugReportFlagsEXT x) = showParen (p >= 11) (showString "DebugReportFlagsEXT " . showsPrec 11 x)
 
 instance Read DebugReportFlagsEXT where
-  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_INFORMATION_BIT_EXT", pure VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-                             , ("VK_DEBUG_REPORT_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_WARNING_BIT_EXT)
-                             , ("VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
-                             , ("VK_DEBUG_REPORT_ERROR_BIT_EXT", pure VK_DEBUG_REPORT_ERROR_BIT_EXT)
-                             , ("VK_DEBUG_REPORT_DEBUG_BIT_EXT", pure VK_DEBUG_REPORT_DEBUG_BIT_EXT)
+  readPrec = parens ( choose [ ("DebugReportInformationBitExt", pure DebugReportInformationBitExt)
+                             , ("DebugReportWarningBitExt", pure DebugReportWarningBitExt)
+                             , ("DebugReportPerformanceWarningBitExt", pure DebugReportPerformanceWarningBitExt)
+                             , ("DebugReportErrorBitExt", pure DebugReportErrorBitExt)
+                             , ("DebugReportDebugBitExt", pure DebugReportDebugBitExt)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DebugReportFlagsEXT")
@@ -274,15 +274,15 @@ instance Read DebugReportFlagsEXT where
                     )
 
 
-pattern VK_DEBUG_REPORT_INFORMATION_BIT_EXT = DebugReportFlagsEXT 0x1
+pattern DebugReportInformationBitExt = DebugReportFlagsEXT 0x1
 
-pattern VK_DEBUG_REPORT_WARNING_BIT_EXT = DebugReportFlagsEXT 0x2
+pattern DebugReportWarningBitExt = DebugReportFlagsEXT 0x2
 
-pattern VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = DebugReportFlagsEXT 0x4
+pattern DebugReportPerformanceWarningBitExt = DebugReportFlagsEXT 0x4
 
-pattern VK_DEBUG_REPORT_ERROR_BIT_EXT = DebugReportFlagsEXT 0x8
+pattern DebugReportErrorBitExt = DebugReportFlagsEXT 0x8
 
-pattern VK_DEBUG_REPORT_DEBUG_BIT_EXT = DebugReportFlagsEXT 0x10
+pattern DebugReportDebugBitExt = DebugReportFlagsEXT 0x10
 
 
 type PFN_vkDebugReportCallbackEXT = FunPtr

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -9,25 +9,23 @@ import Text.Read.Lex( Lexeme(Ident)
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
-                  , FunPtr
+import Foreign.Ptr( Ptr(..)
+                  , FunPtr(..)
                   , plusPtr
                   )
-import Data.Int( Int32
+import Data.Int( Int32(..)
+               , Int32
                )
-import Graphics.Vulkan.EXT.DebugReport( VkDebugReportObjectTypeEXT
-                                      , DebugReportCallbackEXT
-                                      , PFN_vkDebugReportCallbackEXT
-                                      , VkDebugReportCallbackCreateInfoEXT
-                                      , VkDebugReportFlagsEXT
-                                      )
+import Data.Bits( Bits
+                , FiniteBits
+                )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -36,15 +34,15 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( Instance
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CSize
-                      , CChar
+import Foreign.C.Types( CChar(..)
+                      , CSize(..)
                       )
 
 -- ** vkDebugReportMessageEXT
@@ -248,9 +246,44 @@ foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallb
   DebugReportCallbackEXT -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkDebugReportFlagsEXT
--- | Opaque flag
+
 newtype VkDebugReportFlagsEXT = VkDebugReportFlagsEXT VkFlags
-  deriving (Eq, Storable)
+  deriving (Eq, Storable, Bits, FiniteBits)
+
+instance Show VkDebugReportFlagsEXT where
+  showsPrec _ VK_DEBUG_REPORT_INFORMATION_BIT_EXT = showString "VK_DEBUG_REPORT_INFORMATION_BIT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_WARNING_BIT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = showString "VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_ERROR_BIT_EXT = showString "VK_DEBUG_REPORT_ERROR_BIT_EXT"
+  showsPrec _ VK_DEBUG_REPORT_DEBUG_BIT_EXT = showString "VK_DEBUG_REPORT_DEBUG_BIT_EXT"
+  
+  showsPrec p (VkDebugReportFlagsEXT x) = showParen (p >= 11) (showString "VkDebugReportFlagsEXT " . showsPrec 11 x)
+
+instance Read VkDebugReportFlagsEXT where
+  readPrec = parens ( choose [ ("VK_DEBUG_REPORT_INFORMATION_BIT_EXT", pure VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
+                             , ("VK_DEBUG_REPORT_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_WARNING_BIT_EXT)
+                             , ("VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT", pure VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
+                             , ("VK_DEBUG_REPORT_ERROR_BIT_EXT", pure VK_DEBUG_REPORT_ERROR_BIT_EXT)
+                             , ("VK_DEBUG_REPORT_DEBUG_BIT_EXT", pure VK_DEBUG_REPORT_DEBUG_BIT_EXT)
+                             ] +++
+                      prec 10 (do
+                        expectP (Ident "VkDebugReportFlagsEXT")
+                        v <- step readPrec
+                        pure (VkDebugReportFlagsEXT v)
+                        )
+                    )
+
+
+pattern VK_DEBUG_REPORT_INFORMATION_BIT_EXT = VkDebugReportFlagsEXT 0x1
+
+pattern VK_DEBUG_REPORT_WARNING_BIT_EXT = VkDebugReportFlagsEXT 0x2
+
+pattern VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT = VkDebugReportFlagsEXT 0x4
+
+pattern VK_DEBUG_REPORT_ERROR_BIT_EXT = VkDebugReportFlagsEXT 0x8
+
+pattern VK_DEBUG_REPORT_DEBUG_BIT_EXT = VkDebugReportFlagsEXT 0x10
+
 
 type PFN_vkDebugReportCallbackEXT = FunPtr
   (VkDebugReportFlagsEXT ->

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Event where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -33,13 +33,13 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkDestroyEvent
 foreign import ccall "vkDestroyEvent" vkDestroyEvent ::
-  VkDevice -> VkEvent -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Event -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkEventCreateInfo =
-  VkEventCreateInfo{ vkSType :: VkStructureType 
-                   , vkPNext :: Ptr Void 
-                   , vkFlags :: VkEventCreateFlags 
+  VkEventCreateInfo{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , flags :: VkEventCreateFlags 
                    }
   deriving (Eq)
 
@@ -49,30 +49,30 @@ instance Storable VkEventCreateInfo where
   peek ptr = VkEventCreateInfo <$> peek (ptr `plusPtr` 0)
                                <*> peek (ptr `plusPtr` 8)
                                <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkEventCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkEventCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkEventCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkEventCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkEventCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkEventCreateInfo))
 
 
 -- ** vkSetEvent
 foreign import ccall "vkSetEvent" vkSetEvent ::
-  VkDevice -> VkEvent -> IO VkResult
+  Device -> Event -> IO VkResult
 
 -- ** vkGetEventStatus
 foreign import ccall "vkGetEventStatus" vkGetEventStatus ::
-  VkDevice -> VkEvent -> IO VkResult
+  Device -> Event -> IO VkResult
 
 -- ** vkResetEvent
 foreign import ccall "vkResetEvent" vkResetEvent ::
-  VkDevice -> VkEvent -> IO VkResult
+  Device -> Event -> IO VkResult
 
 -- ** vkCreateEvent
 foreign import ccall "vkCreateEvent" vkCreateEvent ::
-  VkDevice ->
+  Device ->
   Ptr VkEventCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkEvent -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Event -> IO VkResult
 
-newtype VkEvent = VkEvent Word64
+newtype Event = Event Word64
   deriving (Eq, Storable)
 
 -- ** VkEventCreateFlags

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -3,10 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Event where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -15,21 +12,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkDestroyEvent
 foreign import ccall "vkDestroyEvent" vkDestroyEvent ::

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -16,9 +16,9 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 
 -- ** vkDestroyEvent
@@ -27,9 +27,9 @@ foreign import ccall "vkDestroyEvent" vkDestroyEvent ::
 
 
 data EventCreateInfo =
-  EventCreateInfo{ sType :: VkStructureType 
+  EventCreateInfo{ sType :: StructureType 
                  , pNext :: Ptr Void 
-                 , flags :: VkEventCreateFlags 
+                 , flags :: EventCreateFlags 
                  }
   deriving (Eq)
 
@@ -46,27 +46,27 @@ instance Storable EventCreateInfo where
 
 -- ** vkSetEvent
 foreign import ccall "vkSetEvent" vkSetEvent ::
-  Device -> Event -> IO VkResult
+  Device -> Event -> IO Result
 
 -- ** vkGetEventStatus
 foreign import ccall "vkGetEventStatus" vkGetEventStatus ::
-  Device -> Event -> IO VkResult
+  Device -> Event -> IO Result
 
 -- ** vkResetEvent
 foreign import ccall "vkResetEvent" vkResetEvent ::
-  Device -> Event -> IO VkResult
+  Device -> Event -> IO Result
 
 -- ** vkCreateEvent
 foreign import ccall "vkCreateEvent" vkCreateEvent ::
   Device ->
   Ptr EventCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Event -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Event -> IO Result
 
 newtype Event = Event Word64
   deriving (Eq, Storable)
 
--- ** VkEventCreateFlags
+-- ** EventCreateFlags
 -- | Opaque flag
-newtype VkEventCreateFlags = VkEventCreateFlags VkFlags
+newtype EventCreateFlags = EventCreateFlags VkFlags
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -14,7 +14,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFlags(..)
@@ -23,25 +23,25 @@ import Graphics.Vulkan.Core( VkStructureType(..)
 
 -- ** vkDestroyEvent
 foreign import ccall "vkDestroyEvent" vkDestroyEvent ::
-  Device -> Event -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Event -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkEventCreateInfo =
-  VkEventCreateInfo{ sType :: VkStructureType 
-                   , pNext :: Ptr Void 
-                   , flags :: VkEventCreateFlags 
-                   }
+data EventCreateInfo =
+  EventCreateInfo{ sType :: VkStructureType 
+                 , pNext :: Ptr Void 
+                 , flags :: VkEventCreateFlags 
+                 }
   deriving (Eq)
 
-instance Storable VkEventCreateInfo where
+instance Storable EventCreateInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkEventCreateInfo <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 8)
-                               <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkEventCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkEventCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkEventCreateInfo))
+  peek ptr = EventCreateInfo <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 8)
+                             <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: EventCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: EventCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: EventCreateInfo))
 
 
 -- ** vkSetEvent
@@ -59,8 +59,8 @@ foreign import ccall "vkResetEvent" vkResetEvent ::
 -- ** vkCreateEvent
 foreign import ccall "vkCreateEvent" vkCreateEvent ::
   Device ->
-  Ptr VkEventCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Event -> IO VkResult
+  Ptr EventCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Event -> IO VkResult
 
 newtype Event = Event Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -21,8 +21,8 @@ import Graphics.Vulkan.Core( StructureType(..)
                            , Flags(..)
                            )
 
--- ** vkDestroyEvent
-foreign import ccall "vkDestroyEvent" vkDestroyEvent ::
+-- ** destroyEvent
+foreign import ccall "vkDestroyEvent" destroyEvent ::
   Device -> Event -> Ptr AllocationCallbacks -> IO ()
 
 
@@ -44,20 +44,20 @@ instance Storable EventCreateInfo where
                 *> poke (ptr `plusPtr` 16) (flags (poked :: EventCreateInfo))
 
 
--- ** vkSetEvent
-foreign import ccall "vkSetEvent" vkSetEvent ::
+-- ** setEvent
+foreign import ccall "vkSetEvent" setEvent ::
   Device -> Event -> IO Result
 
--- ** vkGetEventStatus
-foreign import ccall "vkGetEventStatus" vkGetEventStatus ::
+-- ** getEventStatus
+foreign import ccall "vkGetEventStatus" getEventStatus ::
   Device -> Event -> IO Result
 
--- ** vkResetEvent
-foreign import ccall "vkResetEvent" vkResetEvent ::
+-- ** resetEvent
+foreign import ccall "vkResetEvent" resetEvent ::
   Device -> Event -> IO Result
 
--- ** vkCreateEvent
-foreign import ccall "vkCreateEvent" vkCreateEvent ::
+-- ** createEvent
+foreign import ccall "vkCreateEvent" createEvent ::
   Device ->
   Ptr EventCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Event -> IO Result

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -3,6 +3,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Event where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Event( VkEventCreateInfo
+                            , Event
+                            , VkEventCreateFlags
+                            )
 import Data.Word( Word64
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +18,12 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 -- ** vkDestroyEvent
 foreign import ccall "vkDestroyEvent" vkDestroyEvent ::

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -31,7 +31,7 @@ data EventCreateInfo =
                  , pNext :: Ptr Void 
                  , flags :: EventCreateFlags 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable EventCreateInfo where
   sizeOf ~_ = 24
@@ -63,10 +63,10 @@ foreign import ccall "vkCreateEvent" createEvent ::
     Ptr AllocationCallbacks -> Ptr Event -> IO Result
 
 newtype Event = Event Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** EventCreateFlags
 -- | Opaque flag
 newtype EventCreateFlags = EventCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -3,26 +3,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Event where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Event( VkEventCreateInfo
-                            , Event
-                            , VkEventCreateFlags
-                            )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
 
 -- ** vkDestroyEvent

--- a/src/Graphics/Vulkan/Event.hs
+++ b/src/Graphics/Vulkan/Event.hs
@@ -16,9 +16,9 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 -- ** vkDestroyEvent
@@ -67,6 +67,6 @@ newtype Event = Event Word64
 
 -- ** EventCreateFlags
 -- | Opaque flag
-newtype EventCreateFlags = EventCreateFlags VkFlags
+newtype EventCreateFlags = EventCreateFlags Flags
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -5,7 +5,7 @@ module Graphics.Vulkan.ExtensionDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( VkPhysicalDevice(..)
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Data.Word( Word32
                 )
@@ -23,8 +23,8 @@ import Foreign.C.Types( CChar
 
 
 data VkExtensionProperties =
-  VkExtensionProperties{ vkExtensionName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
-                       , vkSpecVersion :: Word32 
+  VkExtensionProperties{ extensionName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+                       , specVersion :: Word32 
                        }
   deriving (Eq)
 
@@ -33,8 +33,8 @@ instance Storable VkExtensionProperties where
   alignment ~_ = 4
   peek ptr = VkExtensionProperties <$> peek (ptr `plusPtr` 0)
                                    <*> peek (ptr `plusPtr` 256)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkExtensionName (poked :: VkExtensionProperties))
-                *> poke (ptr `plusPtr` 256) (vkSpecVersion (poked :: VkExtensionProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (extensionName (poked :: VkExtensionProperties))
+                *> poke (ptr `plusPtr` 256) (specVersion (poked :: VkExtensionProperties))
 
 
 -- ** vkEnumerateInstanceExtensionProperties
@@ -43,6 +43,6 @@ foreign import ccall "vkEnumerateInstanceExtensionProperties" vkEnumerateInstanc
 
 -- ** vkEnumerateDeviceExtensionProperties
 foreign import ccall "vkEnumerateDeviceExtensionProperties" vkEnumerateDeviceExtensionProperties ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr CChar -> Ptr Word32 -> Ptr VkExtensionProperties -> IO VkResult
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -5,8 +5,6 @@ module Graphics.Vulkan.ExtensionDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( PhysicalDevice(..)
-                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -14,10 +12,6 @@ import Foreign.Ptr( Ptr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_EXTENSION_NAME_SIZE
-                                )
-import Graphics.Vulkan.Core( VkResult(..)
-                           )
 import Foreign.C.Types( CChar
                       )
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -37,12 +37,12 @@ instance Storable ExtensionProperties where
                 *> poke (ptr `plusPtr` 256) (specVersion (poked :: ExtensionProperties))
 
 
--- ** vkEnumerateInstanceExtensionProperties
-foreign import ccall "vkEnumerateInstanceExtensionProperties" vkEnumerateInstanceExtensionProperties ::
+-- ** enumerateInstanceExtensionProperties
+foreign import ccall "vkEnumerateInstanceExtensionProperties" enumerateInstanceExtensionProperties ::
   Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO Result
 
--- ** vkEnumerateDeviceExtensionProperties
-foreign import ccall "vkEnumerateDeviceExtensionProperties" vkEnumerateDeviceExtensionProperties ::
+-- ** enumerateDeviceExtensionProperties
+foreign import ccall "vkEnumerateDeviceExtensionProperties" enumerateDeviceExtensionProperties ::
   PhysicalDevice ->
   Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO Result
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -14,7 +14,7 @@ import Foreign.Ptr( Ptr(..)
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_EXTENSION_NAME_SIZE
+import Graphics.Vulkan.Constants( MaxExtensionNameSize
                                 )
 import Graphics.Vulkan.Core( Result(..)
                            )
@@ -23,7 +23,7 @@ import Foreign.C.Types( CChar(..)
 
 
 data ExtensionProperties =
-  ExtensionProperties{ extensionName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+  ExtensionProperties{ extensionName :: Vector MaxExtensionNameSize CChar 
                      , specVersion :: Word32 
                      }
   deriving (Eq)

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -3,22 +3,22 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.ExtensionDiscovery where
 
-import Data.Vector.Storable.Sized( Vector
+import Data.Vector.Storable.Sized( Vector(..)
                                  )
-import Graphics.Vulkan.Device( PhysicalDevice
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.ExtensionDiscovery( VkExtensionProperties
-                                         )
-import Graphics.Vulkan.Core( VkResult
+import Graphics.Vulkan.Constants( VK_MAX_EXTENSION_NAME_SIZE
+                                )
+import Graphics.Vulkan.Core( VkResult(..)
                            )
-import Foreign.C.Types( CChar
+import Foreign.C.Types( CChar(..)
                       )
 
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -22,27 +22,27 @@ import Foreign.C.Types( CChar(..)
                       )
 
 
-data VkExtensionProperties =
-  VkExtensionProperties{ extensionName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
-                       , specVersion :: Word32 
-                       }
+data ExtensionProperties =
+  ExtensionProperties{ extensionName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+                     , specVersion :: Word32 
+                     }
   deriving (Eq)
 
-instance Storable VkExtensionProperties where
+instance Storable ExtensionProperties where
   sizeOf ~_ = 260
   alignment ~_ = 4
-  peek ptr = VkExtensionProperties <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 256)
-  poke ptr poked = poke (ptr `plusPtr` 0) (extensionName (poked :: VkExtensionProperties))
-                *> poke (ptr `plusPtr` 256) (specVersion (poked :: VkExtensionProperties))
+  peek ptr = ExtensionProperties <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 256)
+  poke ptr poked = poke (ptr `plusPtr` 0) (extensionName (poked :: ExtensionProperties))
+                *> poke (ptr `plusPtr` 256) (specVersion (poked :: ExtensionProperties))
 
 
 -- ** vkEnumerateInstanceExtensionProperties
 foreign import ccall "vkEnumerateInstanceExtensionProperties" vkEnumerateInstanceExtensionProperties ::
-  Ptr CChar -> Ptr Word32 -> Ptr VkExtensionProperties -> IO VkResult
+  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO VkResult
 
 -- ** vkEnumerateDeviceExtensionProperties
 foreign import ccall "vkEnumerateDeviceExtensionProperties" vkEnumerateDeviceExtensionProperties ::
   PhysicalDevice ->
-  Ptr CChar -> Ptr Word32 -> Ptr VkExtensionProperties -> IO VkResult
+  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO VkResult
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -5,6 +5,8 @@ module Graphics.Vulkan.ExtensionDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
+import Graphics.Vulkan.Device( PhysicalDevice
+                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +14,10 @@ import Foreign.Ptr( Ptr
                   )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.ExtensionDiscovery( VkExtensionProperties
+                                         )
+import Graphics.Vulkan.Core( VkResult
+                           )
 import Foreign.C.Types( CChar
                       )
 

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -26,7 +26,7 @@ data ExtensionProperties =
   ExtensionProperties{ extensionName :: Vector MaxExtensionNameSize CChar 
                      , specVersion :: Word32 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ExtensionProperties where
   sizeOf ~_ = 260

--- a/src/Graphics/Vulkan/ExtensionDiscovery.hs
+++ b/src/Graphics/Vulkan/ExtensionDiscovery.hs
@@ -16,7 +16,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Graphics.Vulkan.Constants( VK_MAX_EXTENSION_NAME_SIZE
                                 )
-import Graphics.Vulkan.Core( VkResult(..)
+import Graphics.Vulkan.Core( Result(..)
                            )
 import Foreign.C.Types( CChar(..)
                       )
@@ -39,10 +39,10 @@ instance Storable ExtensionProperties where
 
 -- ** vkEnumerateInstanceExtensionProperties
 foreign import ccall "vkEnumerateInstanceExtensionProperties" vkEnumerateInstanceExtensionProperties ::
-  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO VkResult
+  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO Result
 
 -- ** vkEnumerateDeviceExtensionProperties
 foreign import ccall "vkEnumerateDeviceExtensionProperties" vkEnumerateDeviceExtensionProperties ::
   PhysicalDevice ->
-  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO VkResult
+  Ptr CChar -> Ptr Word32 -> Ptr ExtensionProperties -> IO Result
 

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Fence where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -50,9 +50,9 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkFenceCreateInfo =
-  VkFenceCreateInfo{ vkSType :: VkStructureType 
-                   , vkPNext :: Ptr Void 
-                   , vkFlags :: VkFenceCreateFlags 
+  VkFenceCreateInfo{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , flags :: VkFenceCreateFlags 
                    }
   deriving (Eq)
 
@@ -62,27 +62,26 @@ instance Storable VkFenceCreateInfo where
   peek ptr = VkFenceCreateInfo <$> peek (ptr `plusPtr` 0)
                                <*> peek (ptr `plusPtr` 8)
                                <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkFenceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkFenceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkFenceCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkFenceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkFenceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkFenceCreateInfo))
 
 
 -- ** vkResetFences
 foreign import ccall "vkResetFences" vkResetFences ::
-  VkDevice -> Word32 -> Ptr VkFence -> IO VkResult
+  Device -> Word32 -> Ptr Fence -> IO VkResult
 
 -- ** vkDestroyFence
 foreign import ccall "vkDestroyFence" vkDestroyFence ::
-  VkDevice -> VkFence -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Fence -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** vkWaitForFences
 foreign import ccall "vkWaitForFences" vkWaitForFences ::
-  VkDevice ->
-  Word32 -> Ptr VkFence -> VkBool32 -> Word64 -> IO VkResult
+  Device -> Word32 -> Ptr Fence -> VkBool32 -> Word64 -> IO VkResult
 
 -- ** vkGetFenceStatus
 foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
-  VkDevice -> VkFence -> IO VkResult
+  Device -> Fence -> IO VkResult
 
 -- ** VkFenceCreateFlags
 
@@ -113,10 +112,10 @@ pattern VK_FENCE_CREATE_SIGNALED_BIT = VkFenceCreateFlagBits 0x1
 
 -- ** vkCreateFence
 foreign import ccall "vkCreateFence" vkCreateFence ::
-  VkDevice ->
+  Device ->
   Ptr VkFenceCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkFence -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Fence -> IO VkResult
 
-newtype VkFence = VkFence Word64
+newtype Fence = Fence Word64
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Fence where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,15 +22,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -40,13 +29,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkFenceCreateInfo =

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -74,7 +74,7 @@ foreign import ccall "vkWaitForFences" waitForFences ::
 foreign import ccall "vkGetFenceStatus" getFenceStatus ::
   Device -> Fence -> IO Result
 
--- ** VkFenceCreateFlags
+-- ** FenceCreateFlags
 
 newtype FenceCreateFlags = FenceCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -24,7 +24,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -40,22 +40,22 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            )
 
 
-data VkFenceCreateInfo =
-  VkFenceCreateInfo{ sType :: VkStructureType 
-                   , pNext :: Ptr Void 
-                   , flags :: VkFenceCreateFlags 
-                   }
+data FenceCreateInfo =
+  FenceCreateInfo{ sType :: VkStructureType 
+                 , pNext :: Ptr Void 
+                 , flags :: VkFenceCreateFlags 
+                 }
   deriving (Eq)
 
-instance Storable VkFenceCreateInfo where
+instance Storable FenceCreateInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkFenceCreateInfo <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 8)
-                               <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkFenceCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkFenceCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkFenceCreateInfo))
+  peek ptr = FenceCreateInfo <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 8)
+                             <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: FenceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: FenceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: FenceCreateInfo))
 
 
 -- ** vkResetFences
@@ -64,7 +64,7 @@ foreign import ccall "vkResetFences" vkResetFences ::
 
 -- ** vkDestroyFence
 foreign import ccall "vkDestroyFence" vkDestroyFence ::
-  Device -> Fence -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Fence -> Ptr AllocationCallbacks -> IO ()
 
 -- ** vkWaitForFences
 foreign import ccall "vkWaitForFences" vkWaitForFences ::
@@ -101,8 +101,8 @@ pattern VK_FENCE_CREATE_SIGNALED_BIT = VkFenceCreateFlags 0x1
 -- ** vkCreateFence
 foreign import ccall "vkCreateFence" vkCreateFence ::
   Device ->
-  Ptr VkFenceCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Fence -> IO VkResult
+  Ptr FenceCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Fence -> IO VkResult
 
 newtype Fence = Fence Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -33,17 +33,17 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 
 
 data FenceCreateInfo =
-  FenceCreateInfo{ sType :: VkStructureType 
+  FenceCreateInfo{ sType :: StructureType 
                  , pNext :: Ptr Void 
-                 , flags :: VkFenceCreateFlags 
+                 , flags :: FenceCreateFlags 
                  }
   deriving (Eq)
 
@@ -60,7 +60,7 @@ instance Storable FenceCreateInfo where
 
 -- ** vkResetFences
 foreign import ccall "vkResetFences" vkResetFences ::
-  Device -> Word32 -> Ptr Fence -> IO VkResult
+  Device -> Word32 -> Ptr Fence -> IO Result
 
 -- ** vkDestroyFence
 foreign import ccall "vkDestroyFence" vkDestroyFence ::
@@ -68,41 +68,41 @@ foreign import ccall "vkDestroyFence" vkDestroyFence ::
 
 -- ** vkWaitForFences
 foreign import ccall "vkWaitForFences" vkWaitForFences ::
-  Device -> Word32 -> Ptr Fence -> VkBool32 -> Word64 -> IO VkResult
+  Device -> Word32 -> Ptr Fence -> VkBool32 -> Word64 -> IO Result
 
 -- ** vkGetFenceStatus
 foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
-  Device -> Fence -> IO VkResult
+  Device -> Fence -> IO Result
 
 -- ** VkFenceCreateFlags
 
-newtype VkFenceCreateFlags = VkFenceCreateFlags VkFlags
+newtype FenceCreateFlags = FenceCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkFenceCreateFlags where
+instance Show FenceCreateFlags where
   showsPrec _ VK_FENCE_CREATE_SIGNALED_BIT = showString "VK_FENCE_CREATE_SIGNALED_BIT"
   
-  showsPrec p (VkFenceCreateFlags x) = showParen (p >= 11) (showString "VkFenceCreateFlags " . showsPrec 11 x)
+  showsPrec p (FenceCreateFlags x) = showParen (p >= 11) (showString "FenceCreateFlags " . showsPrec 11 x)
 
-instance Read VkFenceCreateFlags where
+instance Read FenceCreateFlags where
   readPrec = parens ( choose [ ("VK_FENCE_CREATE_SIGNALED_BIT", pure VK_FENCE_CREATE_SIGNALED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFenceCreateFlags")
+                        expectP (Ident "FenceCreateFlags")
                         v <- step readPrec
-                        pure (VkFenceCreateFlags v)
+                        pure (FenceCreateFlags v)
                         )
                     )
 
 
-pattern VK_FENCE_CREATE_SIGNALED_BIT = VkFenceCreateFlags 0x1
+pattern VK_FENCE_CREATE_SIGNALED_BIT = FenceCreateFlags 0x1
 
 
 -- ** vkCreateFence
 foreign import ccall "vkCreateFence" vkCreateFence ::
   Device ->
   Ptr FenceCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Fence -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Fence -> IO Result
 
 newtype Fence = Fence Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Fence where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Bits( Bits
@@ -22,13 +22,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( VkFenceCreateInfo
-                            , Fence
-                            , VkFenceCreateFlags
-                            )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -37,10 +33,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
 
 
@@ -80,29 +76,26 @@ foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
 
 -- ** VkFenceCreateFlags
 
-newtype VkFenceCreateFlagBits = VkFenceCreateFlagBits VkFlags
+newtype VkFenceCreateFlags = VkFenceCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkFenceCreateFlagBits
-type VkFenceCreateFlags = VkFenceCreateFlagBits
-
-instance Show VkFenceCreateFlagBits where
+instance Show VkFenceCreateFlags where
   showsPrec _ VK_FENCE_CREATE_SIGNALED_BIT = showString "VK_FENCE_CREATE_SIGNALED_BIT"
   
-  showsPrec p (VkFenceCreateFlagBits x) = showParen (p >= 11) (showString "VkFenceCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkFenceCreateFlags x) = showParen (p >= 11) (showString "VkFenceCreateFlags " . showsPrec 11 x)
 
-instance Read VkFenceCreateFlagBits where
+instance Read VkFenceCreateFlags where
   readPrec = parens ( choose [ ("VK_FENCE_CREATE_SIGNALED_BIT", pure VK_FENCE_CREATE_SIGNALED_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFenceCreateFlagBits")
+                        expectP (Ident "VkFenceCreateFlags")
                         v <- step readPrec
-                        pure (VkFenceCreateFlagBits v)
+                        pure (VkFenceCreateFlags v)
                         )
                     )
 
 
-pattern VK_FENCE_CREATE_SIGNALED_BIT = VkFenceCreateFlagBits 0x1
+pattern VK_FENCE_CREATE_SIGNALED_BIT = VkFenceCreateFlags 0x1
 
 
 -- ** vkCreateFence

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -33,10 +33,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 
@@ -68,7 +68,7 @@ foreign import ccall "vkDestroyFence" vkDestroyFence ::
 
 -- ** vkWaitForFences
 foreign import ccall "vkWaitForFences" vkWaitForFences ::
-  Device -> Word32 -> Ptr Fence -> VkBool32 -> Word64 -> IO Result
+  Device -> Word32 -> Ptr Fence -> Bool32 -> Word64 -> IO Result
 
 -- ** vkGetFenceStatus
 foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
@@ -76,7 +76,7 @@ foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
 
 -- ** VkFenceCreateFlags
 
-newtype FenceCreateFlags = FenceCreateFlags VkFlags
+newtype FenceCreateFlags = FenceCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show FenceCreateFlags where

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -58,20 +58,20 @@ instance Storable FenceCreateInfo where
                 *> poke (ptr `plusPtr` 16) (flags (poked :: FenceCreateInfo))
 
 
--- ** vkResetFences
-foreign import ccall "vkResetFences" vkResetFences ::
+-- ** resetFences
+foreign import ccall "vkResetFences" resetFences ::
   Device -> Word32 -> Ptr Fence -> IO Result
 
--- ** vkDestroyFence
-foreign import ccall "vkDestroyFence" vkDestroyFence ::
+-- ** destroyFence
+foreign import ccall "vkDestroyFence" destroyFence ::
   Device -> Fence -> Ptr AllocationCallbacks -> IO ()
 
--- ** vkWaitForFences
-foreign import ccall "vkWaitForFences" vkWaitForFences ::
+-- ** waitForFences
+foreign import ccall "vkWaitForFences" waitForFences ::
   Device -> Word32 -> Ptr Fence -> Bool32 -> Word64 -> IO Result
 
--- ** vkGetFenceStatus
-foreign import ccall "vkGetFenceStatus" vkGetFenceStatus ::
+-- ** getFenceStatus
+foreign import ccall "vkGetFenceStatus" getFenceStatus ::
   Device -> Fence -> IO Result
 
 -- ** VkFenceCreateFlags
@@ -98,8 +98,8 @@ instance Read FenceCreateFlags where
 pattern VK_FENCE_CREATE_SIGNALED_BIT = FenceCreateFlags 0x1
 
 
--- ** vkCreateFence
-foreign import ccall "vkCreateFence" vkCreateFence ::
+-- ** createFence
+foreign import ccall "vkCreateFence" createFence ::
   Device ->
   Ptr FenceCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Fence -> IO Result

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Fence where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -20,8 +22,14 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Fence( VkFenceCreateInfo
+                            , Fence
+                            , VkFenceCreateFlags
+                            )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +37,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 
 data VkFenceCreateInfo =

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -45,7 +45,7 @@ data FenceCreateInfo =
                  , pNext :: Ptr Void 
                  , flags :: FenceCreateFlags 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable FenceCreateInfo where
   sizeOf ~_ = 24
@@ -77,7 +77,7 @@ foreign import ccall "vkGetFenceStatus" getFenceStatus ::
 -- ** FenceCreateFlags
 
 newtype FenceCreateFlags = FenceCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show FenceCreateFlags where
   showsPrec _ FenceCreateSignaledBit = showString "FenceCreateSignaledBit"
@@ -105,5 +105,5 @@ foreign import ccall "vkCreateFence" createFence ::
     Ptr AllocationCallbacks -> Ptr Fence -> IO Result
 
 newtype Fence = Fence Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/Fence.hs
+++ b/src/Graphics/Vulkan/Fence.hs
@@ -80,12 +80,12 @@ newtype FenceCreateFlags = FenceCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show FenceCreateFlags where
-  showsPrec _ VK_FENCE_CREATE_SIGNALED_BIT = showString "VK_FENCE_CREATE_SIGNALED_BIT"
+  showsPrec _ FenceCreateSignaledBit = showString "FenceCreateSignaledBit"
   
   showsPrec p (FenceCreateFlags x) = showParen (p >= 11) (showString "FenceCreateFlags " . showsPrec 11 x)
 
 instance Read FenceCreateFlags where
-  readPrec = parens ( choose [ ("VK_FENCE_CREATE_SIGNALED_BIT", pure VK_FENCE_CREATE_SIGNALED_BIT)
+  readPrec = parens ( choose [ ("FenceCreateSignaledBit", pure FenceCreateSignaledBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "FenceCreateFlags")
@@ -95,7 +95,7 @@ instance Read FenceCreateFlags where
                     )
 
 
-pattern VK_FENCE_CREATE_SIGNALED_BIT = FenceCreateFlags 0x1
+pattern FenceCreateSignaledBit = FenceCreateFlags 0x1
 
 
 -- ** createFence

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Image where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -26,15 +24,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -42,18 +31,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
-                              )
-import Graphics.Vulkan.Core( VkExtent3D(..)
-                           , VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           , VkSharingMode(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkCreateImage
 foreign import ccall "vkCreateImage" vkCreateImage ::

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Image where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -57,9 +57,9 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkCreateImage
 foreign import ccall "vkCreateImage" vkCreateImage ::
-  VkDevice ->
+  Device ->
   Ptr VkImageCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkImage -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Image -> IO VkResult
 
 -- ** VkImageCreateFlags
 
@@ -159,7 +159,7 @@ pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = VkImageUsageFlagBits 0x40
 pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = VkImageUsageFlagBits 0x80
 
 
-newtype VkImage = VkImage Word64
+newtype Image = Image Word64
   deriving (Eq, Storable)
 
 -- ** VkImageAspectFlags
@@ -203,11 +203,11 @@ pattern VK_IMAGE_ASPECT_METADATA_BIT = VkImageAspectFlagBits 0x8
 
 
 data VkSubresourceLayout =
-  VkSubresourceLayout{ vkOffset :: VkDeviceSize 
-                     , vkSize :: VkDeviceSize 
-                     , vkRowPitch :: VkDeviceSize 
-                     , vkArrayPitch :: VkDeviceSize 
-                     , vkDepthPitch :: VkDeviceSize 
+  VkSubresourceLayout{ offset :: VkDeviceSize 
+                     , size :: VkDeviceSize 
+                     , rowPitch :: VkDeviceSize 
+                     , arrayPitch :: VkDeviceSize 
+                     , depthPitch :: VkDeviceSize 
                      }
   deriving (Eq)
 
@@ -219,11 +219,11 @@ instance Storable VkSubresourceLayout where
                                  <*> peek (ptr `plusPtr` 16)
                                  <*> peek (ptr `plusPtr` 24)
                                  <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkOffset (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 8) (vkSize (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 16) (vkRowPitch (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 24) (vkArrayPitch (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 32) (vkDepthPitch (poked :: VkSubresourceLayout))
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkSubresourceLayout))
+                *> poke (ptr `plusPtr` 8) (size (poked :: VkSubresourceLayout))
+                *> poke (ptr `plusPtr` 16) (rowPitch (poked :: VkSubresourceLayout))
+                *> poke (ptr `plusPtr` 24) (arrayPitch (poked :: VkSubresourceLayout))
+                *> poke (ptr `plusPtr` 32) (depthPitch (poked :: VkSubresourceLayout))
 
 
 -- ** VkImageTiling
@@ -338,13 +338,13 @@ pattern VK_IMAGE_TYPE_3D = VkImageType 2
 
 -- ** vkDestroyImage
 foreign import ccall "vkDestroyImage" vkDestroyImage ::
-  VkDevice -> VkImage -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Image -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkImageSubresource =
-  VkImageSubresource{ vkAspectMask :: VkImageAspectFlags 
-                    , vkMipLevel :: Word32 
-                    , vkArrayLayer :: Word32 
+  VkImageSubresource{ aspectMask :: VkImageAspectFlags 
+                    , mipLevel :: Word32 
+                    , arrayLayer :: Word32 
                     }
   deriving (Eq)
 
@@ -354,18 +354,18 @@ instance Storable VkImageSubresource where
   peek ptr = VkImageSubresource <$> peek (ptr `plusPtr` 0)
                                 <*> peek (ptr `plusPtr` 4)
                                 <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAspectMask (poked :: VkImageSubresource))
-                *> poke (ptr `plusPtr` 4) (vkMipLevel (poked :: VkImageSubresource))
-                *> poke (ptr `plusPtr` 8) (vkArrayLayer (poked :: VkImageSubresource))
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresource))
+                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: VkImageSubresource))
+                *> poke (ptr `plusPtr` 8) (arrayLayer (poked :: VkImageSubresource))
 
 
 
 data VkImageSubresourceRange =
-  VkImageSubresourceRange{ vkAspectMask :: VkImageAspectFlags 
-                         , vkBaseMipLevel :: Word32 
-                         , vkLevelCount :: Word32 
-                         , vkBaseArrayLayer :: Word32 
-                         , vkLayerCount :: Word32 
+  VkImageSubresourceRange{ aspectMask :: VkImageAspectFlags 
+                         , baseMipLevel :: Word32 
+                         , levelCount :: Word32 
+                         , baseArrayLayer :: Word32 
+                         , layerCount :: Word32 
                          }
   deriving (Eq)
 
@@ -377,36 +377,35 @@ instance Storable VkImageSubresourceRange where
                                      <*> peek (ptr `plusPtr` 8)
                                      <*> peek (ptr `plusPtr` 12)
                                      <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAspectMask (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 4) (vkBaseMipLevel (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 8) (vkLevelCount (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 12) (vkBaseArrayLayer (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 16) (vkLayerCount (poked :: VkImageSubresourceRange))
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresourceRange))
+                *> poke (ptr `plusPtr` 4) (baseMipLevel (poked :: VkImageSubresourceRange))
+                *> poke (ptr `plusPtr` 8) (levelCount (poked :: VkImageSubresourceRange))
+                *> poke (ptr `plusPtr` 12) (baseArrayLayer (poked :: VkImageSubresourceRange))
+                *> poke (ptr `plusPtr` 16) (layerCount (poked :: VkImageSubresourceRange))
 
 
 -- ** vkGetImageSubresourceLayout
 foreign import ccall "vkGetImageSubresourceLayout" vkGetImageSubresourceLayout ::
-  VkDevice ->
-  VkImage ->
-    Ptr VkImageSubresource -> Ptr VkSubresourceLayout -> IO ()
+  Device ->
+  Image -> Ptr VkImageSubresource -> Ptr VkSubresourceLayout -> IO ()
 
 
 data VkImageCreateInfo =
-  VkImageCreateInfo{ vkSType :: VkStructureType 
-                   , vkPNext :: Ptr Void 
-                   , vkFlags :: VkImageCreateFlags 
-                   , vkImageType :: VkImageType 
-                   , vkFormat :: VkFormat 
-                   , vkExtent :: VkExtent3D 
-                   , vkMipLevels :: Word32 
-                   , vkArrayLayers :: Word32 
-                   , vkSamples :: VkSampleCountFlagBits 
-                   , vkTiling :: VkImageTiling 
-                   , vkUsage :: VkImageUsageFlags 
-                   , vkSharingMode :: VkSharingMode 
-                   , vkQueueFamilyIndexCount :: Word32 
-                   , vkPQueueFamilyIndices :: Ptr Word32 
-                   , vkInitialLayout :: VkImageLayout 
+  VkImageCreateInfo{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , flags :: VkImageCreateFlags 
+                   , imageType :: VkImageType 
+                   , format :: VkFormat 
+                   , extent :: VkExtent3D 
+                   , mipLevels :: Word32 
+                   , arrayLayers :: Word32 
+                   , samples :: VkSampleCountFlagBits 
+                   , tiling :: VkImageTiling 
+                   , usage :: VkImageUsageFlags 
+                   , sharingMode :: VkSharingMode 
+                   , queueFamilyIndexCount :: Word32 
+                   , pQueueFamilyIndices :: Ptr Word32 
+                   , initialLayout :: VkImageLayout 
                    }
   deriving (Eq)
 
@@ -428,20 +427,20 @@ instance Storable VkImageCreateInfo where
                                <*> peek (ptr `plusPtr` 64)
                                <*> peek (ptr `plusPtr` 72)
                                <*> peek (ptr `plusPtr` 80)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkImageType (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkFormat (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkExtent (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkMipLevels (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 44) (vkArrayLayers (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkSamples (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 52) (vkTiling (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkUsage (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 60) (vkSharingMode (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 64) (vkQueueFamilyIndexCount (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 72) (vkPQueueFamilyIndices (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 80) (vkInitialLayout (poked :: VkImageCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 20) (imageType (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 24) (format (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 28) (extent (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 40) (mipLevels (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 44) (arrayLayers (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 48) (samples (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 52) (tiling (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 56) (usage (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 60) (sharingMode (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: VkImageCreateInfo))
+                *> poke (ptr `plusPtr` 80) (initialLayout (poked :: VkImageCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Image where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
@@ -24,9 +24,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -35,26 +35,15 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( VkImageType
-                            , VkSubresourceLayout
-                            , VkImageAspectFlags
-                            , VkImageCreateFlags
-                            , VkImageLayout
-                            , VkImageTiling
-                            , VkImageCreateInfo
-                            , VkImageSubresource
-                            , Image
-                            , VkImageUsageFlags
-                            )
-import Graphics.Vulkan.Core( VkResult
-                           , VkExtent3D
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
-                           , VkSharingMode
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
+                           , VkExtent3D(..)
+                           , VkSharingMode(..)
                            )
 
 -- ** vkCreateImage
@@ -65,22 +54,19 @@ foreign import ccall "vkCreateImage" vkCreateImage ::
 
 -- ** VkImageCreateFlags
 
-newtype VkImageCreateFlagBits = VkImageCreateFlagBits VkFlags
+newtype VkImageCreateFlags = VkImageCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkImageCreateFlagBits
-type VkImageCreateFlags = VkImageCreateFlagBits
-
-instance Show VkImageCreateFlagBits where
+instance Show VkImageCreateFlags where
   showsPrec _ VK_IMAGE_CREATE_SPARSE_BINDING_BIT = showString "VK_IMAGE_CREATE_SPARSE_BINDING_BIT"
   showsPrec _ VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT"
   showsPrec _ VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = showString "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT"
   showsPrec _ VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = showString "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT"
   showsPrec _ VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = showString "VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT"
   
-  showsPrec p (VkImageCreateFlagBits x) = showParen (p >= 11) (showString "VkImageCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkImageCreateFlags x) = showParen (p >= 11) (showString "VkImageCreateFlags " . showsPrec 11 x)
 
-instance Read VkImageCreateFlagBits where
+instance Read VkImageCreateFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_CREATE_SPARSE_BINDING_BIT", pure VK_IMAGE_CREATE_SPARSE_BINDING_BIT)
                              , ("VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT", pure VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT)
                              , ("VK_IMAGE_CREATE_SPARSE_ALIASED_BIT", pure VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)
@@ -88,33 +74,30 @@ instance Read VkImageCreateFlagBits where
                              , ("VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT", pure VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageCreateFlagBits")
+                        expectP (Ident "VkImageCreateFlags")
                         v <- step readPrec
-                        pure (VkImageCreateFlagBits v)
+                        pure (VkImageCreateFlags v)
                         )
                     )
 
 -- | Image should support sparse backing
-pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = VkImageCreateFlagBits 0x1
+pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = VkImageCreateFlags 0x1
 -- | Image should support sparse backing with partial residency
-pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = VkImageCreateFlagBits 0x2
+pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = VkImageCreateFlags 0x2
 -- | Image should support constent data access to physical memory blocks mapped into multiple locations of sparse images
-pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = VkImageCreateFlagBits 0x4
+pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = VkImageCreateFlags 0x4
 -- | Allows image views to have different format than the base image
-pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = VkImageCreateFlagBits 0x8
+pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = VkImageCreateFlags 0x8
 -- | Allows creating image views with cube type from the created image
-pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = VkImageCreateFlagBits 0x10
+pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = VkImageCreateFlags 0x10
 
 
 -- ** VkImageUsageFlags
 
-newtype VkImageUsageFlagBits = VkImageUsageFlagBits VkFlags
+newtype VkImageUsageFlags = VkImageUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkImageUsageFlagBits
-type VkImageUsageFlags = VkImageUsageFlagBits
-
-instance Show VkImageUsageFlagBits where
+instance Show VkImageUsageFlags where
   showsPrec _ VK_IMAGE_USAGE_TRANSFER_SRC_BIT = showString "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
   showsPrec _ VK_IMAGE_USAGE_TRANSFER_DST_BIT = showString "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
   showsPrec _ VK_IMAGE_USAGE_SAMPLED_BIT = showString "VK_IMAGE_USAGE_SAMPLED_BIT"
@@ -124,9 +107,9 @@ instance Show VkImageUsageFlagBits where
   showsPrec _ VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT"
   showsPrec _ VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT"
   
-  showsPrec p (VkImageUsageFlagBits x) = showParen (p >= 11) (showString "VkImageUsageFlagBits " . showsPrec 11 x)
+  showsPrec p (VkImageUsageFlags x) = showParen (p >= 11) (showString "VkImageUsageFlags " . showsPrec 11 x)
 
-instance Read VkImageUsageFlagBits where
+instance Read VkImageUsageFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_USAGE_TRANSFER_SRC_BIT", pure VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
                              , ("VK_IMAGE_USAGE_TRANSFER_DST_BIT", pure VK_IMAGE_USAGE_TRANSFER_DST_BIT)
                              , ("VK_IMAGE_USAGE_SAMPLED_BIT", pure VK_IMAGE_USAGE_SAMPLED_BIT)
@@ -137,28 +120,28 @@ instance Read VkImageUsageFlagBits where
                              , ("VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageUsageFlagBits")
+                        expectP (Ident "VkImageUsageFlags")
                         v <- step readPrec
-                        pure (VkImageUsageFlagBits v)
+                        pure (VkImageUsageFlags v)
                         )
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_SRC_BIT = VkImageUsageFlagBits 0x1
+pattern VK_IMAGE_USAGE_TRANSFER_SRC_BIT = VkImageUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_DST_BIT = VkImageUsageFlagBits 0x2
+pattern VK_IMAGE_USAGE_TRANSFER_DST_BIT = VkImageUsageFlags 0x2
 -- | Can be sampled from (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_IMAGE_USAGE_SAMPLED_BIT = VkImageUsageFlagBits 0x4
+pattern VK_IMAGE_USAGE_SAMPLED_BIT = VkImageUsageFlags 0x4
 -- | Can be used as storage image (STORAGE_IMAGE descriptor type)
-pattern VK_IMAGE_USAGE_STORAGE_BIT = VkImageUsageFlagBits 0x8
+pattern VK_IMAGE_USAGE_STORAGE_BIT = VkImageUsageFlags 0x8
 -- | Can be used as framebuffer color attachment
-pattern VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = VkImageUsageFlagBits 0x10
+pattern VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = VkImageUsageFlags 0x10
 -- | Can be used as framebuffer depth/stencil attachment
-pattern VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = VkImageUsageFlagBits 0x20
+pattern VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = VkImageUsageFlags 0x20
 -- | Image data not needed outside of rendering
-pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = VkImageUsageFlagBits 0x40
+pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = VkImageUsageFlags 0x40
 -- | Can be used as framebuffer input attachment
-pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = VkImageUsageFlagBits 0x80
+pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = VkImageUsageFlags 0x80
 
 
 newtype Image = Image Word64
@@ -166,41 +149,38 @@ newtype Image = Image Word64
 
 -- ** VkImageAspectFlags
 
-newtype VkImageAspectFlagBits = VkImageAspectFlagBits VkFlags
+newtype VkImageAspectFlags = VkImageAspectFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkImageAspectFlagBits
-type VkImageAspectFlags = VkImageAspectFlagBits
-
-instance Show VkImageAspectFlagBits where
+instance Show VkImageAspectFlags where
   showsPrec _ VK_IMAGE_ASPECT_COLOR_BIT = showString "VK_IMAGE_ASPECT_COLOR_BIT"
   showsPrec _ VK_IMAGE_ASPECT_DEPTH_BIT = showString "VK_IMAGE_ASPECT_DEPTH_BIT"
   showsPrec _ VK_IMAGE_ASPECT_STENCIL_BIT = showString "VK_IMAGE_ASPECT_STENCIL_BIT"
   showsPrec _ VK_IMAGE_ASPECT_METADATA_BIT = showString "VK_IMAGE_ASPECT_METADATA_BIT"
   
-  showsPrec p (VkImageAspectFlagBits x) = showParen (p >= 11) (showString "VkImageAspectFlagBits " . showsPrec 11 x)
+  showsPrec p (VkImageAspectFlags x) = showParen (p >= 11) (showString "VkImageAspectFlags " . showsPrec 11 x)
 
-instance Read VkImageAspectFlagBits where
+instance Read VkImageAspectFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_ASPECT_COLOR_BIT", pure VK_IMAGE_ASPECT_COLOR_BIT)
                              , ("VK_IMAGE_ASPECT_DEPTH_BIT", pure VK_IMAGE_ASPECT_DEPTH_BIT)
                              , ("VK_IMAGE_ASPECT_STENCIL_BIT", pure VK_IMAGE_ASPECT_STENCIL_BIT)
                              , ("VK_IMAGE_ASPECT_METADATA_BIT", pure VK_IMAGE_ASPECT_METADATA_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageAspectFlagBits")
+                        expectP (Ident "VkImageAspectFlags")
                         v <- step readPrec
-                        pure (VkImageAspectFlagBits v)
+                        pure (VkImageAspectFlags v)
                         )
                     )
 
 
-pattern VK_IMAGE_ASPECT_COLOR_BIT = VkImageAspectFlagBits 0x1
+pattern VK_IMAGE_ASPECT_COLOR_BIT = VkImageAspectFlags 0x1
 
-pattern VK_IMAGE_ASPECT_DEPTH_BIT = VkImageAspectFlagBits 0x2
+pattern VK_IMAGE_ASPECT_DEPTH_BIT = VkImageAspectFlags 0x2
 
-pattern VK_IMAGE_ASPECT_STENCIL_BIT = VkImageAspectFlagBits 0x4
+pattern VK_IMAGE_ASPECT_STENCIL_BIT = VkImageAspectFlags 0x4
 
-pattern VK_IMAGE_ASPECT_METADATA_BIT = VkImageAspectFlagBits 0x8
+pattern VK_IMAGE_ASPECT_METADATA_BIT = VkImageAspectFlags 0x8
 
 
 
@@ -401,7 +381,7 @@ data VkImageCreateInfo =
                    , extent :: VkExtent3D 
                    , mipLevels :: Word32 
                    , arrayLayers :: Word32 
-                   , samples :: VkSampleCountFlagBits 
+                   , samples :: VkSampleCountFlags 
                    , tiling :: VkImageTiling 
                    , usage :: VkImageUsageFlags 
                    , sharingMode :: VkSharingMode 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -214,13 +214,13 @@ newtype ImageTiling = ImageTiling Int32
   deriving (Eq, Storable)
 
 instance Show ImageTiling where
-  showsPrec _ VK_IMAGE_TILING_OPTIMAL = showString "VK_IMAGE_TILING_OPTIMAL"
-  showsPrec _ VK_IMAGE_TILING_LINEAR = showString "VK_IMAGE_TILING_LINEAR"
+  showsPrec _ ImageTilingOptimal = showString "ImageTilingOptimal"
+  showsPrec _ ImageTilingLinear = showString "ImageTilingLinear"
   showsPrec p (ImageTiling x) = showParen (p >= 11) (showString "ImageTiling " . showsPrec 11 x)
 
 instance Read ImageTiling where
-  readPrec = parens ( choose [ ("VK_IMAGE_TILING_OPTIMAL", pure VK_IMAGE_TILING_OPTIMAL)
-                             , ("VK_IMAGE_TILING_LINEAR", pure VK_IMAGE_TILING_LINEAR)
+  readPrec = parens ( choose [ ("ImageTilingOptimal", pure ImageTilingOptimal)
+                             , ("ImageTilingLinear", pure ImageTilingLinear)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageTiling")
@@ -230,9 +230,9 @@ instance Read ImageTiling where
                     )
 
 
-pattern VK_IMAGE_TILING_OPTIMAL = ImageTiling 0
+pattern ImageTilingOptimal = ImageTiling 0
 
-pattern VK_IMAGE_TILING_LINEAR = ImageTiling 1
+pattern ImageTilingLinear = ImageTiling 1
 
 -- ** ImageLayout
 
@@ -240,27 +240,27 @@ newtype ImageLayout = ImageLayout Int32
   deriving (Eq, Storable)
 
 instance Show ImageLayout where
-  showsPrec _ VK_IMAGE_LAYOUT_UNDEFINED = showString "VK_IMAGE_LAYOUT_UNDEFINED"
-  showsPrec _ VK_IMAGE_LAYOUT_GENERAL = showString "VK_IMAGE_LAYOUT_GENERAL"
-  showsPrec _ VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = showString "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL = showString "VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL = showString "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = showString "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = showString "VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = showString "VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL"
-  showsPrec _ VK_IMAGE_LAYOUT_PREINITIALIZED = showString "VK_IMAGE_LAYOUT_PREINITIALIZED"
+  showsPrec _ ImageLayoutUndefined = showString "ImageLayoutUndefined"
+  showsPrec _ ImageLayoutGeneral = showString "ImageLayoutGeneral"
+  showsPrec _ ImageLayoutColorAttachmentOptimal = showString "ImageLayoutColorAttachmentOptimal"
+  showsPrec _ ImageLayoutDepthStencilAttachmentOptimal = showString "ImageLayoutDepthStencilAttachmentOptimal"
+  showsPrec _ ImageLayoutDepthStencilReadOnlyOptimal = showString "ImageLayoutDepthStencilReadOnlyOptimal"
+  showsPrec _ ImageLayoutShaderReadOnlyOptimal = showString "ImageLayoutShaderReadOnlyOptimal"
+  showsPrec _ ImageLayoutTransferSrcOptimal = showString "ImageLayoutTransferSrcOptimal"
+  showsPrec _ ImageLayoutTransferDstOptimal = showString "ImageLayoutTransferDstOptimal"
+  showsPrec _ ImageLayoutPreinitialized = showString "ImageLayoutPreinitialized"
   showsPrec p (ImageLayout x) = showParen (p >= 11) (showString "ImageLayout " . showsPrec 11 x)
 
 instance Read ImageLayout where
-  readPrec = parens ( choose [ ("VK_IMAGE_LAYOUT_UNDEFINED", pure VK_IMAGE_LAYOUT_UNDEFINED)
-                             , ("VK_IMAGE_LAYOUT_GENERAL", pure VK_IMAGE_LAYOUT_GENERAL)
-                             , ("VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL", pure VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL", pure VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL", pure VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL", pure VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL", pure VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL", pure VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL)
-                             , ("VK_IMAGE_LAYOUT_PREINITIALIZED", pure VK_IMAGE_LAYOUT_PREINITIALIZED)
+  readPrec = parens ( choose [ ("ImageLayoutUndefined", pure ImageLayoutUndefined)
+                             , ("ImageLayoutGeneral", pure ImageLayoutGeneral)
+                             , ("ImageLayoutColorAttachmentOptimal", pure ImageLayoutColorAttachmentOptimal)
+                             , ("ImageLayoutDepthStencilAttachmentOptimal", pure ImageLayoutDepthStencilAttachmentOptimal)
+                             , ("ImageLayoutDepthStencilReadOnlyOptimal", pure ImageLayoutDepthStencilReadOnlyOptimal)
+                             , ("ImageLayoutShaderReadOnlyOptimal", pure ImageLayoutShaderReadOnlyOptimal)
+                             , ("ImageLayoutTransferSrcOptimal", pure ImageLayoutTransferSrcOptimal)
+                             , ("ImageLayoutTransferDstOptimal", pure ImageLayoutTransferDstOptimal)
+                             , ("ImageLayoutPreinitialized", pure ImageLayoutPreinitialized)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageLayout")
@@ -270,23 +270,23 @@ instance Read ImageLayout where
                     )
 
 -- | Implicit layout an image is when its contents are undefined due to various reasons (e.g. right after creation)
-pattern VK_IMAGE_LAYOUT_UNDEFINED = ImageLayout 0
+pattern ImageLayoutUndefined = ImageLayout 0
 -- | General layout when image can be used for any kind of access
-pattern VK_IMAGE_LAYOUT_GENERAL = ImageLayout 1
+pattern ImageLayoutGeneral = ImageLayout 1
 -- | Optimal layout when image is only used for color attachment read/write
-pattern VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = ImageLayout 2
+pattern ImageLayoutColorAttachmentOptimal = ImageLayout 2
 -- | Optimal layout when image is only used for depth/stencil attachment read/write
-pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL = ImageLayout 3
+pattern ImageLayoutDepthStencilAttachmentOptimal = ImageLayout 3
 -- | Optimal layout when image is used for read only depth/stencil attachment and shader access
-pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL = ImageLayout 4
+pattern ImageLayoutDepthStencilReadOnlyOptimal = ImageLayout 4
 -- | Optimal layout when image is used for read only shader access
-pattern VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = ImageLayout 5
+pattern ImageLayoutShaderReadOnlyOptimal = ImageLayout 5
 -- | Optimal layout when image is used only as source of transfer operations
-pattern VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = ImageLayout 6
+pattern ImageLayoutTransferSrcOptimal = ImageLayout 6
 -- | Optimal layout when image is used only as destination of transfer operations
-pattern VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = ImageLayout 7
+pattern ImageLayoutTransferDstOptimal = ImageLayout 7
 -- | Initial layout used when the data is populated by the CPU
-pattern VK_IMAGE_LAYOUT_PREINITIALIZED = ImageLayout 8
+pattern ImageLayoutPreinitialized = ImageLayout 8
 
 -- ** ImageType
 
@@ -294,15 +294,15 @@ newtype ImageType = ImageType Int32
   deriving (Eq, Storable)
 
 instance Show ImageType where
-  showsPrec _ VK_IMAGE_TYPE_1D = showString "VK_IMAGE_TYPE_1D"
-  showsPrec _ VK_IMAGE_TYPE_2D = showString "VK_IMAGE_TYPE_2D"
-  showsPrec _ VK_IMAGE_TYPE_3D = showString "VK_IMAGE_TYPE_3D"
+  showsPrec _ ImageType1d = showString "ImageType1d"
+  showsPrec _ ImageType2d = showString "ImageType2d"
+  showsPrec _ ImageType3d = showString "ImageType3d"
   showsPrec p (ImageType x) = showParen (p >= 11) (showString "ImageType " . showsPrec 11 x)
 
 instance Read ImageType where
-  readPrec = parens ( choose [ ("VK_IMAGE_TYPE_1D", pure VK_IMAGE_TYPE_1D)
-                             , ("VK_IMAGE_TYPE_2D", pure VK_IMAGE_TYPE_2D)
-                             , ("VK_IMAGE_TYPE_3D", pure VK_IMAGE_TYPE_3D)
+  readPrec = parens ( choose [ ("ImageType1d", pure ImageType1d)
+                             , ("ImageType2d", pure ImageType2d)
+                             , ("ImageType3d", pure ImageType3d)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageType")
@@ -312,11 +312,11 @@ instance Read ImageType where
                     )
 
 
-pattern VK_IMAGE_TYPE_1D = ImageType 0
+pattern ImageType1d = ImageType 0
 
-pattern VK_IMAGE_TYPE_2D = ImageType 1
+pattern ImageType2d = ImageType 1
 
-pattern VK_IMAGE_TYPE_3D = ImageType 2
+pattern ImageType3d = ImageType 2
 
 -- ** destroyImage
 foreign import ccall "vkDestroyImage" destroyImage ::

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -58,20 +58,20 @@ newtype ImageCreateFlags = ImageCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageCreateFlags where
-  showsPrec _ VK_IMAGE_CREATE_SPARSE_BINDING_BIT = showString "VK_IMAGE_CREATE_SPARSE_BINDING_BIT"
-  showsPrec _ VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT"
-  showsPrec _ VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = showString "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT"
-  showsPrec _ VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = showString "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT"
-  showsPrec _ VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = showString "VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT"
+  showsPrec _ ImageCreateSparseBindingBit = showString "ImageCreateSparseBindingBit"
+  showsPrec _ ImageCreateSparseResidencyBit = showString "ImageCreateSparseResidencyBit"
+  showsPrec _ ImageCreateSparseAliasedBit = showString "ImageCreateSparseAliasedBit"
+  showsPrec _ ImageCreateMutableFormatBit = showString "ImageCreateMutableFormatBit"
+  showsPrec _ ImageCreateCubeCompatibleBit = showString "ImageCreateCubeCompatibleBit"
   
   showsPrec p (ImageCreateFlags x) = showParen (p >= 11) (showString "ImageCreateFlags " . showsPrec 11 x)
 
 instance Read ImageCreateFlags where
-  readPrec = parens ( choose [ ("VK_IMAGE_CREATE_SPARSE_BINDING_BIT", pure VK_IMAGE_CREATE_SPARSE_BINDING_BIT)
-                             , ("VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT", pure VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT)
-                             , ("VK_IMAGE_CREATE_SPARSE_ALIASED_BIT", pure VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)
-                             , ("VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT", pure VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)
-                             , ("VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT", pure VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)
+  readPrec = parens ( choose [ ("ImageCreateSparseBindingBit", pure ImageCreateSparseBindingBit)
+                             , ("ImageCreateSparseResidencyBit", pure ImageCreateSparseResidencyBit)
+                             , ("ImageCreateSparseAliasedBit", pure ImageCreateSparseAliasedBit)
+                             , ("ImageCreateMutableFormatBit", pure ImageCreateMutableFormatBit)
+                             , ("ImageCreateCubeCompatibleBit", pure ImageCreateCubeCompatibleBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageCreateFlags")
@@ -81,15 +81,15 @@ instance Read ImageCreateFlags where
                     )
 
 -- | Image should support sparse backing
-pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = ImageCreateFlags 0x1
+pattern ImageCreateSparseBindingBit = ImageCreateFlags 0x1
 -- | Image should support sparse backing with partial residency
-pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = ImageCreateFlags 0x2
+pattern ImageCreateSparseResidencyBit = ImageCreateFlags 0x2
 -- | Image should support constent data access to physical memory blocks mapped into multiple locations of sparse images
-pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = ImageCreateFlags 0x4
+pattern ImageCreateSparseAliasedBit = ImageCreateFlags 0x4
 -- | Allows image views to have different format than the base image
-pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = ImageCreateFlags 0x8
+pattern ImageCreateMutableFormatBit = ImageCreateFlags 0x8
 -- | Allows creating image views with cube type from the created image
-pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = ImageCreateFlags 0x10
+pattern ImageCreateCubeCompatibleBit = ImageCreateFlags 0x10
 
 
 -- ** ImageUsageFlags
@@ -98,26 +98,26 @@ newtype ImageUsageFlags = ImageUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageUsageFlags where
-  showsPrec _ VK_IMAGE_USAGE_TRANSFER_SRC_BIT = showString "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
-  showsPrec _ VK_IMAGE_USAGE_TRANSFER_DST_BIT = showString "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
-  showsPrec _ VK_IMAGE_USAGE_SAMPLED_BIT = showString "VK_IMAGE_USAGE_SAMPLED_BIT"
-  showsPrec _ VK_IMAGE_USAGE_STORAGE_BIT = showString "VK_IMAGE_USAGE_STORAGE_BIT"
-  showsPrec _ VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT"
-  showsPrec _ VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT"
-  showsPrec _ VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT"
-  showsPrec _ VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT"
+  showsPrec _ ImageUsageTransferSrcBit = showString "ImageUsageTransferSrcBit"
+  showsPrec _ ImageUsageTransferDstBit = showString "ImageUsageTransferDstBit"
+  showsPrec _ ImageUsageSampledBit = showString "ImageUsageSampledBit"
+  showsPrec _ ImageUsageStorageBit = showString "ImageUsageStorageBit"
+  showsPrec _ ImageUsageColorAttachmentBit = showString "ImageUsageColorAttachmentBit"
+  showsPrec _ ImageUsageDepthStencilAttachmentBit = showString "ImageUsageDepthStencilAttachmentBit"
+  showsPrec _ ImageUsageTransientAttachmentBit = showString "ImageUsageTransientAttachmentBit"
+  showsPrec _ ImageUsageInputAttachmentBit = showString "ImageUsageInputAttachmentBit"
   
   showsPrec p (ImageUsageFlags x) = showParen (p >= 11) (showString "ImageUsageFlags " . showsPrec 11 x)
 
 instance Read ImageUsageFlags where
-  readPrec = parens ( choose [ ("VK_IMAGE_USAGE_TRANSFER_SRC_BIT", pure VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
-                             , ("VK_IMAGE_USAGE_TRANSFER_DST_BIT", pure VK_IMAGE_USAGE_TRANSFER_DST_BIT)
-                             , ("VK_IMAGE_USAGE_SAMPLED_BIT", pure VK_IMAGE_USAGE_SAMPLED_BIT)
-                             , ("VK_IMAGE_USAGE_STORAGE_BIT", pure VK_IMAGE_USAGE_STORAGE_BIT)
-                             , ("VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
-                             , ("VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
-                             , ("VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT)
-                             , ("VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)
+  readPrec = parens ( choose [ ("ImageUsageTransferSrcBit", pure ImageUsageTransferSrcBit)
+                             , ("ImageUsageTransferDstBit", pure ImageUsageTransferDstBit)
+                             , ("ImageUsageSampledBit", pure ImageUsageSampledBit)
+                             , ("ImageUsageStorageBit", pure ImageUsageStorageBit)
+                             , ("ImageUsageColorAttachmentBit", pure ImageUsageColorAttachmentBit)
+                             , ("ImageUsageDepthStencilAttachmentBit", pure ImageUsageDepthStencilAttachmentBit)
+                             , ("ImageUsageTransientAttachmentBit", pure ImageUsageTransientAttachmentBit)
+                             , ("ImageUsageInputAttachmentBit", pure ImageUsageInputAttachmentBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageUsageFlags")
@@ -127,21 +127,21 @@ instance Read ImageUsageFlags where
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_SRC_BIT = ImageUsageFlags 0x1
+pattern ImageUsageTransferSrcBit = ImageUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_DST_BIT = ImageUsageFlags 0x2
+pattern ImageUsageTransferDstBit = ImageUsageFlags 0x2
 -- | Can be sampled from (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_IMAGE_USAGE_SAMPLED_BIT = ImageUsageFlags 0x4
+pattern ImageUsageSampledBit = ImageUsageFlags 0x4
 -- | Can be used as storage image (STORAGE_IMAGE descriptor type)
-pattern VK_IMAGE_USAGE_STORAGE_BIT = ImageUsageFlags 0x8
+pattern ImageUsageStorageBit = ImageUsageFlags 0x8
 -- | Can be used as framebuffer color attachment
-pattern VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = ImageUsageFlags 0x10
+pattern ImageUsageColorAttachmentBit = ImageUsageFlags 0x10
 -- | Can be used as framebuffer depth/stencil attachment
-pattern VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = ImageUsageFlags 0x20
+pattern ImageUsageDepthStencilAttachmentBit = ImageUsageFlags 0x20
 -- | Image data not needed outside of rendering
-pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = ImageUsageFlags 0x40
+pattern ImageUsageTransientAttachmentBit = ImageUsageFlags 0x40
 -- | Can be used as framebuffer input attachment
-pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = ImageUsageFlags 0x80
+pattern ImageUsageInputAttachmentBit = ImageUsageFlags 0x80
 
 
 newtype Image = Image Word64
@@ -153,18 +153,18 @@ newtype ImageAspectFlags = ImageAspectFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageAspectFlags where
-  showsPrec _ VK_IMAGE_ASPECT_COLOR_BIT = showString "VK_IMAGE_ASPECT_COLOR_BIT"
-  showsPrec _ VK_IMAGE_ASPECT_DEPTH_BIT = showString "VK_IMAGE_ASPECT_DEPTH_BIT"
-  showsPrec _ VK_IMAGE_ASPECT_STENCIL_BIT = showString "VK_IMAGE_ASPECT_STENCIL_BIT"
-  showsPrec _ VK_IMAGE_ASPECT_METADATA_BIT = showString "VK_IMAGE_ASPECT_METADATA_BIT"
+  showsPrec _ ImageAspectColorBit = showString "ImageAspectColorBit"
+  showsPrec _ ImageAspectDepthBit = showString "ImageAspectDepthBit"
+  showsPrec _ ImageAspectStencilBit = showString "ImageAspectStencilBit"
+  showsPrec _ ImageAspectMetadataBit = showString "ImageAspectMetadataBit"
   
   showsPrec p (ImageAspectFlags x) = showParen (p >= 11) (showString "ImageAspectFlags " . showsPrec 11 x)
 
 instance Read ImageAspectFlags where
-  readPrec = parens ( choose [ ("VK_IMAGE_ASPECT_COLOR_BIT", pure VK_IMAGE_ASPECT_COLOR_BIT)
-                             , ("VK_IMAGE_ASPECT_DEPTH_BIT", pure VK_IMAGE_ASPECT_DEPTH_BIT)
-                             , ("VK_IMAGE_ASPECT_STENCIL_BIT", pure VK_IMAGE_ASPECT_STENCIL_BIT)
-                             , ("VK_IMAGE_ASPECT_METADATA_BIT", pure VK_IMAGE_ASPECT_METADATA_BIT)
+  readPrec = parens ( choose [ ("ImageAspectColorBit", pure ImageAspectColorBit)
+                             , ("ImageAspectDepthBit", pure ImageAspectDepthBit)
+                             , ("ImageAspectStencilBit", pure ImageAspectStencilBit)
+                             , ("ImageAspectMetadataBit", pure ImageAspectMetadataBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageAspectFlags")
@@ -174,13 +174,13 @@ instance Read ImageAspectFlags where
                     )
 
 
-pattern VK_IMAGE_ASPECT_COLOR_BIT = ImageAspectFlags 0x1
+pattern ImageAspectColorBit = ImageAspectFlags 0x1
 
-pattern VK_IMAGE_ASPECT_DEPTH_BIT = ImageAspectFlags 0x2
+pattern ImageAspectDepthBit = ImageAspectFlags 0x2
 
-pattern VK_IMAGE_ASPECT_STENCIL_BIT = ImageAspectFlags 0x4
+pattern ImageAspectStencilBit = ImageAspectFlags 0x4
 
-pattern VK_IMAGE_ASPECT_METADATA_BIT = ImageAspectFlags 0x8
+pattern ImageAspectMetadataBit = ImageAspectFlags 0x8
 
 
 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -26,7 +26,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -40,17 +40,17 @@ import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
                            , VkFlags(..)
+                           , Extent3D(..)
                            , VkResult(..)
                            , VkDeviceSize(..)
-                           , VkExtent3D(..)
                            , VkSharingMode(..)
                            )
 
 -- ** vkCreateImage
 foreign import ccall "vkCreateImage" vkCreateImage ::
   Device ->
-  Ptr VkImageCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Image -> IO VkResult
+  Ptr ImageCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Image -> IO VkResult
 
 -- ** VkImageCreateFlags
 
@@ -184,28 +184,28 @@ pattern VK_IMAGE_ASPECT_METADATA_BIT = VkImageAspectFlags 0x8
 
 
 
-data VkSubresourceLayout =
-  VkSubresourceLayout{ offset :: VkDeviceSize 
-                     , size :: VkDeviceSize 
-                     , rowPitch :: VkDeviceSize 
-                     , arrayPitch :: VkDeviceSize 
-                     , depthPitch :: VkDeviceSize 
-                     }
+data SubresourceLayout =
+  SubresourceLayout{ offset :: VkDeviceSize 
+                   , size :: VkDeviceSize 
+                   , rowPitch :: VkDeviceSize 
+                   , arrayPitch :: VkDeviceSize 
+                   , depthPitch :: VkDeviceSize 
+                   }
   deriving (Eq)
 
-instance Storable VkSubresourceLayout where
+instance Storable SubresourceLayout where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkSubresourceLayout <$> peek (ptr `plusPtr` 0)
-                                 <*> peek (ptr `plusPtr` 8)
-                                 <*> peek (ptr `plusPtr` 16)
-                                 <*> peek (ptr `plusPtr` 24)
-                                 <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 8) (size (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 16) (rowPitch (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 24) (arrayPitch (poked :: VkSubresourceLayout))
-                *> poke (ptr `plusPtr` 32) (depthPitch (poked :: VkSubresourceLayout))
+  peek ptr = SubresourceLayout <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 24)
+                               <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (offset (poked :: SubresourceLayout))
+                *> poke (ptr `plusPtr` 8) (size (poked :: SubresourceLayout))
+                *> poke (ptr `plusPtr` 16) (rowPitch (poked :: SubresourceLayout))
+                *> poke (ptr `plusPtr` 24) (arrayPitch (poked :: SubresourceLayout))
+                *> poke (ptr `plusPtr` 32) (depthPitch (poked :: SubresourceLayout))
 
 
 -- ** VkImageTiling
@@ -320,109 +320,109 @@ pattern VK_IMAGE_TYPE_3D = VkImageType 2
 
 -- ** vkDestroyImage
 foreign import ccall "vkDestroyImage" vkDestroyImage ::
-  Device -> Image -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Image -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkImageSubresource =
-  VkImageSubresource{ aspectMask :: VkImageAspectFlags 
-                    , mipLevel :: Word32 
-                    , arrayLayer :: Word32 
-                    }
+data ImageSubresource =
+  ImageSubresource{ aspectMask :: VkImageAspectFlags 
+                  , mipLevel :: Word32 
+                  , arrayLayer :: Word32 
+                  }
   deriving (Eq)
 
-instance Storable VkImageSubresource where
+instance Storable ImageSubresource where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkImageSubresource <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 4)
-                                <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresource))
-                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: VkImageSubresource))
-                *> poke (ptr `plusPtr` 8) (arrayLayer (poked :: VkImageSubresource))
+  peek ptr = ImageSubresource <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 4)
+                              <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: ImageSubresource))
+                *> poke (ptr `plusPtr` 4) (mipLevel (poked :: ImageSubresource))
+                *> poke (ptr `plusPtr` 8) (arrayLayer (poked :: ImageSubresource))
 
 
 
-data VkImageSubresourceRange =
-  VkImageSubresourceRange{ aspectMask :: VkImageAspectFlags 
-                         , baseMipLevel :: Word32 
-                         , levelCount :: Word32 
-                         , baseArrayLayer :: Word32 
-                         , layerCount :: Word32 
-                         }
+data ImageSubresourceRange =
+  ImageSubresourceRange{ aspectMask :: VkImageAspectFlags 
+                       , baseMipLevel :: Word32 
+                       , levelCount :: Word32 
+                       , baseArrayLayer :: Word32 
+                       , layerCount :: Word32 
+                       }
   deriving (Eq)
 
-instance Storable VkImageSubresourceRange where
+instance Storable ImageSubresourceRange where
   sizeOf ~_ = 20
   alignment ~_ = 4
-  peek ptr = VkImageSubresourceRange <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 4)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 12)
-                                     <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 4) (baseMipLevel (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 8) (levelCount (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 12) (baseArrayLayer (poked :: VkImageSubresourceRange))
-                *> poke (ptr `plusPtr` 16) (layerCount (poked :: VkImageSubresourceRange))
+  peek ptr = ImageSubresourceRange <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 4)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 12)
+                                   <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: ImageSubresourceRange))
+                *> poke (ptr `plusPtr` 4) (baseMipLevel (poked :: ImageSubresourceRange))
+                *> poke (ptr `plusPtr` 8) (levelCount (poked :: ImageSubresourceRange))
+                *> poke (ptr `plusPtr` 12) (baseArrayLayer (poked :: ImageSubresourceRange))
+                *> poke (ptr `plusPtr` 16) (layerCount (poked :: ImageSubresourceRange))
 
 
 -- ** vkGetImageSubresourceLayout
 foreign import ccall "vkGetImageSubresourceLayout" vkGetImageSubresourceLayout ::
   Device ->
-  Image -> Ptr VkImageSubresource -> Ptr VkSubresourceLayout -> IO ()
+  Image -> Ptr ImageSubresource -> Ptr SubresourceLayout -> IO ()
 
 
-data VkImageCreateInfo =
-  VkImageCreateInfo{ sType :: VkStructureType 
-                   , pNext :: Ptr Void 
-                   , flags :: VkImageCreateFlags 
-                   , imageType :: VkImageType 
-                   , format :: VkFormat 
-                   , extent :: VkExtent3D 
-                   , mipLevels :: Word32 
-                   , arrayLayers :: Word32 
-                   , samples :: VkSampleCountFlags 
-                   , tiling :: VkImageTiling 
-                   , usage :: VkImageUsageFlags 
-                   , sharingMode :: VkSharingMode 
-                   , queueFamilyIndexCount :: Word32 
-                   , pQueueFamilyIndices :: Ptr Word32 
-                   , initialLayout :: VkImageLayout 
-                   }
+data ImageCreateInfo =
+  ImageCreateInfo{ sType :: VkStructureType 
+                 , pNext :: Ptr Void 
+                 , flags :: VkImageCreateFlags 
+                 , imageType :: VkImageType 
+                 , format :: VkFormat 
+                 , extent :: Extent3D 
+                 , mipLevels :: Word32 
+                 , arrayLayers :: Word32 
+                 , samples :: VkSampleCountFlags 
+                 , tiling :: VkImageTiling 
+                 , usage :: VkImageUsageFlags 
+                 , sharingMode :: VkSharingMode 
+                 , queueFamilyIndexCount :: Word32 
+                 , pQueueFamilyIndices :: Ptr Word32 
+                 , initialLayout :: VkImageLayout 
+                 }
   deriving (Eq)
 
-instance Storable VkImageCreateInfo where
+instance Storable ImageCreateInfo where
   sizeOf ~_ = 88
   alignment ~_ = 8
-  peek ptr = VkImageCreateInfo <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 8)
-                               <*> peek (ptr `plusPtr` 16)
-                               <*> peek (ptr `plusPtr` 20)
-                               <*> peek (ptr `plusPtr` 24)
-                               <*> peek (ptr `plusPtr` 28)
-                               <*> peek (ptr `plusPtr` 40)
-                               <*> peek (ptr `plusPtr` 44)
-                               <*> peek (ptr `plusPtr` 48)
-                               <*> peek (ptr `plusPtr` 52)
-                               <*> peek (ptr `plusPtr` 56)
-                               <*> peek (ptr `plusPtr` 60)
-                               <*> peek (ptr `plusPtr` 64)
-                               <*> peek (ptr `plusPtr` 72)
-                               <*> peek (ptr `plusPtr` 80)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 20) (imageType (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 24) (format (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 28) (extent (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 40) (mipLevels (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 44) (arrayLayers (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 48) (samples (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 52) (tiling (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 56) (usage (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 60) (sharingMode (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: VkImageCreateInfo))
-                *> poke (ptr `plusPtr` 80) (initialLayout (poked :: VkImageCreateInfo))
+  peek ptr = ImageCreateInfo <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 8)
+                             <*> peek (ptr `plusPtr` 16)
+                             <*> peek (ptr `plusPtr` 20)
+                             <*> peek (ptr `plusPtr` 24)
+                             <*> peek (ptr `plusPtr` 28)
+                             <*> peek (ptr `plusPtr` 40)
+                             <*> peek (ptr `plusPtr` 44)
+                             <*> peek (ptr `plusPtr` 48)
+                             <*> peek (ptr `plusPtr` 52)
+                             <*> peek (ptr `plusPtr` 56)
+                             <*> peek (ptr `plusPtr` 60)
+                             <*> peek (ptr `plusPtr` 64)
+                             <*> peek (ptr `plusPtr` 72)
+                             <*> peek (ptr `plusPtr` 80)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 20) (imageType (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 24) (format (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 28) (extent (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 40) (mipLevels (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 44) (arrayLayers (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 48) (samples (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 52) (tiling (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 56) (usage (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 60) (sharingMode (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: ImageCreateInfo))
+                *> poke (ptr `plusPtr` 80) (initialLayout (poked :: ImageCreateInfo))
 
 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -52,7 +52,7 @@ foreign import ccall "vkCreateImage" createImage ::
   Ptr ImageCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Image -> IO Result
 
--- ** VkImageCreateFlags
+-- ** ImageCreateFlags
 
 newtype ImageCreateFlags = ImageCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -92,7 +92,7 @@ pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = ImageCreateFlags 0x8
 pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = ImageCreateFlags 0x10
 
 
--- ** VkImageUsageFlags
+-- ** ImageUsageFlags
 
 newtype ImageUsageFlags = ImageUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -147,7 +147,7 @@ pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = ImageUsageFlags 0x80
 newtype Image = Image Word64
   deriving (Eq, Storable)
 
--- ** VkImageAspectFlags
+-- ** ImageAspectFlags
 
 newtype ImageAspectFlags = ImageAspectFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Image where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,6 +26,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -31,6 +35,27 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+                              )
+import Graphics.Vulkan.Image( VkImageType
+                            , VkSubresourceLayout
+                            , VkImageAspectFlags
+                            , VkImageCreateFlags
+                            , VkImageLayout
+                            , VkImageTiling
+                            , VkImageCreateInfo
+                            , VkImageSubresource
+                            , Image
+                            , VkImageUsageFlags
+                            )
+import Graphics.Vulkan.Core( VkResult
+                           , VkExtent3D
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           , VkSharingMode
+                           )
 
 -- ** vkCreateImage
 foreign import ccall "vkCreateImage" vkCreateImage ::

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -46,8 +46,8 @@ import Graphics.Vulkan.Core( SharingMode(..)
                            , Flags(..)
                            )
 
--- ** vkCreateImage
-foreign import ccall "vkCreateImage" vkCreateImage ::
+-- ** createImage
+foreign import ccall "vkCreateImage" createImage ::
   Device ->
   Ptr ImageCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Image -> IO Result
@@ -318,8 +318,8 @@ pattern VK_IMAGE_TYPE_2D = ImageType 1
 
 pattern VK_IMAGE_TYPE_3D = ImageType 2
 
--- ** vkDestroyImage
-foreign import ccall "vkDestroyImage" vkDestroyImage ::
+-- ** destroyImage
+foreign import ccall "vkDestroyImage" destroyImage ::
   Device -> Image -> Ptr AllocationCallbacks -> IO ()
 
 
@@ -366,8 +366,8 @@ instance Storable ImageSubresourceRange where
                 *> poke (ptr `plusPtr` 16) (layerCount (poked :: ImageSubresourceRange))
 
 
--- ** vkGetImageSubresourceLayout
-foreign import ccall "vkGetImageSubresourceLayout" vkGetImageSubresourceLayout ::
+-- ** getImageSubresourceLayout
+foreign import ccall "vkGetImageSubresourceLayout" getImageSubresourceLayout ::
   Device ->
   Image -> Ptr ImageSubresource -> Ptr SubresourceLayout -> IO ()
 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -55,7 +55,7 @@ foreign import ccall "vkCreateImage" createImage ::
 -- ** ImageCreateFlags
 
 newtype ImageCreateFlags = ImageCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show ImageCreateFlags where
   showsPrec _ ImageCreateSparseBindingBit = showString "ImageCreateSparseBindingBit"
@@ -95,7 +95,7 @@ pattern ImageCreateCubeCompatibleBit = ImageCreateFlags 0x10
 -- ** ImageUsageFlags
 
 newtype ImageUsageFlags = ImageUsageFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show ImageUsageFlags where
   showsPrec _ ImageUsageTransferSrcBit = showString "ImageUsageTransferSrcBit"
@@ -145,12 +145,12 @@ pattern ImageUsageInputAttachmentBit = ImageUsageFlags 0x80
 
 
 newtype Image = Image Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** ImageAspectFlags
 
 newtype ImageAspectFlags = ImageAspectFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show ImageAspectFlags where
   showsPrec _ ImageAspectColorBit = showString "ImageAspectColorBit"
@@ -191,7 +191,7 @@ data SubresourceLayout =
                    , arrayPitch :: DeviceSize 
                    , depthPitch :: DeviceSize 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SubresourceLayout where
   sizeOf ~_ = 40
@@ -211,7 +211,7 @@ instance Storable SubresourceLayout where
 -- ** ImageTiling
 
 newtype ImageTiling = ImageTiling Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ImageTiling where
   showsPrec _ ImageTilingOptimal = showString "ImageTilingOptimal"
@@ -237,7 +237,7 @@ pattern ImageTilingLinear = ImageTiling 1
 -- ** ImageLayout
 
 newtype ImageLayout = ImageLayout Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ImageLayout where
   showsPrec _ ImageLayoutUndefined = showString "ImageLayoutUndefined"
@@ -291,7 +291,7 @@ pattern ImageLayoutPreinitialized = ImageLayout 8
 -- ** ImageType
 
 newtype ImageType = ImageType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ImageType where
   showsPrec _ ImageType1d = showString "ImageType1d"
@@ -328,7 +328,7 @@ data ImageSubresource =
                   , mipLevel :: Word32 
                   , arrayLayer :: Word32 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageSubresource where
   sizeOf ~_ = 12
@@ -349,7 +349,7 @@ data ImageSubresourceRange =
                        , baseArrayLayer :: Word32 
                        , layerCount :: Word32 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageSubresourceRange where
   sizeOf ~_ = 20
@@ -389,7 +389,7 @@ data ImageCreateInfo =
                  , pQueueFamilyIndices :: Ptr Word32 
                  , initialLayout :: ImageLayout 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageCreateInfo where
   sizeOf ~_ = 88

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -37,13 +37,13 @@ import Text.ParserCombinators.ReadPrec( prec
                                       )
 import Graphics.Vulkan.Sampler( SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , SharingMode(..)
+import Graphics.Vulkan.Core( SharingMode(..)
                            , StructureType(..)
                            , Format(..)
                            , Extent3D(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 
 -- ** vkCreateImage
@@ -54,7 +54,7 @@ foreign import ccall "vkCreateImage" vkCreateImage ::
 
 -- ** VkImageCreateFlags
 
-newtype ImageCreateFlags = ImageCreateFlags VkFlags
+newtype ImageCreateFlags = ImageCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageCreateFlags where
@@ -94,7 +94,7 @@ pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = ImageCreateFlags 0x10
 
 -- ** VkImageUsageFlags
 
-newtype ImageUsageFlags = ImageUsageFlags VkFlags
+newtype ImageUsageFlags = ImageUsageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageUsageFlags where
@@ -149,7 +149,7 @@ newtype Image = Image Word64
 
 -- ** VkImageAspectFlags
 
-newtype ImageAspectFlags = ImageAspectFlags VkFlags
+newtype ImageAspectFlags = ImageAspectFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ImageAspectFlags where
@@ -185,11 +185,11 @@ pattern VK_IMAGE_ASPECT_METADATA_BIT = ImageAspectFlags 0x8
 
 
 data SubresourceLayout =
-  SubresourceLayout{ offset :: VkDeviceSize 
-                   , size :: VkDeviceSize 
-                   , rowPitch :: VkDeviceSize 
-                   , arrayPitch :: VkDeviceSize 
-                   , depthPitch :: VkDeviceSize 
+  SubresourceLayout{ offset :: DeviceSize 
+                   , size :: DeviceSize 
+                   , rowPitch :: DeviceSize 
+                   , arrayPitch :: DeviceSize 
+                   , depthPitch :: DeviceSize 
                    }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -35,38 +35,38 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
+import Graphics.Vulkan.Sampler( SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , SharingMode(..)
+                           , StructureType(..)
+                           , Format(..)
                            , Extent3D(..)
-                           , VkResult(..)
+                           , Result(..)
                            , VkDeviceSize(..)
-                           , VkSharingMode(..)
                            )
 
 -- ** vkCreateImage
 foreign import ccall "vkCreateImage" vkCreateImage ::
   Device ->
   Ptr ImageCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Image -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Image -> IO Result
 
 -- ** VkImageCreateFlags
 
-newtype VkImageCreateFlags = VkImageCreateFlags VkFlags
+newtype ImageCreateFlags = ImageCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkImageCreateFlags where
+instance Show ImageCreateFlags where
   showsPrec _ VK_IMAGE_CREATE_SPARSE_BINDING_BIT = showString "VK_IMAGE_CREATE_SPARSE_BINDING_BIT"
   showsPrec _ VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = showString "VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT"
   showsPrec _ VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = showString "VK_IMAGE_CREATE_SPARSE_ALIASED_BIT"
   showsPrec _ VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = showString "VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT"
   showsPrec _ VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = showString "VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT"
   
-  showsPrec p (VkImageCreateFlags x) = showParen (p >= 11) (showString "VkImageCreateFlags " . showsPrec 11 x)
+  showsPrec p (ImageCreateFlags x) = showParen (p >= 11) (showString "ImageCreateFlags " . showsPrec 11 x)
 
-instance Read VkImageCreateFlags where
+instance Read ImageCreateFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_CREATE_SPARSE_BINDING_BIT", pure VK_IMAGE_CREATE_SPARSE_BINDING_BIT)
                              , ("VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT", pure VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT)
                              , ("VK_IMAGE_CREATE_SPARSE_ALIASED_BIT", pure VK_IMAGE_CREATE_SPARSE_ALIASED_BIT)
@@ -74,30 +74,30 @@ instance Read VkImageCreateFlags where
                              , ("VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT", pure VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageCreateFlags")
+                        expectP (Ident "ImageCreateFlags")
                         v <- step readPrec
-                        pure (VkImageCreateFlags v)
+                        pure (ImageCreateFlags v)
                         )
                     )
 
 -- | Image should support sparse backing
-pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = VkImageCreateFlags 0x1
+pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = ImageCreateFlags 0x1
 -- | Image should support sparse backing with partial residency
-pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = VkImageCreateFlags 0x2
+pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = ImageCreateFlags 0x2
 -- | Image should support constent data access to physical memory blocks mapped into multiple locations of sparse images
-pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = VkImageCreateFlags 0x4
+pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = ImageCreateFlags 0x4
 -- | Allows image views to have different format than the base image
-pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = VkImageCreateFlags 0x8
+pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = ImageCreateFlags 0x8
 -- | Allows creating image views with cube type from the created image
-pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = VkImageCreateFlags 0x10
+pattern VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT = ImageCreateFlags 0x10
 
 
 -- ** VkImageUsageFlags
 
-newtype VkImageUsageFlags = VkImageUsageFlags VkFlags
+newtype ImageUsageFlags = ImageUsageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkImageUsageFlags where
+instance Show ImageUsageFlags where
   showsPrec _ VK_IMAGE_USAGE_TRANSFER_SRC_BIT = showString "VK_IMAGE_USAGE_TRANSFER_SRC_BIT"
   showsPrec _ VK_IMAGE_USAGE_TRANSFER_DST_BIT = showString "VK_IMAGE_USAGE_TRANSFER_DST_BIT"
   showsPrec _ VK_IMAGE_USAGE_SAMPLED_BIT = showString "VK_IMAGE_USAGE_SAMPLED_BIT"
@@ -107,9 +107,9 @@ instance Show VkImageUsageFlags where
   showsPrec _ VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT"
   showsPrec _ VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = showString "VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT"
   
-  showsPrec p (VkImageUsageFlags x) = showParen (p >= 11) (showString "VkImageUsageFlags " . showsPrec 11 x)
+  showsPrec p (ImageUsageFlags x) = showParen (p >= 11) (showString "ImageUsageFlags " . showsPrec 11 x)
 
-instance Read VkImageUsageFlags where
+instance Read ImageUsageFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_USAGE_TRANSFER_SRC_BIT", pure VK_IMAGE_USAGE_TRANSFER_SRC_BIT)
                              , ("VK_IMAGE_USAGE_TRANSFER_DST_BIT", pure VK_IMAGE_USAGE_TRANSFER_DST_BIT)
                              , ("VK_IMAGE_USAGE_SAMPLED_BIT", pure VK_IMAGE_USAGE_SAMPLED_BIT)
@@ -120,28 +120,28 @@ instance Read VkImageUsageFlags where
                              , ("VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT", pure VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageUsageFlags")
+                        expectP (Ident "ImageUsageFlags")
                         v <- step readPrec
-                        pure (VkImageUsageFlags v)
+                        pure (ImageUsageFlags v)
                         )
                     )
 
 -- | Can be used as a source of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_SRC_BIT = VkImageUsageFlags 0x1
+pattern VK_IMAGE_USAGE_TRANSFER_SRC_BIT = ImageUsageFlags 0x1
 -- | Can be used as a destination of transfer operations
-pattern VK_IMAGE_USAGE_TRANSFER_DST_BIT = VkImageUsageFlags 0x2
+pattern VK_IMAGE_USAGE_TRANSFER_DST_BIT = ImageUsageFlags 0x2
 -- | Can be sampled from (SAMPLED_IMAGE and COMBINED_IMAGE_SAMPLER descriptor types)
-pattern VK_IMAGE_USAGE_SAMPLED_BIT = VkImageUsageFlags 0x4
+pattern VK_IMAGE_USAGE_SAMPLED_BIT = ImageUsageFlags 0x4
 -- | Can be used as storage image (STORAGE_IMAGE descriptor type)
-pattern VK_IMAGE_USAGE_STORAGE_BIT = VkImageUsageFlags 0x8
+pattern VK_IMAGE_USAGE_STORAGE_BIT = ImageUsageFlags 0x8
 -- | Can be used as framebuffer color attachment
-pattern VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = VkImageUsageFlags 0x10
+pattern VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT = ImageUsageFlags 0x10
 -- | Can be used as framebuffer depth/stencil attachment
-pattern VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = VkImageUsageFlags 0x20
+pattern VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT = ImageUsageFlags 0x20
 -- | Image data not needed outside of rendering
-pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = VkImageUsageFlags 0x40
+pattern VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT = ImageUsageFlags 0x40
 -- | Can be used as framebuffer input attachment
-pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = VkImageUsageFlags 0x80
+pattern VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT = ImageUsageFlags 0x80
 
 
 newtype Image = Image Word64
@@ -149,38 +149,38 @@ newtype Image = Image Word64
 
 -- ** VkImageAspectFlags
 
-newtype VkImageAspectFlags = VkImageAspectFlags VkFlags
+newtype ImageAspectFlags = ImageAspectFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkImageAspectFlags where
+instance Show ImageAspectFlags where
   showsPrec _ VK_IMAGE_ASPECT_COLOR_BIT = showString "VK_IMAGE_ASPECT_COLOR_BIT"
   showsPrec _ VK_IMAGE_ASPECT_DEPTH_BIT = showString "VK_IMAGE_ASPECT_DEPTH_BIT"
   showsPrec _ VK_IMAGE_ASPECT_STENCIL_BIT = showString "VK_IMAGE_ASPECT_STENCIL_BIT"
   showsPrec _ VK_IMAGE_ASPECT_METADATA_BIT = showString "VK_IMAGE_ASPECT_METADATA_BIT"
   
-  showsPrec p (VkImageAspectFlags x) = showParen (p >= 11) (showString "VkImageAspectFlags " . showsPrec 11 x)
+  showsPrec p (ImageAspectFlags x) = showParen (p >= 11) (showString "ImageAspectFlags " . showsPrec 11 x)
 
-instance Read VkImageAspectFlags where
+instance Read ImageAspectFlags where
   readPrec = parens ( choose [ ("VK_IMAGE_ASPECT_COLOR_BIT", pure VK_IMAGE_ASPECT_COLOR_BIT)
                              , ("VK_IMAGE_ASPECT_DEPTH_BIT", pure VK_IMAGE_ASPECT_DEPTH_BIT)
                              , ("VK_IMAGE_ASPECT_STENCIL_BIT", pure VK_IMAGE_ASPECT_STENCIL_BIT)
                              , ("VK_IMAGE_ASPECT_METADATA_BIT", pure VK_IMAGE_ASPECT_METADATA_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageAspectFlags")
+                        expectP (Ident "ImageAspectFlags")
                         v <- step readPrec
-                        pure (VkImageAspectFlags v)
+                        pure (ImageAspectFlags v)
                         )
                     )
 
 
-pattern VK_IMAGE_ASPECT_COLOR_BIT = VkImageAspectFlags 0x1
+pattern VK_IMAGE_ASPECT_COLOR_BIT = ImageAspectFlags 0x1
 
-pattern VK_IMAGE_ASPECT_DEPTH_BIT = VkImageAspectFlags 0x2
+pattern VK_IMAGE_ASPECT_DEPTH_BIT = ImageAspectFlags 0x2
 
-pattern VK_IMAGE_ASPECT_STENCIL_BIT = VkImageAspectFlags 0x4
+pattern VK_IMAGE_ASPECT_STENCIL_BIT = ImageAspectFlags 0x4
 
-pattern VK_IMAGE_ASPECT_METADATA_BIT = VkImageAspectFlags 0x8
+pattern VK_IMAGE_ASPECT_METADATA_BIT = ImageAspectFlags 0x8
 
 
 
@@ -208,38 +208,38 @@ instance Storable SubresourceLayout where
                 *> poke (ptr `plusPtr` 32) (depthPitch (poked :: SubresourceLayout))
 
 
--- ** VkImageTiling
+-- ** ImageTiling
 
-newtype VkImageTiling = VkImageTiling Int32
+newtype ImageTiling = ImageTiling Int32
   deriving (Eq, Storable)
 
-instance Show VkImageTiling where
+instance Show ImageTiling where
   showsPrec _ VK_IMAGE_TILING_OPTIMAL = showString "VK_IMAGE_TILING_OPTIMAL"
   showsPrec _ VK_IMAGE_TILING_LINEAR = showString "VK_IMAGE_TILING_LINEAR"
-  showsPrec p (VkImageTiling x) = showParen (p >= 11) (showString "VkImageTiling " . showsPrec 11 x)
+  showsPrec p (ImageTiling x) = showParen (p >= 11) (showString "ImageTiling " . showsPrec 11 x)
 
-instance Read VkImageTiling where
+instance Read ImageTiling where
   readPrec = parens ( choose [ ("VK_IMAGE_TILING_OPTIMAL", pure VK_IMAGE_TILING_OPTIMAL)
                              , ("VK_IMAGE_TILING_LINEAR", pure VK_IMAGE_TILING_LINEAR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageTiling")
+                        expectP (Ident "ImageTiling")
                         v <- step readPrec
-                        pure (VkImageTiling v)
+                        pure (ImageTiling v)
                         )
                     )
 
 
-pattern VK_IMAGE_TILING_OPTIMAL = VkImageTiling 0
+pattern VK_IMAGE_TILING_OPTIMAL = ImageTiling 0
 
-pattern VK_IMAGE_TILING_LINEAR = VkImageTiling 1
+pattern VK_IMAGE_TILING_LINEAR = ImageTiling 1
 
--- ** VkImageLayout
+-- ** ImageLayout
 
-newtype VkImageLayout = VkImageLayout Int32
+newtype ImageLayout = ImageLayout Int32
   deriving (Eq, Storable)
 
-instance Show VkImageLayout where
+instance Show ImageLayout where
   showsPrec _ VK_IMAGE_LAYOUT_UNDEFINED = showString "VK_IMAGE_LAYOUT_UNDEFINED"
   showsPrec _ VK_IMAGE_LAYOUT_GENERAL = showString "VK_IMAGE_LAYOUT_GENERAL"
   showsPrec _ VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = showString "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL"
@@ -249,9 +249,9 @@ instance Show VkImageLayout where
   showsPrec _ VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = showString "VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL"
   showsPrec _ VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = showString "VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL"
   showsPrec _ VK_IMAGE_LAYOUT_PREINITIALIZED = showString "VK_IMAGE_LAYOUT_PREINITIALIZED"
-  showsPrec p (VkImageLayout x) = showParen (p >= 11) (showString "VkImageLayout " . showsPrec 11 x)
+  showsPrec p (ImageLayout x) = showParen (p >= 11) (showString "ImageLayout " . showsPrec 11 x)
 
-instance Read VkImageLayout where
+instance Read ImageLayout where
   readPrec = parens ( choose [ ("VK_IMAGE_LAYOUT_UNDEFINED", pure VK_IMAGE_LAYOUT_UNDEFINED)
                              , ("VK_IMAGE_LAYOUT_GENERAL", pure VK_IMAGE_LAYOUT_GENERAL)
                              , ("VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL", pure VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL)
@@ -263,60 +263,60 @@ instance Read VkImageLayout where
                              , ("VK_IMAGE_LAYOUT_PREINITIALIZED", pure VK_IMAGE_LAYOUT_PREINITIALIZED)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageLayout")
+                        expectP (Ident "ImageLayout")
                         v <- step readPrec
-                        pure (VkImageLayout v)
+                        pure (ImageLayout v)
                         )
                     )
 
 -- | Implicit layout an image is when its contents are undefined due to various reasons (e.g. right after creation)
-pattern VK_IMAGE_LAYOUT_UNDEFINED = VkImageLayout 0
+pattern VK_IMAGE_LAYOUT_UNDEFINED = ImageLayout 0
 -- | General layout when image can be used for any kind of access
-pattern VK_IMAGE_LAYOUT_GENERAL = VkImageLayout 1
+pattern VK_IMAGE_LAYOUT_GENERAL = ImageLayout 1
 -- | Optimal layout when image is only used for color attachment read/write
-pattern VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = VkImageLayout 2
+pattern VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL = ImageLayout 2
 -- | Optimal layout when image is only used for depth/stencil attachment read/write
-pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL = VkImageLayout 3
+pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL = ImageLayout 3
 -- | Optimal layout when image is used for read only depth/stencil attachment and shader access
-pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL = VkImageLayout 4
+pattern VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL = ImageLayout 4
 -- | Optimal layout when image is used for read only shader access
-pattern VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = VkImageLayout 5
+pattern VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL = ImageLayout 5
 -- | Optimal layout when image is used only as source of transfer operations
-pattern VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = VkImageLayout 6
+pattern VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL = ImageLayout 6
 -- | Optimal layout when image is used only as destination of transfer operations
-pattern VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = VkImageLayout 7
+pattern VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL = ImageLayout 7
 -- | Initial layout used when the data is populated by the CPU
-pattern VK_IMAGE_LAYOUT_PREINITIALIZED = VkImageLayout 8
+pattern VK_IMAGE_LAYOUT_PREINITIALIZED = ImageLayout 8
 
--- ** VkImageType
+-- ** ImageType
 
-newtype VkImageType = VkImageType Int32
+newtype ImageType = ImageType Int32
   deriving (Eq, Storable)
 
-instance Show VkImageType where
+instance Show ImageType where
   showsPrec _ VK_IMAGE_TYPE_1D = showString "VK_IMAGE_TYPE_1D"
   showsPrec _ VK_IMAGE_TYPE_2D = showString "VK_IMAGE_TYPE_2D"
   showsPrec _ VK_IMAGE_TYPE_3D = showString "VK_IMAGE_TYPE_3D"
-  showsPrec p (VkImageType x) = showParen (p >= 11) (showString "VkImageType " . showsPrec 11 x)
+  showsPrec p (ImageType x) = showParen (p >= 11) (showString "ImageType " . showsPrec 11 x)
 
-instance Read VkImageType where
+instance Read ImageType where
   readPrec = parens ( choose [ ("VK_IMAGE_TYPE_1D", pure VK_IMAGE_TYPE_1D)
                              , ("VK_IMAGE_TYPE_2D", pure VK_IMAGE_TYPE_2D)
                              , ("VK_IMAGE_TYPE_3D", pure VK_IMAGE_TYPE_3D)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageType")
+                        expectP (Ident "ImageType")
                         v <- step readPrec
-                        pure (VkImageType v)
+                        pure (ImageType v)
                         )
                     )
 
 
-pattern VK_IMAGE_TYPE_1D = VkImageType 0
+pattern VK_IMAGE_TYPE_1D = ImageType 0
 
-pattern VK_IMAGE_TYPE_2D = VkImageType 1
+pattern VK_IMAGE_TYPE_2D = ImageType 1
 
-pattern VK_IMAGE_TYPE_3D = VkImageType 2
+pattern VK_IMAGE_TYPE_3D = ImageType 2
 
 -- ** vkDestroyImage
 foreign import ccall "vkDestroyImage" vkDestroyImage ::
@@ -324,7 +324,7 @@ foreign import ccall "vkDestroyImage" vkDestroyImage ::
 
 
 data ImageSubresource =
-  ImageSubresource{ aspectMask :: VkImageAspectFlags 
+  ImageSubresource{ aspectMask :: ImageAspectFlags 
                   , mipLevel :: Word32 
                   , arrayLayer :: Word32 
                   }
@@ -343,7 +343,7 @@ instance Storable ImageSubresource where
 
 
 data ImageSubresourceRange =
-  ImageSubresourceRange{ aspectMask :: VkImageAspectFlags 
+  ImageSubresourceRange{ aspectMask :: ImageAspectFlags 
                        , baseMipLevel :: Word32 
                        , levelCount :: Word32 
                        , baseArrayLayer :: Word32 
@@ -373,21 +373,21 @@ foreign import ccall "vkGetImageSubresourceLayout" vkGetImageSubresourceLayout :
 
 
 data ImageCreateInfo =
-  ImageCreateInfo{ sType :: VkStructureType 
+  ImageCreateInfo{ sType :: StructureType 
                  , pNext :: Ptr Void 
-                 , flags :: VkImageCreateFlags 
-                 , imageType :: VkImageType 
-                 , format :: VkFormat 
+                 , flags :: ImageCreateFlags 
+                 , imageType :: ImageType 
+                 , format :: Format 
                  , extent :: Extent3D 
                  , mipLevels :: Word32 
                  , arrayLayers :: Word32 
-                 , samples :: VkSampleCountFlags 
-                 , tiling :: VkImageTiling 
-                 , usage :: VkImageUsageFlags 
-                 , sharingMode :: VkSharingMode 
+                 , samples :: SampleCountFlags 
+                 , tiling :: ImageTiling 
+                 , usage :: ImageUsageFlags 
+                 , sharingMode :: SharingMode 
                  , queueFamilyIndexCount :: Word32 
                  , pQueueFamilyIndices :: Ptr Word32 
-                 , initialLayout :: VkImageLayout 
+                 , initialLayout :: ImageLayout 
                  }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -4,15 +4,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.ImageView where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -23,15 +20,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -39,18 +27,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( Image(..)
-                            , VkImageAspectFlagBits(..)
-                            , VkImageSubresourceRange(..)
-                            , VkImageAspectFlags(..)
-                            )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkImageViewCreateInfo =

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.ImageView where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -39,7 +39,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( VkImage(..)
+import Graphics.Vulkan.Image( Image(..)
                             , VkImageAspectFlagBits(..)
                             , VkImageSubresourceRange(..)
                             , VkImageAspectFlags(..)
@@ -54,14 +54,14 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkImageViewCreateInfo =
-  VkImageViewCreateInfo{ vkSType :: VkStructureType 
-                       , vkPNext :: Ptr Void 
-                       , vkFlags :: VkImageViewCreateFlags 
-                       , vkImage :: VkImage 
-                       , vkViewType :: VkImageViewType 
-                       , vkFormat :: VkFormat 
-                       , vkComponents :: VkComponentMapping 
-                       , vkSubresourceRange :: VkImageSubresourceRange 
+  VkImageViewCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkImageViewCreateFlags 
+                       , image :: Image 
+                       , viewType :: VkImageViewType 
+                       , format :: VkFormat 
+                       , components :: VkComponentMapping 
+                       , subresourceRange :: VkImageSubresourceRange 
                        }
   deriving (Eq)
 
@@ -76,23 +76,23 @@ instance Storable VkImageViewCreateInfo where
                                    <*> peek (ptr `plusPtr` 36)
                                    <*> peek (ptr `plusPtr` 40)
                                    <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkImage (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkViewType (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 36) (vkFormat (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkComponents (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkSubresourceRange (poked :: VkImageViewCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 24) (image (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 32) (viewType (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 36) (format (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 40) (components (poked :: VkImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 56) (subresourceRange (poked :: VkImageViewCreateInfo))
 
 
 -- ** vkCreateImageView
 foreign import ccall "vkCreateImageView" vkCreateImageView ::
-  VkDevice ->
+  Device ->
   Ptr VkImageViewCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkImageView -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr ImageView -> IO VkResult
 
-newtype VkImageView = VkImageView Word64
+newtype ImageView = ImageView Word64
   deriving (Eq, Storable)
 
 -- ** VkImageViewType
@@ -148,10 +148,10 @@ newtype VkImageViewCreateFlags = VkImageViewCreateFlags VkFlags
 
 
 data VkComponentMapping =
-  VkComponentMapping{ vkR :: VkComponentSwizzle 
-                    , vkG :: VkComponentSwizzle 
-                    , vkB :: VkComponentSwizzle 
-                    , vkA :: VkComponentSwizzle 
+  VkComponentMapping{ r :: VkComponentSwizzle 
+                    , g :: VkComponentSwizzle 
+                    , b :: VkComponentSwizzle 
+                    , a :: VkComponentSwizzle 
                     }
   deriving (Eq)
 
@@ -162,10 +162,10 @@ instance Storable VkComponentMapping where
                                 <*> peek (ptr `plusPtr` 4)
                                 <*> peek (ptr `plusPtr` 8)
                                 <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkR (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 4) (vkG (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 8) (vkB (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 12) (vkA (poked :: VkComponentMapping))
+  poke ptr poked = poke (ptr `plusPtr` 0) (r (poked :: VkComponentMapping))
+                *> poke (ptr `plusPtr` 4) (g (poked :: VkComponentMapping))
+                *> poke (ptr `plusPtr` 8) (b (poked :: VkComponentMapping))
+                *> poke (ptr `plusPtr` 12) (a (poked :: VkComponentMapping))
 
 
 -- ** VkComponentSwizzle
@@ -216,5 +216,5 @@ pattern VK_COMPONENT_SWIZZLE_A = VkComponentSwizzle 6
 
 -- ** vkDestroyImageView
 foreign import ccall "vkDestroyImageView" vkDestroyImageView ::
-  VkDevice -> VkImageView -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> ImageView -> Ptr VkAllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.ImageView where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -20,6 +22,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -27,6 +31,21 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Image( VkImageSubresourceRange
+                            , Image
+                            )
+import Graphics.Vulkan.ImageView( VkImageViewType
+                                , ImageView
+                                , VkImageViewCreateFlags
+                                , VkComponentSwizzle
+                                , VkImageViewCreateInfo
+                                , VkComponentMapping
+                                )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           )
 
 
 data VkImageViewCreateInfo =

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -34,10 +34,10 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Image( Image(..)
                             , ImageSubresourceRange(..)
                             )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Format(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 
@@ -131,7 +131,7 @@ pattern VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = ImageViewType 6
 
 -- ** ImageViewCreateFlags
 -- | Opaque flag
-newtype ImageViewCreateFlags = ImageViewCreateFlags VkFlags
+newtype ImageViewCreateFlags = ImageViewCreateFlags Flags
   deriving (Eq, Storable)
 
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -4,25 +4,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.ImageView where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
                )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -31,20 +31,13 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( VkImageSubresourceRange
-                            , Image
+import Graphics.Vulkan.Image( Image(..)
+                            , VkImageSubresourceRange(..)
                             )
-import Graphics.Vulkan.ImageView( VkImageViewType
-                                , ImageView
-                                , VkImageViewCreateFlags
-                                , VkComponentSwizzle
-                                , VkImageViewCreateInfo
-                                , VkComponentMapping
-                                )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
 
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -136,10 +136,10 @@ newtype ImageViewCreateFlags = ImageViewCreateFlags Flags
 
 
 data ComponentMapping =
-  ComponentMapping{ r :: ComponentSwizzle 
-                  , g :: ComponentSwizzle 
-                  , b :: ComponentSwizzle 
-                  , a :: ComponentSwizzle 
+  ComponentMapping{ red :: ComponentSwizzle 
+                  , green :: ComponentSwizzle 
+                  , blue :: ComponentSwizzle 
+                  , alpha :: ComponentSwizzle 
                   }
   deriving (Eq, Ord)
 
@@ -150,10 +150,10 @@ instance Storable ComponentMapping where
                               <*> peek (ptr `plusPtr` 4)
                               <*> peek (ptr `plusPtr` 8)
                               <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (r (poked :: ComponentMapping))
-                *> poke (ptr `plusPtr` 4) (g (poked :: ComponentMapping))
-                *> poke (ptr `plusPtr` 8) (b (poked :: ComponentMapping))
-                *> poke (ptr `plusPtr` 12) (a (poked :: ComponentMapping))
+  poke ptr poked = poke (ptr `plusPtr` 0) (red (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 4) (green (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 8) (blue (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 12) (alpha (poked :: ComponentMapping))
 
 
 -- ** ComponentSwizzle

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -89,23 +89,23 @@ newtype ImageViewType = ImageViewType Int32
   deriving (Eq, Storable)
 
 instance Show ImageViewType where
-  showsPrec _ VK_IMAGE_VIEW_TYPE_1D = showString "VK_IMAGE_VIEW_TYPE_1D"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_2D = showString "VK_IMAGE_VIEW_TYPE_2D"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_3D = showString "VK_IMAGE_VIEW_TYPE_3D"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_CUBE = showString "VK_IMAGE_VIEW_TYPE_CUBE"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_1D_ARRAY = showString "VK_IMAGE_VIEW_TYPE_1D_ARRAY"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_2D_ARRAY = showString "VK_IMAGE_VIEW_TYPE_2D_ARRAY"
-  showsPrec _ VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = showString "VK_IMAGE_VIEW_TYPE_CUBE_ARRAY"
+  showsPrec _ ImageViewType1d = showString "ImageViewType1d"
+  showsPrec _ ImageViewType2d = showString "ImageViewType2d"
+  showsPrec _ ImageViewType3d = showString "ImageViewType3d"
+  showsPrec _ ImageViewTypeCube = showString "ImageViewTypeCube"
+  showsPrec _ ImageViewType1dArray = showString "ImageViewType1dArray"
+  showsPrec _ ImageViewType2dArray = showString "ImageViewType2dArray"
+  showsPrec _ ImageViewTypeCubeArray = showString "ImageViewTypeCubeArray"
   showsPrec p (ImageViewType x) = showParen (p >= 11) (showString "ImageViewType " . showsPrec 11 x)
 
 instance Read ImageViewType where
-  readPrec = parens ( choose [ ("VK_IMAGE_VIEW_TYPE_1D", pure VK_IMAGE_VIEW_TYPE_1D)
-                             , ("VK_IMAGE_VIEW_TYPE_2D", pure VK_IMAGE_VIEW_TYPE_2D)
-                             , ("VK_IMAGE_VIEW_TYPE_3D", pure VK_IMAGE_VIEW_TYPE_3D)
-                             , ("VK_IMAGE_VIEW_TYPE_CUBE", pure VK_IMAGE_VIEW_TYPE_CUBE)
-                             , ("VK_IMAGE_VIEW_TYPE_1D_ARRAY", pure VK_IMAGE_VIEW_TYPE_1D_ARRAY)
-                             , ("VK_IMAGE_VIEW_TYPE_2D_ARRAY", pure VK_IMAGE_VIEW_TYPE_2D_ARRAY)
-                             , ("VK_IMAGE_VIEW_TYPE_CUBE_ARRAY", pure VK_IMAGE_VIEW_TYPE_CUBE_ARRAY)
+  readPrec = parens ( choose [ ("ImageViewType1d", pure ImageViewType1d)
+                             , ("ImageViewType2d", pure ImageViewType2d)
+                             , ("ImageViewType3d", pure ImageViewType3d)
+                             , ("ImageViewTypeCube", pure ImageViewTypeCube)
+                             , ("ImageViewType1dArray", pure ImageViewType1dArray)
+                             , ("ImageViewType2dArray", pure ImageViewType2dArray)
+                             , ("ImageViewTypeCubeArray", pure ImageViewTypeCubeArray)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ImageViewType")
@@ -115,19 +115,19 @@ instance Read ImageViewType where
                     )
 
 
-pattern VK_IMAGE_VIEW_TYPE_1D = ImageViewType 0
+pattern ImageViewType1d = ImageViewType 0
 
-pattern VK_IMAGE_VIEW_TYPE_2D = ImageViewType 1
+pattern ImageViewType2d = ImageViewType 1
 
-pattern VK_IMAGE_VIEW_TYPE_3D = ImageViewType 2
+pattern ImageViewType3d = ImageViewType 2
 
-pattern VK_IMAGE_VIEW_TYPE_CUBE = ImageViewType 3
+pattern ImageViewTypeCube = ImageViewType 3
 
-pattern VK_IMAGE_VIEW_TYPE_1D_ARRAY = ImageViewType 4
+pattern ImageViewType1dArray = ImageViewType 4
 
-pattern VK_IMAGE_VIEW_TYPE_2D_ARRAY = ImageViewType 5
+pattern ImageViewType2dArray = ImageViewType 5
 
-pattern VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = ImageViewType 6
+pattern ImageViewTypeCubeArray = ImageViewType 6
 
 -- ** ImageViewCreateFlags
 -- | Opaque flag
@@ -162,23 +162,23 @@ newtype ComponentSwizzle = ComponentSwizzle Int32
   deriving (Eq, Storable)
 
 instance Show ComponentSwizzle where
-  showsPrec _ VK_COMPONENT_SWIZZLE_IDENTITY = showString "VK_COMPONENT_SWIZZLE_IDENTITY"
-  showsPrec _ VK_COMPONENT_SWIZZLE_ZERO = showString "VK_COMPONENT_SWIZZLE_ZERO"
-  showsPrec _ VK_COMPONENT_SWIZZLE_ONE = showString "VK_COMPONENT_SWIZZLE_ONE"
-  showsPrec _ VK_COMPONENT_SWIZZLE_R = showString "VK_COMPONENT_SWIZZLE_R"
-  showsPrec _ VK_COMPONENT_SWIZZLE_G = showString "VK_COMPONENT_SWIZZLE_G"
-  showsPrec _ VK_COMPONENT_SWIZZLE_B = showString "VK_COMPONENT_SWIZZLE_B"
-  showsPrec _ VK_COMPONENT_SWIZZLE_A = showString "VK_COMPONENT_SWIZZLE_A"
+  showsPrec _ ComponentSwizzleIdentity = showString "ComponentSwizzleIdentity"
+  showsPrec _ ComponentSwizzleZero = showString "ComponentSwizzleZero"
+  showsPrec _ ComponentSwizzleOne = showString "ComponentSwizzleOne"
+  showsPrec _ ComponentSwizzleR = showString "ComponentSwizzleR"
+  showsPrec _ ComponentSwizzleG = showString "ComponentSwizzleG"
+  showsPrec _ ComponentSwizzleB = showString "ComponentSwizzleB"
+  showsPrec _ ComponentSwizzleA = showString "ComponentSwizzleA"
   showsPrec p (ComponentSwizzle x) = showParen (p >= 11) (showString "ComponentSwizzle " . showsPrec 11 x)
 
 instance Read ComponentSwizzle where
-  readPrec = parens ( choose [ ("VK_COMPONENT_SWIZZLE_IDENTITY", pure VK_COMPONENT_SWIZZLE_IDENTITY)
-                             , ("VK_COMPONENT_SWIZZLE_ZERO", pure VK_COMPONENT_SWIZZLE_ZERO)
-                             , ("VK_COMPONENT_SWIZZLE_ONE", pure VK_COMPONENT_SWIZZLE_ONE)
-                             , ("VK_COMPONENT_SWIZZLE_R", pure VK_COMPONENT_SWIZZLE_R)
-                             , ("VK_COMPONENT_SWIZZLE_G", pure VK_COMPONENT_SWIZZLE_G)
-                             , ("VK_COMPONENT_SWIZZLE_B", pure VK_COMPONENT_SWIZZLE_B)
-                             , ("VK_COMPONENT_SWIZZLE_A", pure VK_COMPONENT_SWIZZLE_A)
+  readPrec = parens ( choose [ ("ComponentSwizzleIdentity", pure ComponentSwizzleIdentity)
+                             , ("ComponentSwizzleZero", pure ComponentSwizzleZero)
+                             , ("ComponentSwizzleOne", pure ComponentSwizzleOne)
+                             , ("ComponentSwizzleR", pure ComponentSwizzleR)
+                             , ("ComponentSwizzleG", pure ComponentSwizzleG)
+                             , ("ComponentSwizzleB", pure ComponentSwizzleB)
+                             , ("ComponentSwizzleA", pure ComponentSwizzleA)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ComponentSwizzle")
@@ -188,19 +188,19 @@ instance Read ComponentSwizzle where
                     )
 
 
-pattern VK_COMPONENT_SWIZZLE_IDENTITY = ComponentSwizzle 0
+pattern ComponentSwizzleIdentity = ComponentSwizzle 0
 
-pattern VK_COMPONENT_SWIZZLE_ZERO = ComponentSwizzle 1
+pattern ComponentSwizzleZero = ComponentSwizzle 1
 
-pattern VK_COMPONENT_SWIZZLE_ONE = ComponentSwizzle 2
+pattern ComponentSwizzleOne = ComponentSwizzle 2
 
-pattern VK_COMPONENT_SWIZZLE_R = ComponentSwizzle 3
+pattern ComponentSwizzleR = ComponentSwizzle 3
 
-pattern VK_COMPONENT_SWIZZLE_G = ComponentSwizzle 4
+pattern ComponentSwizzleG = ComponentSwizzle 4
 
-pattern VK_COMPONENT_SWIZZLE_B = ComponentSwizzle 5
+pattern ComponentSwizzleB = ComponentSwizzle 5
 
-pattern VK_COMPONENT_SWIZZLE_A = ComponentSwizzle 6
+pattern ComponentSwizzleA = ComponentSwizzle 6
 
 -- ** destroyImageView
 foreign import ccall "vkDestroyImageView" destroyImageView ::

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -74,8 +74,8 @@ instance Storable ImageViewCreateInfo where
                 *> poke (ptr `plusPtr` 56) (subresourceRange (poked :: ImageViewCreateInfo))
 
 
--- ** vkCreateImageView
-foreign import ccall "vkCreateImageView" vkCreateImageView ::
+-- ** createImageView
+foreign import ccall "vkCreateImageView" createImageView ::
   Device ->
   Ptr ImageViewCreateInfo ->
     Ptr AllocationCallbacks -> Ptr ImageView -> IO Result
@@ -202,7 +202,7 @@ pattern VK_COMPONENT_SWIZZLE_B = ComponentSwizzle 5
 
 pattern VK_COMPONENT_SWIZZLE_A = ComponentSwizzle 6
 
--- ** vkDestroyImageView
-foreign import ccall "vkDestroyImageView" vkDestroyImageView ::
+-- ** destroyImageView
+foreign import ccall "vkDestroyImageView" destroyImageView ::
   Device -> ImageView -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -51,7 +51,7 @@ data ImageViewCreateInfo =
                      , components :: ComponentMapping 
                      , subresourceRange :: ImageSubresourceRange 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageViewCreateInfo where
   sizeOf ~_ = 80
@@ -81,12 +81,12 @@ foreign import ccall "vkCreateImageView" createImageView ::
     Ptr AllocationCallbacks -> Ptr ImageView -> IO Result
 
 newtype ImageView = ImageView Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** ImageViewType
 
 newtype ImageViewType = ImageViewType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ImageViewType where
   showsPrec _ ImageViewType1d = showString "ImageViewType1d"
@@ -132,7 +132,7 @@ pattern ImageViewTypeCubeArray = ImageViewType 6
 -- ** ImageViewCreateFlags
 -- | Opaque flag
 newtype ImageViewCreateFlags = ImageViewCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data ComponentMapping =
@@ -141,7 +141,7 @@ data ComponentMapping =
                   , b :: ComponentSwizzle 
                   , a :: ComponentSwizzle 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ComponentMapping where
   sizeOf ~_ = 16
@@ -159,7 +159,7 @@ instance Storable ComponentMapping where
 -- ** ComponentSwizzle
 
 newtype ComponentSwizzle = ComponentSwizzle Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ComponentSwizzle where
   showsPrec _ ComponentSwizzleIdentity = showString "ComponentSwizzleIdentity"

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -22,7 +22,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -32,7 +32,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , step
                                       )
 import Graphics.Vulkan.Image( Image(..)
-                            , VkImageSubresourceRange(..)
+                            , ImageSubresourceRange(..)
                             )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
@@ -41,44 +41,44 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            )
 
 
-data VkImageViewCreateInfo =
-  VkImageViewCreateInfo{ sType :: VkStructureType 
-                       , pNext :: Ptr Void 
-                       , flags :: VkImageViewCreateFlags 
-                       , image :: Image 
-                       , viewType :: VkImageViewType 
-                       , format :: VkFormat 
-                       , components :: VkComponentMapping 
-                       , subresourceRange :: VkImageSubresourceRange 
-                       }
+data ImageViewCreateInfo =
+  ImageViewCreateInfo{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , flags :: VkImageViewCreateFlags 
+                     , image :: Image 
+                     , viewType :: VkImageViewType 
+                     , format :: VkFormat 
+                     , components :: ComponentMapping 
+                     , subresourceRange :: ImageSubresourceRange 
+                     }
   deriving (Eq)
 
-instance Storable VkImageViewCreateInfo where
+instance Storable ImageViewCreateInfo where
   sizeOf ~_ = 80
   alignment ~_ = 8
-  peek ptr = VkImageViewCreateInfo <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 24)
-                                   <*> peek (ptr `plusPtr` 32)
-                                   <*> peek (ptr `plusPtr` 36)
-                                   <*> peek (ptr `plusPtr` 40)
-                                   <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 24) (image (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 32) (viewType (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 36) (format (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 40) (components (poked :: VkImageViewCreateInfo))
-                *> poke (ptr `plusPtr` 56) (subresourceRange (poked :: VkImageViewCreateInfo))
+  peek ptr = ImageViewCreateInfo <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 36)
+                                 <*> peek (ptr `plusPtr` 40)
+                                 <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 24) (image (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 32) (viewType (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 36) (format (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 40) (components (poked :: ImageViewCreateInfo))
+                *> poke (ptr `plusPtr` 56) (subresourceRange (poked :: ImageViewCreateInfo))
 
 
 -- ** vkCreateImageView
 foreign import ccall "vkCreateImageView" vkCreateImageView ::
   Device ->
-  Ptr VkImageViewCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr ImageView -> IO VkResult
+  Ptr ImageViewCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr ImageView -> IO VkResult
 
 newtype ImageView = ImageView Word64
   deriving (Eq, Storable)
@@ -135,25 +135,25 @@ newtype VkImageViewCreateFlags = VkImageViewCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
-data VkComponentMapping =
-  VkComponentMapping{ r :: VkComponentSwizzle 
-                    , g :: VkComponentSwizzle 
-                    , b :: VkComponentSwizzle 
-                    , a :: VkComponentSwizzle 
-                    }
+data ComponentMapping =
+  ComponentMapping{ r :: VkComponentSwizzle 
+                  , g :: VkComponentSwizzle 
+                  , b :: VkComponentSwizzle 
+                  , a :: VkComponentSwizzle 
+                  }
   deriving (Eq)
 
-instance Storable VkComponentMapping where
+instance Storable ComponentMapping where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ptr = VkComponentMapping <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 4)
-                                <*> peek (ptr `plusPtr` 8)
-                                <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (r (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 4) (g (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 8) (b (poked :: VkComponentMapping))
-                *> poke (ptr `plusPtr` 12) (a (poked :: VkComponentMapping))
+  peek ptr = ComponentMapping <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 4)
+                              <*> peek (ptr `plusPtr` 8)
+                              <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (r (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 4) (g (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 8) (b (poked :: ComponentMapping))
+                *> poke (ptr `plusPtr` 12) (a (poked :: ComponentMapping))
 
 
 -- ** VkComponentSwizzle
@@ -204,5 +204,5 @@ pattern VK_COMPONENT_SWIZZLE_A = VkComponentSwizzle 6
 
 -- ** vkDestroyImageView
 foreign import ccall "vkDestroyImageView" vkDestroyImageView ::
-  Device -> ImageView -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> ImageView -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/ImageView.hs
+++ b/src/Graphics/Vulkan/ImageView.hs
@@ -34,20 +34,20 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Image( Image(..)
                             , ImageSubresourceRange(..)
                             )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Format(..)
+                           , Result(..)
                            )
 
 
 data ImageViewCreateInfo =
-  ImageViewCreateInfo{ sType :: VkStructureType 
+  ImageViewCreateInfo{ sType :: StructureType 
                      , pNext :: Ptr Void 
-                     , flags :: VkImageViewCreateFlags 
+                     , flags :: ImageViewCreateFlags 
                      , image :: Image 
-                     , viewType :: VkImageViewType 
-                     , format :: VkFormat 
+                     , viewType :: ImageViewType 
+                     , format :: Format 
                      , components :: ComponentMapping 
                      , subresourceRange :: ImageSubresourceRange 
                      }
@@ -78,17 +78,17 @@ instance Storable ImageViewCreateInfo where
 foreign import ccall "vkCreateImageView" vkCreateImageView ::
   Device ->
   Ptr ImageViewCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr ImageView -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr ImageView -> IO Result
 
 newtype ImageView = ImageView Word64
   deriving (Eq, Storable)
 
--- ** VkImageViewType
+-- ** ImageViewType
 
-newtype VkImageViewType = VkImageViewType Int32
+newtype ImageViewType = ImageViewType Int32
   deriving (Eq, Storable)
 
-instance Show VkImageViewType where
+instance Show ImageViewType where
   showsPrec _ VK_IMAGE_VIEW_TYPE_1D = showString "VK_IMAGE_VIEW_TYPE_1D"
   showsPrec _ VK_IMAGE_VIEW_TYPE_2D = showString "VK_IMAGE_VIEW_TYPE_2D"
   showsPrec _ VK_IMAGE_VIEW_TYPE_3D = showString "VK_IMAGE_VIEW_TYPE_3D"
@@ -96,9 +96,9 @@ instance Show VkImageViewType where
   showsPrec _ VK_IMAGE_VIEW_TYPE_1D_ARRAY = showString "VK_IMAGE_VIEW_TYPE_1D_ARRAY"
   showsPrec _ VK_IMAGE_VIEW_TYPE_2D_ARRAY = showString "VK_IMAGE_VIEW_TYPE_2D_ARRAY"
   showsPrec _ VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = showString "VK_IMAGE_VIEW_TYPE_CUBE_ARRAY"
-  showsPrec p (VkImageViewType x) = showParen (p >= 11) (showString "VkImageViewType " . showsPrec 11 x)
+  showsPrec p (ImageViewType x) = showParen (p >= 11) (showString "ImageViewType " . showsPrec 11 x)
 
-instance Read VkImageViewType where
+instance Read ImageViewType where
   readPrec = parens ( choose [ ("VK_IMAGE_VIEW_TYPE_1D", pure VK_IMAGE_VIEW_TYPE_1D)
                              , ("VK_IMAGE_VIEW_TYPE_2D", pure VK_IMAGE_VIEW_TYPE_2D)
                              , ("VK_IMAGE_VIEW_TYPE_3D", pure VK_IMAGE_VIEW_TYPE_3D)
@@ -108,38 +108,38 @@ instance Read VkImageViewType where
                              , ("VK_IMAGE_VIEW_TYPE_CUBE_ARRAY", pure VK_IMAGE_VIEW_TYPE_CUBE_ARRAY)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkImageViewType")
+                        expectP (Ident "ImageViewType")
                         v <- step readPrec
-                        pure (VkImageViewType v)
+                        pure (ImageViewType v)
                         )
                     )
 
 
-pattern VK_IMAGE_VIEW_TYPE_1D = VkImageViewType 0
+pattern VK_IMAGE_VIEW_TYPE_1D = ImageViewType 0
 
-pattern VK_IMAGE_VIEW_TYPE_2D = VkImageViewType 1
+pattern VK_IMAGE_VIEW_TYPE_2D = ImageViewType 1
 
-pattern VK_IMAGE_VIEW_TYPE_3D = VkImageViewType 2
+pattern VK_IMAGE_VIEW_TYPE_3D = ImageViewType 2
 
-pattern VK_IMAGE_VIEW_TYPE_CUBE = VkImageViewType 3
+pattern VK_IMAGE_VIEW_TYPE_CUBE = ImageViewType 3
 
-pattern VK_IMAGE_VIEW_TYPE_1D_ARRAY = VkImageViewType 4
+pattern VK_IMAGE_VIEW_TYPE_1D_ARRAY = ImageViewType 4
 
-pattern VK_IMAGE_VIEW_TYPE_2D_ARRAY = VkImageViewType 5
+pattern VK_IMAGE_VIEW_TYPE_2D_ARRAY = ImageViewType 5
 
-pattern VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = VkImageViewType 6
+pattern VK_IMAGE_VIEW_TYPE_CUBE_ARRAY = ImageViewType 6
 
--- ** VkImageViewCreateFlags
+-- ** ImageViewCreateFlags
 -- | Opaque flag
-newtype VkImageViewCreateFlags = VkImageViewCreateFlags VkFlags
+newtype ImageViewCreateFlags = ImageViewCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data ComponentMapping =
-  ComponentMapping{ r :: VkComponentSwizzle 
-                  , g :: VkComponentSwizzle 
-                  , b :: VkComponentSwizzle 
-                  , a :: VkComponentSwizzle 
+  ComponentMapping{ r :: ComponentSwizzle 
+                  , g :: ComponentSwizzle 
+                  , b :: ComponentSwizzle 
+                  , a :: ComponentSwizzle 
                   }
   deriving (Eq)
 
@@ -156,12 +156,12 @@ instance Storable ComponentMapping where
                 *> poke (ptr `plusPtr` 12) (a (poked :: ComponentMapping))
 
 
--- ** VkComponentSwizzle
+-- ** ComponentSwizzle
 
-newtype VkComponentSwizzle = VkComponentSwizzle Int32
+newtype ComponentSwizzle = ComponentSwizzle Int32
   deriving (Eq, Storable)
 
-instance Show VkComponentSwizzle where
+instance Show ComponentSwizzle where
   showsPrec _ VK_COMPONENT_SWIZZLE_IDENTITY = showString "VK_COMPONENT_SWIZZLE_IDENTITY"
   showsPrec _ VK_COMPONENT_SWIZZLE_ZERO = showString "VK_COMPONENT_SWIZZLE_ZERO"
   showsPrec _ VK_COMPONENT_SWIZZLE_ONE = showString "VK_COMPONENT_SWIZZLE_ONE"
@@ -169,9 +169,9 @@ instance Show VkComponentSwizzle where
   showsPrec _ VK_COMPONENT_SWIZZLE_G = showString "VK_COMPONENT_SWIZZLE_G"
   showsPrec _ VK_COMPONENT_SWIZZLE_B = showString "VK_COMPONENT_SWIZZLE_B"
   showsPrec _ VK_COMPONENT_SWIZZLE_A = showString "VK_COMPONENT_SWIZZLE_A"
-  showsPrec p (VkComponentSwizzle x) = showParen (p >= 11) (showString "VkComponentSwizzle " . showsPrec 11 x)
+  showsPrec p (ComponentSwizzle x) = showParen (p >= 11) (showString "ComponentSwizzle " . showsPrec 11 x)
 
-instance Read VkComponentSwizzle where
+instance Read ComponentSwizzle where
   readPrec = parens ( choose [ ("VK_COMPONENT_SWIZZLE_IDENTITY", pure VK_COMPONENT_SWIZZLE_IDENTITY)
                              , ("VK_COMPONENT_SWIZZLE_ZERO", pure VK_COMPONENT_SWIZZLE_ZERO)
                              , ("VK_COMPONENT_SWIZZLE_ONE", pure VK_COMPONENT_SWIZZLE_ONE)
@@ -181,26 +181,26 @@ instance Read VkComponentSwizzle where
                              , ("VK_COMPONENT_SWIZZLE_A", pure VK_COMPONENT_SWIZZLE_A)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkComponentSwizzle")
+                        expectP (Ident "ComponentSwizzle")
                         v <- step readPrec
-                        pure (VkComponentSwizzle v)
+                        pure (ComponentSwizzle v)
                         )
                     )
 
 
-pattern VK_COMPONENT_SWIZZLE_IDENTITY = VkComponentSwizzle 0
+pattern VK_COMPONENT_SWIZZLE_IDENTITY = ComponentSwizzle 0
 
-pattern VK_COMPONENT_SWIZZLE_ZERO = VkComponentSwizzle 1
+pattern VK_COMPONENT_SWIZZLE_ZERO = ComponentSwizzle 1
 
-pattern VK_COMPONENT_SWIZZLE_ONE = VkComponentSwizzle 2
+pattern VK_COMPONENT_SWIZZLE_ONE = ComponentSwizzle 2
 
-pattern VK_COMPONENT_SWIZZLE_R = VkComponentSwizzle 3
+pattern VK_COMPONENT_SWIZZLE_R = ComponentSwizzle 3
 
-pattern VK_COMPONENT_SWIZZLE_G = VkComponentSwizzle 4
+pattern VK_COMPONENT_SWIZZLE_G = ComponentSwizzle 4
 
-pattern VK_COMPONENT_SWIZZLE_B = VkComponentSwizzle 5
+pattern VK_COMPONENT_SWIZZLE_B = ComponentSwizzle 5
 
-pattern VK_COMPONENT_SWIZZLE_A = VkComponentSwizzle 6
+pattern VK_COMPONENT_SWIZZLE_A = ComponentSwizzle 6
 
 -- ** vkDestroyImageView
 foreign import ccall "vkDestroyImageView" vkDestroyImageView ::

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Display where
 
-import Graphics.Vulkan.Device( VkPhysicalDevice(..)
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -19,7 +19,7 @@ import Foreign.Ptr( Ptr
                   )
 import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR(..)
                                   , VkSurfaceTransformFlagsKHR(..)
-                                  , VkSurfaceKHR(..)
+                                  , SurfaceKHR(..)
                                   )
 import Data.Int( Int32
                )
@@ -46,7 +46,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( VkInstance(..)
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkBool32(..)
@@ -63,16 +63,16 @@ import Foreign.C.Types( CFloat
 
 
 data VkDisplaySurfaceCreateInfoKHR =
-  VkDisplaySurfaceCreateInfoKHR{ vkSType :: VkStructureType 
-                               , vkPNext :: Ptr Void 
-                               , vkFlags :: VkDisplaySurfaceCreateFlagsKHR 
-                               , vkDisplayMode :: VkDisplayModeKHR 
-                               , vkPlaneIndex :: Word32 
-                               , vkPlaneStackIndex :: Word32 
-                               , vkTransform :: VkSurfaceTransformFlagBitsKHR 
-                               , vkGlobalAlpha :: CFloat 
-                               , vkAlphaMode :: VkDisplayPlaneAlphaFlagBitsKHR 
-                               , vkImageExtent :: VkExtent2D 
+  VkDisplaySurfaceCreateInfoKHR{ sType :: VkStructureType 
+                               , pNext :: Ptr Void 
+                               , flags :: VkDisplaySurfaceCreateFlagsKHR 
+                               , displayMode :: DisplayModeKHR 
+                               , planeIndex :: Word32 
+                               , planeStackIndex :: Word32 
+                               , transform :: VkSurfaceTransformFlagBitsKHR 
+                               , globalAlpha :: CFloat 
+                               , alphaMode :: VkDisplayPlaneAlphaFlagBitsKHR 
+                               , imageExtent :: VkExtent2D 
                                }
   deriving (Eq)
 
@@ -89,29 +89,29 @@ instance Storable VkDisplaySurfaceCreateInfoKHR where
                                            <*> peek (ptr `plusPtr` 44)
                                            <*> peek (ptr `plusPtr` 48)
                                            <*> peek (ptr `plusPtr` 52)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (vkDisplayMode (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (vkPlaneIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (vkPlaneStackIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (vkTransform (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (vkGlobalAlpha (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 48) (vkAlphaMode (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (vkImageExtent (poked :: VkDisplaySurfaceCreateInfoKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (displayMode (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (planeIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (planeStackIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (transform (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (globalAlpha (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 48) (alphaMode (poked :: VkDisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (imageExtent (poked :: VkDisplaySurfaceCreateInfoKHR))
 
 
 
 data VkDisplayPlaneCapabilitiesKHR =
-  VkDisplayPlaneCapabilitiesKHR{ vkSupportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
-                               , vkMinSrcPosition :: VkOffset2D 
-                               , vkMaxSrcPosition :: VkOffset2D 
-                               , vkMinSrcExtent :: VkExtent2D 
-                               , vkMaxSrcExtent :: VkExtent2D 
-                               , vkMinDstPosition :: VkOffset2D 
-                               , vkMaxDstPosition :: VkOffset2D 
-                               , vkMinDstExtent :: VkExtent2D 
-                               , vkMaxDstExtent :: VkExtent2D 
+  VkDisplayPlaneCapabilitiesKHR{ supportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
+                               , minSrcPosition :: VkOffset2D 
+                               , maxSrcPosition :: VkOffset2D 
+                               , minSrcExtent :: VkExtent2D 
+                               , maxSrcExtent :: VkExtent2D 
+                               , minDstPosition :: VkOffset2D 
+                               , maxDstPosition :: VkOffset2D 
+                               , minDstExtent :: VkExtent2D 
+                               , maxDstExtent :: VkExtent2D 
                                }
   deriving (Eq)
 
@@ -127,32 +127,32 @@ instance Storable VkDisplayPlaneCapabilitiesKHR where
                                            <*> peek (ptr `plusPtr` 44)
                                            <*> peek (ptr `plusPtr` 52)
                                            <*> peek (ptr `plusPtr` 60)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSupportedAlpha (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (vkMinSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 12) (vkMaxSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 20) (vkMinSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 28) (vkMaxSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (vkMinDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (vkMaxDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 52) (vkMinDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 60) (vkMaxDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (supportedAlpha (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 4) (minSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 12) (maxSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 20) (minSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 28) (maxSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 36) (minDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 44) (maxDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 52) (minDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
 
 
 -- ** vkGetDisplayModePropertiesKHR
 foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
-  VkPhysicalDevice ->
-  VkDisplayKHR ->
+  PhysicalDevice ->
+  DisplayKHR ->
     Ptr Word32 -> Ptr VkDisplayModePropertiesKHR -> IO VkResult
 
 
 data VkDisplayPropertiesKHR =
-  VkDisplayPropertiesKHR{ vkDisplay :: VkDisplayKHR 
-                        , vkDisplayName :: Ptr CChar 
-                        , vkPhysicalDimensions :: VkExtent2D 
-                        , vkPhysicalResolution :: VkExtent2D 
-                        , vkSupportedTransforms :: VkSurfaceTransformFlagsKHR 
-                        , vkPlaneReorderPossible :: VkBool32 
-                        , vkPersistentContent :: VkBool32 
+  VkDisplayPropertiesKHR{ display :: DisplayKHR 
+                        , displayName :: Ptr CChar 
+                        , physicalDimensions :: VkExtent2D 
+                        , physicalResolution :: VkExtent2D 
+                        , supportedTransforms :: VkSurfaceTransformFlagsKHR 
+                        , planeReorderPossible :: VkBool32 
+                        , persistentContent :: VkBool32 
                         }
   deriving (Eq)
 
@@ -166,31 +166,31 @@ instance Storable VkDisplayPropertiesKHR where
                                     <*> peek (ptr `plusPtr` 32)
                                     <*> peek (ptr `plusPtr` 36)
                                     <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkDisplay (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (vkDisplayName (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 16) (vkPhysicalDimensions (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 24) (vkPhysicalResolution (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 32) (vkSupportedTransforms (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 36) (vkPlaneReorderPossible (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 40) (vkPersistentContent (poked :: VkDisplayPropertiesKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (display (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (displayName (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 16) (physicalDimensions (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 24) (physicalResolution (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 32) (supportedTransforms (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 36) (planeReorderPossible (poked :: VkDisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 40) (persistentContent (poked :: VkDisplayPropertiesKHR))
 
 
 -- ** vkGetDisplayPlaneSupportedDisplaysKHR
 foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSupportedDisplaysKHR ::
-  VkPhysicalDevice ->
-  Word32 -> Ptr Word32 -> Ptr VkDisplayKHR -> IO VkResult
+  PhysicalDevice ->
+  Word32 -> Ptr Word32 -> Ptr DisplayKHR -> IO VkResult
 
 -- ** vkCreateDisplayModeKHR
 foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
-  VkPhysicalDevice ->
-  VkDisplayKHR ->
+  PhysicalDevice ->
+  DisplayKHR ->
     Ptr VkDisplayModeCreateInfoKHR ->
-      Ptr VkAllocationCallbacks -> Ptr VkDisplayModeKHR -> IO VkResult
+      Ptr VkAllocationCallbacks -> Ptr DisplayModeKHR -> IO VkResult
 
 
 data VkDisplayPlanePropertiesKHR =
-  VkDisplayPlanePropertiesKHR{ vkCurrentDisplay :: VkDisplayKHR 
-                             , vkCurrentStackIndex :: Word32 
+  VkDisplayPlanePropertiesKHR{ currentDisplay :: DisplayKHR 
+                             , currentStackIndex :: Word32 
                              }
   deriving (Eq)
 
@@ -199,20 +199,20 @@ instance Storable VkDisplayPlanePropertiesKHR where
   alignment ~_ = 8
   peek ptr = VkDisplayPlanePropertiesKHR <$> peek (ptr `plusPtr` 0)
                                          <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkCurrentDisplay (poked :: VkDisplayPlanePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (vkCurrentStackIndex (poked :: VkDisplayPlanePropertiesKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (currentDisplay (poked :: VkDisplayPlanePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: VkDisplayPlanePropertiesKHR))
 
 
 -- ** vkGetDisplayPlaneCapabilitiesKHR
 foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" vkGetDisplayPlaneCapabilitiesKHR ::
-  VkPhysicalDevice ->
-  VkDisplayModeKHR ->
+  PhysicalDevice ->
+  DisplayModeKHR ->
     Word32 -> Ptr VkDisplayPlaneCapabilitiesKHR -> IO VkResult
 
 
 data VkDisplayModePropertiesKHR =
-  VkDisplayModePropertiesKHR{ vkDisplayMode :: VkDisplayModeKHR 
-                            , vkParameters :: VkDisplayModeParametersKHR 
+  VkDisplayModePropertiesKHR{ displayMode :: DisplayModeKHR 
+                            , parameters :: VkDisplayModeParametersKHR 
                             }
   deriving (Eq)
 
@@ -221,8 +221,8 @@ instance Storable VkDisplayModePropertiesKHR where
   alignment ~_ = 8
   peek ptr = VkDisplayModePropertiesKHR <$> peek (ptr `plusPtr` 0)
                                         <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkDisplayMode (poked :: VkDisplayModePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (vkParameters (poked :: VkDisplayModePropertiesKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (displayMode (poked :: VkDisplayModePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (parameters (poked :: VkDisplayModePropertiesKHR))
 
 
 -- ** VkDisplayPlaneAlphaFlagsKHR
@@ -271,10 +271,10 @@ newtype VkDisplayModeCreateFlagsKHR = VkDisplayModeCreateFlagsKHR VkFlags
 
 
 data VkDisplayModeCreateInfoKHR =
-  VkDisplayModeCreateInfoKHR{ vkSType :: VkStructureType 
-                            , vkPNext :: Ptr Void 
-                            , vkFlags :: VkDisplayModeCreateFlagsKHR 
-                            , vkParameters :: VkDisplayModeParametersKHR 
+  VkDisplayModeCreateInfoKHR{ sType :: VkStructureType 
+                            , pNext :: Ptr Void 
+                            , flags :: VkDisplayModeCreateFlagsKHR 
+                            , parameters :: VkDisplayModeParametersKHR 
                             }
   deriving (Eq)
 
@@ -285,24 +285,24 @@ instance Storable VkDisplayModeCreateInfoKHR where
                                         <*> peek (ptr `plusPtr` 8)
                                         <*> peek (ptr `plusPtr` 16)
                                         <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 20) (vkParameters (poked :: VkDisplayModeCreateInfoKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 20) (parameters (poked :: VkDisplayModeCreateInfoKHR))
 
 
 -- ** vkGetPhysicalDeviceDisplayPlanePropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" vkGetPhysicalDeviceDisplayPlanePropertiesKHR ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr Word32 -> Ptr VkDisplayPlanePropertiesKHR -> IO VkResult
 
-newtype VkDisplayModeKHR = VkDisplayModeKHR Word64
+newtype DisplayModeKHR = DisplayModeKHR Word64
   deriving (Eq, Storable)
 
 
 data VkDisplayModeParametersKHR =
-  VkDisplayModeParametersKHR{ vkVisibleRegion :: VkExtent2D 
-                            , vkRefreshRate :: Word32 
+  VkDisplayModeParametersKHR{ visibleRegion :: VkExtent2D 
+                            , refreshRate :: Word32 
                             }
   deriving (Eq)
 
@@ -311,8 +311,8 @@ instance Storable VkDisplayModeParametersKHR where
   alignment ~_ = 4
   peek ptr = VkDisplayModeParametersKHR <$> peek (ptr `plusPtr` 0)
                                         <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkVisibleRegion (poked :: VkDisplayModeParametersKHR))
-                *> poke (ptr `plusPtr` 8) (vkRefreshRate (poked :: VkDisplayModeParametersKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (visibleRegion (poked :: VkDisplayModeParametersKHR))
+                *> poke (ptr `plusPtr` 8) (refreshRate (poked :: VkDisplayModeParametersKHR))
 
 
 -- ** VkDisplaySurfaceCreateFlagsKHR
@@ -320,17 +320,17 @@ instance Storable VkDisplayModeParametersKHR where
 newtype VkDisplaySurfaceCreateFlagsKHR = VkDisplaySurfaceCreateFlagsKHR VkFlags
   deriving (Eq, Storable)
 
-newtype VkDisplayKHR = VkDisplayKHR Word64
+newtype DisplayKHR = DisplayKHR Word64
   deriving (Eq, Storable)
 
 -- ** vkGetPhysicalDeviceDisplayPropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" vkGetPhysicalDeviceDisplayPropertiesKHR ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr Word32 -> Ptr VkDisplayPropertiesKHR -> IO VkResult
 
 -- ** vkCreateDisplayPlaneSurfaceKHR
 foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" vkCreateDisplayPlaneSurfaceKHR ::
-  VkInstance ->
+  Instance ->
   Ptr VkDisplaySurfaceCreateInfoKHR ->
-    Ptr VkAllocationCallbacks -> Ptr VkSurfaceKHR -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr SurfaceKHR -> IO VkResult
 

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Display where
 
-import Graphics.Vulkan.Device( PhysicalDevice(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -17,12 +15,6 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR(..)
-                                  , VkSurfaceTransformFlagsKHR(..)
-                                  , SurfaceKHR(..)
-                                  )
-import Data.Int( Int32
-               )
 import Data.Bits( Bits
                 , FiniteBits
                 )
@@ -30,15 +22,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -46,19 +29,8 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( Instance(..)
-                                           )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkOffset2D(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CFloat
-                      , CFloat(..)
                       , CChar
-                      , CSize(..)
                       )
 
 

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -213,7 +213,7 @@ instance Storable DisplayModePropertiesKHR where
                 *> poke (ptr `plusPtr` 8) (parameters (poked :: DisplayModePropertiesKHR))
 
 
--- ** VkDisplayPlaneAlphaFlagsKHR
+-- ** DisplayPlaneAlphaFlagsKHR
 
 newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -27,7 +27,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -39,128 +39,128 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
 import Graphics.Vulkan.Core( VkStructureType(..)
+                           , Offset2D(..)
                            , VkFlags(..)
                            , VkBool32(..)
                            , VkResult(..)
-                           , VkExtent2D(..)
-                           , VkOffset2D(..)
+                           , Extent2D(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
                       )
 
 
-data VkDisplaySurfaceCreateInfoKHR =
-  VkDisplaySurfaceCreateInfoKHR{ sType :: VkStructureType 
-                               , pNext :: Ptr Void 
-                               , flags :: VkDisplaySurfaceCreateFlagsKHR 
-                               , displayMode :: DisplayModeKHR 
-                               , planeIndex :: Word32 
-                               , planeStackIndex :: Word32 
-                               , transform :: VkSurfaceTransformFlagsKHR 
-                               , globalAlpha :: CFloat 
-                               , alphaMode :: VkDisplayPlaneAlphaFlagsKHR 
-                               , imageExtent :: VkExtent2D 
-                               }
+data DisplaySurfaceCreateInfoKHR =
+  DisplaySurfaceCreateInfoKHR{ sType :: VkStructureType 
+                             , pNext :: Ptr Void 
+                             , flags :: VkDisplaySurfaceCreateFlagsKHR 
+                             , displayMode :: DisplayModeKHR 
+                             , planeIndex :: Word32 
+                             , planeStackIndex :: Word32 
+                             , transform :: VkSurfaceTransformFlagsKHR 
+                             , globalAlpha :: CFloat 
+                             , alphaMode :: VkDisplayPlaneAlphaFlagsKHR 
+                             , imageExtent :: Extent2D 
+                             }
   deriving (Eq)
 
-instance Storable VkDisplaySurfaceCreateInfoKHR where
+instance Storable DisplaySurfaceCreateInfoKHR where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkDisplaySurfaceCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                           <*> peek (ptr `plusPtr` 8)
-                                           <*> peek (ptr `plusPtr` 16)
-                                           <*> peek (ptr `plusPtr` 24)
-                                           <*> peek (ptr `plusPtr` 32)
-                                           <*> peek (ptr `plusPtr` 36)
-                                           <*> peek (ptr `plusPtr` 40)
-                                           <*> peek (ptr `plusPtr` 44)
-                                           <*> peek (ptr `plusPtr` 48)
-                                           <*> peek (ptr `plusPtr` 52)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (displayMode (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (planeIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (planeStackIndex (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (transform (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (globalAlpha (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 48) (alphaMode (poked :: VkDisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (imageExtent (poked :: VkDisplaySurfaceCreateInfoKHR))
+  peek ptr = DisplaySurfaceCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                         <*> peek (ptr `plusPtr` 8)
+                                         <*> peek (ptr `plusPtr` 16)
+                                         <*> peek (ptr `plusPtr` 24)
+                                         <*> peek (ptr `plusPtr` 32)
+                                         <*> peek (ptr `plusPtr` 36)
+                                         <*> peek (ptr `plusPtr` 40)
+                                         <*> peek (ptr `plusPtr` 44)
+                                         <*> peek (ptr `plusPtr` 48)
+                                         <*> peek (ptr `plusPtr` 52)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (displayMode (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (planeIndex (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (planeStackIndex (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (transform (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (globalAlpha (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 48) (alphaMode (poked :: DisplaySurfaceCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (imageExtent (poked :: DisplaySurfaceCreateInfoKHR))
 
 
 
-data VkDisplayPlaneCapabilitiesKHR =
-  VkDisplayPlaneCapabilitiesKHR{ supportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
-                               , minSrcPosition :: VkOffset2D 
-                               , maxSrcPosition :: VkOffset2D 
-                               , minSrcExtent :: VkExtent2D 
-                               , maxSrcExtent :: VkExtent2D 
-                               , minDstPosition :: VkOffset2D 
-                               , maxDstPosition :: VkOffset2D 
-                               , minDstExtent :: VkExtent2D 
-                               , maxDstExtent :: VkExtent2D 
-                               }
+data DisplayPlaneCapabilitiesKHR =
+  DisplayPlaneCapabilitiesKHR{ supportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
+                             , minSrcPosition :: Offset2D 
+                             , maxSrcPosition :: Offset2D 
+                             , minSrcExtent :: Extent2D 
+                             , maxSrcExtent :: Extent2D 
+                             , minDstPosition :: Offset2D 
+                             , maxDstPosition :: Offset2D 
+                             , minDstExtent :: Extent2D 
+                             , maxDstExtent :: Extent2D 
+                             }
   deriving (Eq)
 
-instance Storable VkDisplayPlaneCapabilitiesKHR where
+instance Storable DisplayPlaneCapabilitiesKHR where
   sizeOf ~_ = 68
   alignment ~_ = 4
-  peek ptr = VkDisplayPlaneCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
-                                           <*> peek (ptr `plusPtr` 4)
-                                           <*> peek (ptr `plusPtr` 12)
-                                           <*> peek (ptr `plusPtr` 20)
-                                           <*> peek (ptr `plusPtr` 28)
-                                           <*> peek (ptr `plusPtr` 36)
-                                           <*> peek (ptr `plusPtr` 44)
-                                           <*> peek (ptr `plusPtr` 52)
-                                           <*> peek (ptr `plusPtr` 60)
-  poke ptr poked = poke (ptr `plusPtr` 0) (supportedAlpha (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (minSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 12) (maxSrcPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 20) (minSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 28) (maxSrcExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (minDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (maxDstPosition (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 52) (minDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
+  peek ptr = DisplayPlaneCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
+                                         <*> peek (ptr `plusPtr` 4)
+                                         <*> peek (ptr `plusPtr` 12)
+                                         <*> peek (ptr `plusPtr` 20)
+                                         <*> peek (ptr `plusPtr` 28)
+                                         <*> peek (ptr `plusPtr` 36)
+                                         <*> peek (ptr `plusPtr` 44)
+                                         <*> peek (ptr `plusPtr` 52)
+                                         <*> peek (ptr `plusPtr` 60)
+  poke ptr poked = poke (ptr `plusPtr` 0) (supportedAlpha (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 4) (minSrcPosition (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 12) (maxSrcPosition (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 20) (minSrcExtent (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 28) (maxSrcExtent (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 36) (minDstPosition (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 44) (maxDstPosition (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 52) (minDstExtent (poked :: DisplayPlaneCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: DisplayPlaneCapabilitiesKHR))
 
 
 -- ** vkGetDisplayModePropertiesKHR
 foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
   PhysicalDevice ->
   DisplayKHR ->
-    Ptr Word32 -> Ptr VkDisplayModePropertiesKHR -> IO VkResult
+    Ptr Word32 -> Ptr DisplayModePropertiesKHR -> IO VkResult
 
 
-data VkDisplayPropertiesKHR =
-  VkDisplayPropertiesKHR{ display :: DisplayKHR 
-                        , displayName :: Ptr CChar 
-                        , physicalDimensions :: VkExtent2D 
-                        , physicalResolution :: VkExtent2D 
-                        , supportedTransforms :: VkSurfaceTransformFlagsKHR 
-                        , planeReorderPossible :: VkBool32 
-                        , persistentContent :: VkBool32 
-                        }
+data DisplayPropertiesKHR =
+  DisplayPropertiesKHR{ display :: DisplayKHR 
+                      , displayName :: Ptr CChar 
+                      , physicalDimensions :: Extent2D 
+                      , physicalResolution :: Extent2D 
+                      , supportedTransforms :: VkSurfaceTransformFlagsKHR 
+                      , planeReorderPossible :: VkBool32 
+                      , persistentContent :: VkBool32 
+                      }
   deriving (Eq)
 
-instance Storable VkDisplayPropertiesKHR where
+instance Storable DisplayPropertiesKHR where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkDisplayPropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 36)
-                                    <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (display (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (displayName (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 16) (physicalDimensions (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 24) (physicalResolution (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 32) (supportedTransforms (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 36) (planeReorderPossible (poked :: VkDisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 40) (persistentContent (poked :: VkDisplayPropertiesKHR))
+  peek ptr = DisplayPropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                  <*> peek (ptr `plusPtr` 8)
+                                  <*> peek (ptr `plusPtr` 16)
+                                  <*> peek (ptr `plusPtr` 24)
+                                  <*> peek (ptr `plusPtr` 32)
+                                  <*> peek (ptr `plusPtr` 36)
+                                  <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (display (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (displayName (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 16) (physicalDimensions (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 24) (physicalResolution (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 32) (supportedTransforms (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 36) (planeReorderPossible (poked :: DisplayPropertiesKHR))
+                *> poke (ptr `plusPtr` 40) (persistentContent (poked :: DisplayPropertiesKHR))
 
 
 -- ** vkGetDisplayPlaneSupportedDisplaysKHR
@@ -172,45 +172,45 @@ foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSu
 foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
   PhysicalDevice ->
   DisplayKHR ->
-    Ptr VkDisplayModeCreateInfoKHR ->
-      Ptr VkAllocationCallbacks -> Ptr DisplayModeKHR -> IO VkResult
+    Ptr DisplayModeCreateInfoKHR ->
+      Ptr AllocationCallbacks -> Ptr DisplayModeKHR -> IO VkResult
 
 
-data VkDisplayPlanePropertiesKHR =
-  VkDisplayPlanePropertiesKHR{ currentDisplay :: DisplayKHR 
-                             , currentStackIndex :: Word32 
-                             }
+data DisplayPlanePropertiesKHR =
+  DisplayPlanePropertiesKHR{ currentDisplay :: DisplayKHR 
+                           , currentStackIndex :: Word32 
+                           }
   deriving (Eq)
 
-instance Storable VkDisplayPlanePropertiesKHR where
+instance Storable DisplayPlanePropertiesKHR where
   sizeOf ~_ = 16
   alignment ~_ = 8
-  peek ptr = VkDisplayPlanePropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (currentDisplay (poked :: VkDisplayPlanePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: VkDisplayPlanePropertiesKHR))
+  peek ptr = DisplayPlanePropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                       <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (currentDisplay (poked :: DisplayPlanePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: DisplayPlanePropertiesKHR))
 
 
 -- ** vkGetDisplayPlaneCapabilitiesKHR
 foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" vkGetDisplayPlaneCapabilitiesKHR ::
   PhysicalDevice ->
   DisplayModeKHR ->
-    Word32 -> Ptr VkDisplayPlaneCapabilitiesKHR -> IO VkResult
+    Word32 -> Ptr DisplayPlaneCapabilitiesKHR -> IO VkResult
 
 
-data VkDisplayModePropertiesKHR =
-  VkDisplayModePropertiesKHR{ displayMode :: DisplayModeKHR 
-                            , parameters :: VkDisplayModeParametersKHR 
-                            }
+data DisplayModePropertiesKHR =
+  DisplayModePropertiesKHR{ displayMode :: DisplayModeKHR 
+                          , parameters :: DisplayModeParametersKHR 
+                          }
   deriving (Eq)
 
-instance Storable VkDisplayModePropertiesKHR where
+instance Storable DisplayModePropertiesKHR where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkDisplayModePropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (displayMode (poked :: VkDisplayModePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (parameters (poked :: VkDisplayModePropertiesKHR))
+  peek ptr = DisplayModePropertiesKHR <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (displayMode (poked :: DisplayModePropertiesKHR))
+                *> poke (ptr `plusPtr` 8) (parameters (poked :: DisplayModePropertiesKHR))
 
 
 -- ** VkDisplayPlaneAlphaFlagsKHR
@@ -255,49 +255,49 @@ newtype VkDisplayModeCreateFlagsKHR = VkDisplayModeCreateFlagsKHR VkFlags
   deriving (Eq, Storable)
 
 
-data VkDisplayModeCreateInfoKHR =
-  VkDisplayModeCreateInfoKHR{ sType :: VkStructureType 
-                            , pNext :: Ptr Void 
-                            , flags :: VkDisplayModeCreateFlagsKHR 
-                            , parameters :: VkDisplayModeParametersKHR 
-                            }
+data DisplayModeCreateInfoKHR =
+  DisplayModeCreateInfoKHR{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkDisplayModeCreateFlagsKHR 
+                          , parameters :: DisplayModeParametersKHR 
+                          }
   deriving (Eq)
 
-instance Storable VkDisplayModeCreateInfoKHR where
+instance Storable DisplayModeCreateInfoKHR where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkDisplayModeCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 8)
-                                        <*> peek (ptr `plusPtr` 16)
-                                        <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkDisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 20) (parameters (poked :: VkDisplayModeCreateInfoKHR))
+  peek ptr = DisplayModeCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplayModeCreateInfoKHR))
+                *> poke (ptr `plusPtr` 20) (parameters (poked :: DisplayModeCreateInfoKHR))
 
 
 -- ** vkGetPhysicalDeviceDisplayPlanePropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" vkGetPhysicalDeviceDisplayPlanePropertiesKHR ::
   PhysicalDevice ->
-  Ptr Word32 -> Ptr VkDisplayPlanePropertiesKHR -> IO VkResult
+  Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO VkResult
 
 newtype DisplayModeKHR = DisplayModeKHR Word64
   deriving (Eq, Storable)
 
 
-data VkDisplayModeParametersKHR =
-  VkDisplayModeParametersKHR{ visibleRegion :: VkExtent2D 
-                            , refreshRate :: Word32 
-                            }
+data DisplayModeParametersKHR =
+  DisplayModeParametersKHR{ visibleRegion :: Extent2D 
+                          , refreshRate :: Word32 
+                          }
   deriving (Eq)
 
-instance Storable VkDisplayModeParametersKHR where
+instance Storable DisplayModeParametersKHR where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkDisplayModeParametersKHR <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (visibleRegion (poked :: VkDisplayModeParametersKHR))
-                *> poke (ptr `plusPtr` 8) (refreshRate (poked :: VkDisplayModeParametersKHR))
+  peek ptr = DisplayModeParametersKHR <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (visibleRegion (poked :: DisplayModeParametersKHR))
+                *> poke (ptr `plusPtr` 8) (refreshRate (poked :: DisplayModeParametersKHR))
 
 
 -- ** VkDisplaySurfaceCreateFlagsKHR
@@ -311,11 +311,11 @@ newtype DisplayKHR = DisplayKHR Word64
 -- ** vkGetPhysicalDeviceDisplayPropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" vkGetPhysicalDeviceDisplayPropertiesKHR ::
   PhysicalDevice ->
-  Ptr Word32 -> Ptr VkDisplayPropertiesKHR -> IO VkResult
+  Ptr Word32 -> Ptr DisplayPropertiesKHR -> IO VkResult
 
 -- ** vkCreateDisplayPlaneSurfaceKHR
 foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" vkCreateDisplayPlaneSurfaceKHR ::
   Instance ->
-  Ptr VkDisplaySurfaceCreateInfoKHR ->
-    Ptr VkAllocationCallbacks -> Ptr SurfaceKHR -> IO VkResult
+  Ptr DisplaySurfaceCreateInfoKHR ->
+    Ptr AllocationCallbacks -> Ptr SurfaceKHR -> IO VkResult
 

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -17,8 +17,8 @@ import Data.Word( Word64(..)
 import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( SurfaceKHR(..)
-                                  , VkSurfaceTransformFlagsKHR(..)
+import Graphics.Vulkan.KHR.Surface( SurfaceTransformFlagsKHR(..)
+                                  , SurfaceKHR(..)
                                   )
 import Data.Bits( Bits
                 , FiniteBits
@@ -38,11 +38,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       )
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , Offset2D(..)
+import Graphics.Vulkan.Core( Offset2D(..)
                            , VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            , Extent2D(..)
                            )
 import Foreign.C.Types( CFloat(..)
@@ -51,15 +51,15 @@ import Foreign.C.Types( CFloat(..)
 
 
 data DisplaySurfaceCreateInfoKHR =
-  DisplaySurfaceCreateInfoKHR{ sType :: VkStructureType 
+  DisplaySurfaceCreateInfoKHR{ sType :: StructureType 
                              , pNext :: Ptr Void 
-                             , flags :: VkDisplaySurfaceCreateFlagsKHR 
+                             , flags :: DisplaySurfaceCreateFlagsKHR 
                              , displayMode :: DisplayModeKHR 
                              , planeIndex :: Word32 
                              , planeStackIndex :: Word32 
-                             , transform :: VkSurfaceTransformFlagsKHR 
+                             , transform :: SurfaceTransformFlagsKHR 
                              , globalAlpha :: CFloat 
-                             , alphaMode :: VkDisplayPlaneAlphaFlagsKHR 
+                             , alphaMode :: DisplayPlaneAlphaFlagsKHR 
                              , imageExtent :: Extent2D 
                              }
   deriving (Eq)
@@ -91,7 +91,7 @@ instance Storable DisplaySurfaceCreateInfoKHR where
 
 
 data DisplayPlaneCapabilitiesKHR =
-  DisplayPlaneCapabilitiesKHR{ supportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
+  DisplayPlaneCapabilitiesKHR{ supportedAlpha :: DisplayPlaneAlphaFlagsKHR 
                              , minSrcPosition :: Offset2D 
                              , maxSrcPosition :: Offset2D 
                              , minSrcExtent :: Extent2D 
@@ -130,7 +130,7 @@ instance Storable DisplayPlaneCapabilitiesKHR where
 foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
   PhysicalDevice ->
   DisplayKHR ->
-    Ptr Word32 -> Ptr DisplayModePropertiesKHR -> IO VkResult
+    Ptr Word32 -> Ptr DisplayModePropertiesKHR -> IO Result
 
 
 data DisplayPropertiesKHR =
@@ -138,7 +138,7 @@ data DisplayPropertiesKHR =
                       , displayName :: Ptr CChar 
                       , physicalDimensions :: Extent2D 
                       , physicalResolution :: Extent2D 
-                      , supportedTransforms :: VkSurfaceTransformFlagsKHR 
+                      , supportedTransforms :: SurfaceTransformFlagsKHR 
                       , planeReorderPossible :: VkBool32 
                       , persistentContent :: VkBool32 
                       }
@@ -166,14 +166,14 @@ instance Storable DisplayPropertiesKHR where
 -- ** vkGetDisplayPlaneSupportedDisplaysKHR
 foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSupportedDisplaysKHR ::
   PhysicalDevice ->
-  Word32 -> Ptr Word32 -> Ptr DisplayKHR -> IO VkResult
+  Word32 -> Ptr Word32 -> Ptr DisplayKHR -> IO Result
 
 -- ** vkCreateDisplayModeKHR
 foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
   PhysicalDevice ->
   DisplayKHR ->
     Ptr DisplayModeCreateInfoKHR ->
-      Ptr AllocationCallbacks -> Ptr DisplayModeKHR -> IO VkResult
+      Ptr AllocationCallbacks -> Ptr DisplayModeKHR -> IO Result
 
 
 data DisplayPlanePropertiesKHR =
@@ -195,7 +195,7 @@ instance Storable DisplayPlanePropertiesKHR where
 foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" vkGetDisplayPlaneCapabilitiesKHR ::
   PhysicalDevice ->
   DisplayModeKHR ->
-    Word32 -> Ptr DisplayPlaneCapabilitiesKHR -> IO VkResult
+    Word32 -> Ptr DisplayPlaneCapabilitiesKHR -> IO Result
 
 
 data DisplayModePropertiesKHR =
@@ -215,50 +215,50 @@ instance Storable DisplayModePropertiesKHR where
 
 -- ** VkDisplayPlaneAlphaFlagsKHR
 
-newtype VkDisplayPlaneAlphaFlagsKHR = VkDisplayPlaneAlphaFlagsKHR VkFlags
+newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkDisplayPlaneAlphaFlagsKHR where
+instance Show DisplayPlaneAlphaFlagsKHR where
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR"
   
-  showsPrec p (VkDisplayPlaneAlphaFlagsKHR x) = showParen (p >= 11) (showString "VkDisplayPlaneAlphaFlagsKHR " . showsPrec 11 x)
+  showsPrec p (DisplayPlaneAlphaFlagsKHR x) = showParen (p >= 11) (showString "DisplayPlaneAlphaFlagsKHR " . showsPrec 11 x)
 
-instance Read VkDisplayPlaneAlphaFlagsKHR where
+instance Read DisplayPlaneAlphaFlagsKHR where
   readPrec = parens ( choose [ ("VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDisplayPlaneAlphaFlagsKHR")
+                        expectP (Ident "DisplayPlaneAlphaFlagsKHR")
                         v <- step readPrec
-                        pure (VkDisplayPlaneAlphaFlagsKHR v)
+                        pure (DisplayPlaneAlphaFlagsKHR v)
                         )
                     )
 
 
-pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x1
+pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x1
 
-pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x2
+pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x2
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x4
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x4
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x8
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x8
 
 
--- ** VkDisplayModeCreateFlagsKHR
+-- ** DisplayModeCreateFlagsKHR
 -- | Opaque flag
-newtype VkDisplayModeCreateFlagsKHR = VkDisplayModeCreateFlagsKHR VkFlags
+newtype DisplayModeCreateFlagsKHR = DisplayModeCreateFlagsKHR VkFlags
   deriving (Eq, Storable)
 
 
 data DisplayModeCreateInfoKHR =
-  DisplayModeCreateInfoKHR{ sType :: VkStructureType 
+  DisplayModeCreateInfoKHR{ sType :: StructureType 
                           , pNext :: Ptr Void 
-                          , flags :: VkDisplayModeCreateFlagsKHR 
+                          , flags :: DisplayModeCreateFlagsKHR 
                           , parameters :: DisplayModeParametersKHR 
                           }
   deriving (Eq)
@@ -279,7 +279,7 @@ instance Storable DisplayModeCreateInfoKHR where
 -- ** vkGetPhysicalDeviceDisplayPlanePropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" vkGetPhysicalDeviceDisplayPlanePropertiesKHR ::
   PhysicalDevice ->
-  Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO VkResult
+  Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO Result
 
 newtype DisplayModeKHR = DisplayModeKHR Word64
   deriving (Eq, Storable)
@@ -300,9 +300,9 @@ instance Storable DisplayModeParametersKHR where
                 *> poke (ptr `plusPtr` 8) (refreshRate (poked :: DisplayModeParametersKHR))
 
 
--- ** VkDisplaySurfaceCreateFlagsKHR
+-- ** DisplaySurfaceCreateFlagsKHR
 -- | Opaque flag
-newtype VkDisplaySurfaceCreateFlagsKHR = VkDisplaySurfaceCreateFlagsKHR VkFlags
+newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR VkFlags
   deriving (Eq, Storable)
 
 newtype DisplayKHR = DisplayKHR Word64
@@ -311,11 +311,11 @@ newtype DisplayKHR = DisplayKHR Word64
 -- ** vkGetPhysicalDeviceDisplayPropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" vkGetPhysicalDeviceDisplayPropertiesKHR ::
   PhysicalDevice ->
-  Ptr Word32 -> Ptr DisplayPropertiesKHR -> IO VkResult
+  Ptr Word32 -> Ptr DisplayPropertiesKHR -> IO Result
 
 -- ** vkCreateDisplayPlaneSurfaceKHR
 foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" vkCreateDisplayPlaneSurfaceKHR ::
   Instance ->
   Ptr DisplaySurfaceCreateInfoKHR ->
-    Ptr AllocationCallbacks -> Ptr SurfaceKHR -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr SurfaceKHR -> IO Result
 

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -219,18 +219,18 @@ newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DisplayPlaneAlphaFlagsKHR where
-  showsPrec _ VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR"
-  showsPrec _ VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR"
-  showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR"
-  showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR"
+  showsPrec _ DisplayPlaneAlphaOpaqueBitKhr = showString "DisplayPlaneAlphaOpaqueBitKhr"
+  showsPrec _ DisplayPlaneAlphaGlobalBitKhr = showString "DisplayPlaneAlphaGlobalBitKhr"
+  showsPrec _ DisplayPlaneAlphaPerPixelBitKhr = showString "DisplayPlaneAlphaPerPixelBitKhr"
+  showsPrec _ DisplayPlaneAlphaPerPixelPremultipliedBitKhr = showString "DisplayPlaneAlphaPerPixelPremultipliedBitKhr"
   
   showsPrec p (DisplayPlaneAlphaFlagsKHR x) = showParen (p >= 11) (showString "DisplayPlaneAlphaFlagsKHR " . showsPrec 11 x)
 
 instance Read DisplayPlaneAlphaFlagsKHR where
-  readPrec = parens ( choose [ ("VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
-                             , ("VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
-                             , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
-                             , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
+  readPrec = parens ( choose [ ("DisplayPlaneAlphaOpaqueBitKhr", pure DisplayPlaneAlphaOpaqueBitKhr)
+                             , ("DisplayPlaneAlphaGlobalBitKhr", pure DisplayPlaneAlphaGlobalBitKhr)
+                             , ("DisplayPlaneAlphaPerPixelBitKhr", pure DisplayPlaneAlphaPerPixelBitKhr)
+                             , ("DisplayPlaneAlphaPerPixelPremultipliedBitKhr", pure DisplayPlaneAlphaPerPixelPremultipliedBitKhr)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DisplayPlaneAlphaFlagsKHR")
@@ -240,13 +240,13 @@ instance Read DisplayPlaneAlphaFlagsKHR where
                     )
 
 
-pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x1
+pattern DisplayPlaneAlphaOpaqueBitKhr = DisplayPlaneAlphaFlagsKHR 0x1
 
-pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x2
+pattern DisplayPlaneAlphaGlobalBitKhr = DisplayPlaneAlphaFlagsKHR 0x2
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x4
+pattern DisplayPlaneAlphaPerPixelBitKhr = DisplayPlaneAlphaFlagsKHR 0x4
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = DisplayPlaneAlphaFlagsKHR 0x8
+pattern DisplayPlaneAlphaPerPixelPremultipliedBitKhr = DisplayPlaneAlphaFlagsKHR 0x8
 
 
 -- ** DisplayModeCreateFlagsKHR

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -39,10 +39,10 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
 import Graphics.Vulkan.Core( Offset2D(..)
-                           , VkFlags(..)
+                           , Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            , Extent2D(..)
                            )
 import Foreign.C.Types( CFloat(..)
@@ -139,8 +139,8 @@ data DisplayPropertiesKHR =
                       , physicalDimensions :: Extent2D 
                       , physicalResolution :: Extent2D 
                       , supportedTransforms :: SurfaceTransformFlagsKHR 
-                      , planeReorderPossible :: VkBool32 
-                      , persistentContent :: VkBool32 
+                      , planeReorderPossible :: Bool32 
+                      , persistentContent :: Bool32 
                       }
   deriving (Eq)
 
@@ -215,7 +215,7 @@ instance Storable DisplayModePropertiesKHR where
 
 -- ** VkDisplayPlaneAlphaFlagsKHR
 
-newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR VkFlags
+newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DisplayPlaneAlphaFlagsKHR where
@@ -251,7 +251,7 @@ pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = DisplayPlaneAlp
 
 -- ** DisplayModeCreateFlagsKHR
 -- | Opaque flag
-newtype DisplayModeCreateFlagsKHR = DisplayModeCreateFlagsKHR VkFlags
+newtype DisplayModeCreateFlagsKHR = DisplayModeCreateFlagsKHR Flags
   deriving (Eq, Storable)
 
 
@@ -302,7 +302,7 @@ instance Storable DisplayModeParametersKHR where
 
 -- ** DisplaySurfaceCreateFlagsKHR
 -- | Opaque flag
-newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR VkFlags
+newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR Flags
   deriving (Eq, Storable)
 
 newtype DisplayKHR = DisplayKHR Word64

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Display where
 
+import Graphics.Vulkan.Device( PhysicalDevice
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -15,13 +17,33 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR
+                                  , SurfaceKHR
+                                  , VkSurfaceTransformFlagsKHR
+                                  )
 import Data.Bits( Bits
                 , FiniteBits
                 )
+import Graphics.Vulkan.KHR.Display( VkDisplayPropertiesKHR
+                                  , VkDisplayPlaneCapabilitiesKHR
+                                  , VkDisplaySurfaceCreateInfoKHR
+                                  , VkDisplayModePropertiesKHR
+                                  , VkDisplayPlanePropertiesKHR
+                                  , DisplayModeKHR
+                                  , VkDisplayPlaneAlphaFlagBitsKHR
+                                  , DisplayKHR
+                                  , VkDisplayModeCreateFlagsKHR
+                                  , VkDisplayModeCreateInfoKHR
+                                  , VkDisplayPlaneAlphaFlagsKHR
+                                  , VkDisplaySurfaceCreateFlagsKHR
+                                  , VkDisplayModeParametersKHR
+                                  )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +51,15 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.DeviceInitialization( Instance
+                                           )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkExtent2D
+                           , VkFlags
+                           , VkOffset2D
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CFloat
                       , CChar
                       )

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -126,8 +126,8 @@ instance Storable DisplayPlaneCapabilitiesKHR where
                 *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: DisplayPlaneCapabilitiesKHR))
 
 
--- ** vkGetDisplayModePropertiesKHR
-foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
+-- ** getDisplayModePropertiesKHR
+foreign import ccall "vkGetDisplayModePropertiesKHR" getDisplayModePropertiesKHR ::
   PhysicalDevice ->
   DisplayKHR ->
     Ptr Word32 -> Ptr DisplayModePropertiesKHR -> IO Result
@@ -163,13 +163,13 @@ instance Storable DisplayPropertiesKHR where
                 *> poke (ptr `plusPtr` 40) (persistentContent (poked :: DisplayPropertiesKHR))
 
 
--- ** vkGetDisplayPlaneSupportedDisplaysKHR
-foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSupportedDisplaysKHR ::
+-- ** getDisplayPlaneSupportedDisplaysKHR
+foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" getDisplayPlaneSupportedDisplaysKHR ::
   PhysicalDevice ->
   Word32 -> Ptr Word32 -> Ptr DisplayKHR -> IO Result
 
--- ** vkCreateDisplayModeKHR
-foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
+-- ** createDisplayModeKHR
+foreign import ccall "vkCreateDisplayModeKHR" createDisplayModeKHR ::
   PhysicalDevice ->
   DisplayKHR ->
     Ptr DisplayModeCreateInfoKHR ->
@@ -191,8 +191,8 @@ instance Storable DisplayPlanePropertiesKHR where
                 *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: DisplayPlanePropertiesKHR))
 
 
--- ** vkGetDisplayPlaneCapabilitiesKHR
-foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" vkGetDisplayPlaneCapabilitiesKHR ::
+-- ** getDisplayPlaneCapabilitiesKHR
+foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" getDisplayPlaneCapabilitiesKHR ::
   PhysicalDevice ->
   DisplayModeKHR ->
     Word32 -> Ptr DisplayPlaneCapabilitiesKHR -> IO Result
@@ -276,8 +276,8 @@ instance Storable DisplayModeCreateInfoKHR where
                 *> poke (ptr `plusPtr` 20) (parameters (poked :: DisplayModeCreateInfoKHR))
 
 
--- ** vkGetPhysicalDeviceDisplayPlanePropertiesKHR
-foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" vkGetPhysicalDeviceDisplayPlanePropertiesKHR ::
+-- ** getPhysicalDeviceDisplayPlanePropertiesKHR
+foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" getPhysicalDeviceDisplayPlanePropertiesKHR ::
   PhysicalDevice ->
   Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO Result
 
@@ -308,13 +308,13 @@ newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR Flags
 newtype DisplayKHR = DisplayKHR Word64
   deriving (Eq, Storable)
 
--- ** vkGetPhysicalDeviceDisplayPropertiesKHR
-foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" vkGetPhysicalDeviceDisplayPropertiesKHR ::
+-- ** getPhysicalDeviceDisplayPropertiesKHR
+foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" getPhysicalDeviceDisplayPropertiesKHR ::
   PhysicalDevice ->
   Ptr Word32 -> Ptr DisplayPropertiesKHR -> IO Result
 
--- ** vkCreateDisplayPlaneSurfaceKHR
-foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" vkCreateDisplayPlaneSurfaceKHR ::
+-- ** createDisplayPlaneSurfaceKHR
+foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" createDisplayPlaneSurfaceKHR ::
   Instance ->
   Ptr DisplaySurfaceCreateInfoKHR ->
     Ptr AllocationCallbacks -> Ptr SurfaceKHR -> IO Result

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -4,45 +4,30 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Display where
 
-import Graphics.Vulkan.Device( PhysicalDevice
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR
-                                  , SurfaceKHR
-                                  , VkSurfaceTransformFlagsKHR
+import Graphics.Vulkan.KHR.Surface( SurfaceKHR(..)
+                                  , VkSurfaceTransformFlagsKHR(..)
                                   )
 import Data.Bits( Bits
                 , FiniteBits
                 )
-import Graphics.Vulkan.KHR.Display( VkDisplayPropertiesKHR
-                                  , VkDisplayPlaneCapabilitiesKHR
-                                  , VkDisplaySurfaceCreateInfoKHR
-                                  , VkDisplayModePropertiesKHR
-                                  , VkDisplayPlanePropertiesKHR
-                                  , DisplayModeKHR
-                                  , VkDisplayPlaneAlphaFlagBitsKHR
-                                  , DisplayKHR
-                                  , VkDisplayModeCreateFlagsKHR
-                                  , VkDisplayModeCreateInfoKHR
-                                  , VkDisplayPlaneAlphaFlagsKHR
-                                  , VkDisplaySurfaceCreateFlagsKHR
-                                  , VkDisplayModeParametersKHR
-                                  )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -51,17 +36,17 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.DeviceInitialization( Instance
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkExtent2D
-                           , VkFlags
-                           , VkOffset2D
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
+                           , VkExtent2D(..)
+                           , VkOffset2D(..)
                            )
-import Foreign.C.Types( CFloat
-                      , CChar
+import Foreign.C.Types( CFloat(..)
+                      , CChar(..)
                       )
 
 
@@ -72,9 +57,9 @@ data VkDisplaySurfaceCreateInfoKHR =
                                , displayMode :: DisplayModeKHR 
                                , planeIndex :: Word32 
                                , planeStackIndex :: Word32 
-                               , transform :: VkSurfaceTransformFlagBitsKHR 
+                               , transform :: VkSurfaceTransformFlagsKHR 
                                , globalAlpha :: CFloat 
-                               , alphaMode :: VkDisplayPlaneAlphaFlagBitsKHR 
+                               , alphaMode :: VkDisplayPlaneAlphaFlagsKHR 
                                , imageExtent :: VkExtent2D 
                                }
   deriving (Eq)
@@ -230,41 +215,38 @@ instance Storable VkDisplayModePropertiesKHR where
 
 -- ** VkDisplayPlaneAlphaFlagsKHR
 
-newtype VkDisplayPlaneAlphaFlagBitsKHR = VkDisplayPlaneAlphaFlagBitsKHR VkFlags
+newtype VkDisplayPlaneAlphaFlagsKHR = VkDisplayPlaneAlphaFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkDisplayPlaneAlphaFlagBitsKHR
-type VkDisplayPlaneAlphaFlagsKHR = VkDisplayPlaneAlphaFlagBitsKHR
-
-instance Show VkDisplayPlaneAlphaFlagBitsKHR where
+instance Show VkDisplayPlaneAlphaFlagsKHR where
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR"
   showsPrec _ VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = showString "VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR"
   
-  showsPrec p (VkDisplayPlaneAlphaFlagBitsKHR x) = showParen (p >= 11) (showString "VkDisplayPlaneAlphaFlagBitsKHR " . showsPrec 11 x)
+  showsPrec p (VkDisplayPlaneAlphaFlagsKHR x) = showParen (p >= 11) (showString "VkDisplayPlaneAlphaFlagsKHR " . showsPrec 11 x)
 
-instance Read VkDisplayPlaneAlphaFlagBitsKHR where
+instance Read VkDisplayPlaneAlphaFlagsKHR where
   readPrec = parens ( choose [ ("VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR)
                              , ("VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR", pure VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDisplayPlaneAlphaFlagBitsKHR")
+                        expectP (Ident "VkDisplayPlaneAlphaFlagsKHR")
                         v <- step readPrec
-                        pure (VkDisplayPlaneAlphaFlagBitsKHR v)
+                        pure (VkDisplayPlaneAlphaFlagsKHR v)
                         )
                     )
 
 
-pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x1
+pattern VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x1
 
-pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x2
+pattern VK_DISPLAY_PLANE_ALPHA_GLOBAL_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x2
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x4
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x4
 
-pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = VkDisplayPlaneAlphaFlagBitsKHR 0x8
+pattern VK_DISPLAY_PLANE_ALPHA_PER_PIXEL_PREMULTIPLIED_BIT_KHR = VkDisplayPlaneAlphaFlagsKHR 0x8
 
 
 -- ** VkDisplayModeCreateFlagsKHR

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -62,7 +62,7 @@ data DisplaySurfaceCreateInfoKHR =
                              , alphaMode :: DisplayPlaneAlphaFlagsKHR 
                              , imageExtent :: Extent2D 
                              }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplaySurfaceCreateInfoKHR where
   sizeOf ~_ = 64
@@ -101,7 +101,7 @@ data DisplayPlaneCapabilitiesKHR =
                              , minDstExtent :: Extent2D 
                              , maxDstExtent :: Extent2D 
                              }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayPlaneCapabilitiesKHR where
   sizeOf ~_ = 68
@@ -142,7 +142,7 @@ data DisplayPropertiesKHR =
                       , planeReorderPossible :: Bool32 
                       , persistentContent :: Bool32 
                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayPropertiesKHR where
   sizeOf ~_ = 48
@@ -180,7 +180,7 @@ data DisplayPlanePropertiesKHR =
   DisplayPlanePropertiesKHR{ currentDisplay :: DisplayKHR 
                            , currentStackIndex :: Word32 
                            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayPlanePropertiesKHR where
   sizeOf ~_ = 16
@@ -202,7 +202,7 @@ data DisplayModePropertiesKHR =
   DisplayModePropertiesKHR{ displayMode :: DisplayModeKHR 
                           , parameters :: DisplayModeParametersKHR 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayModePropertiesKHR where
   sizeOf ~_ = 24
@@ -216,7 +216,7 @@ instance Storable DisplayModePropertiesKHR where
 -- ** DisplayPlaneAlphaFlagsKHR
 
 newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show DisplayPlaneAlphaFlagsKHR where
   showsPrec _ DisplayPlaneAlphaOpaqueBitKhr = showString "DisplayPlaneAlphaOpaqueBitKhr"
@@ -252,7 +252,7 @@ pattern DisplayPlaneAlphaPerPixelPremultipliedBitKhr = DisplayPlaneAlphaFlagsKHR
 -- ** DisplayModeCreateFlagsKHR
 -- | Opaque flag
 newtype DisplayModeCreateFlagsKHR = DisplayModeCreateFlagsKHR Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data DisplayModeCreateInfoKHR =
@@ -261,7 +261,7 @@ data DisplayModeCreateInfoKHR =
                           , flags :: DisplayModeCreateFlagsKHR 
                           , parameters :: DisplayModeParametersKHR 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayModeCreateInfoKHR where
   sizeOf ~_ = 32
@@ -282,14 +282,14 @@ foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" getPhysicalD
   Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO Result
 
 newtype DisplayModeKHR = DisplayModeKHR Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data DisplayModeParametersKHR =
   DisplayModeParametersKHR{ visibleRegion :: Extent2D 
                           , refreshRate :: Word32 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayModeParametersKHR where
   sizeOf ~_ = 12
@@ -303,10 +303,10 @@ instance Storable DisplayModeParametersKHR where
 -- ** DisplaySurfaceCreateFlagsKHR
 -- | Opaque flag
 newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 newtype DisplayKHR = DisplayKHR Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** getPhysicalDeviceDisplayPropertiesKHR
 foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" getPhysicalDeviceDisplayPropertiesKHR ::

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -17,8 +17,8 @@ import Data.Word( Word64(..)
 import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( SurfaceTransformFlagsKHR(..)
-                                  , SurfaceKHR(..)
+import Graphics.Vulkan.KHR.Surface( Surface(..)
+                                  , SurfaceTransformFlags(..)
                                   )
 import Data.Bits( Bits
                 , FiniteBits
@@ -50,272 +50,268 @@ import Foreign.C.Types( CFloat(..)
                       )
 
 
-data DisplaySurfaceCreateInfoKHR =
-  DisplaySurfaceCreateInfoKHR{ sType :: StructureType 
-                             , pNext :: Ptr Void 
-                             , flags :: DisplaySurfaceCreateFlagsKHR 
-                             , displayMode :: DisplayModeKHR 
-                             , planeIndex :: Word32 
-                             , planeStackIndex :: Word32 
-                             , transform :: SurfaceTransformFlagsKHR 
-                             , globalAlpha :: CFloat 
-                             , alphaMode :: DisplayPlaneAlphaFlagsKHR 
-                             , imageExtent :: Extent2D 
-                             }
-  deriving (Eq, Ord)
-
-instance Storable DisplaySurfaceCreateInfoKHR where
-  sizeOf ~_ = 64
-  alignment ~_ = 8
-  peek ptr = DisplaySurfaceCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-                                         <*> peek (ptr `plusPtr` 16)
-                                         <*> peek (ptr `plusPtr` 24)
-                                         <*> peek (ptr `plusPtr` 32)
-                                         <*> peek (ptr `plusPtr` 36)
-                                         <*> peek (ptr `plusPtr` 40)
-                                         <*> peek (ptr `plusPtr` 44)
-                                         <*> peek (ptr `plusPtr` 48)
-                                         <*> peek (ptr `plusPtr` 52)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (displayMode (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (planeIndex (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (planeStackIndex (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (transform (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (globalAlpha (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 48) (alphaMode (poked :: DisplaySurfaceCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (imageExtent (poked :: DisplaySurfaceCreateInfoKHR))
-
-
-
-data DisplayPlaneCapabilitiesKHR =
-  DisplayPlaneCapabilitiesKHR{ supportedAlpha :: DisplayPlaneAlphaFlagsKHR 
-                             , minSrcPosition :: Offset2D 
-                             , maxSrcPosition :: Offset2D 
-                             , minSrcExtent :: Extent2D 
-                             , maxSrcExtent :: Extent2D 
-                             , minDstPosition :: Offset2D 
-                             , maxDstPosition :: Offset2D 
-                             , minDstExtent :: Extent2D 
-                             , maxDstExtent :: Extent2D 
-                             }
-  deriving (Eq, Ord)
-
-instance Storable DisplayPlaneCapabilitiesKHR where
-  sizeOf ~_ = 68
-  alignment ~_ = 4
-  peek ptr = DisplayPlaneCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 4)
-                                         <*> peek (ptr `plusPtr` 12)
-                                         <*> peek (ptr `plusPtr` 20)
-                                         <*> peek (ptr `plusPtr` 28)
-                                         <*> peek (ptr `plusPtr` 36)
-                                         <*> peek (ptr `plusPtr` 44)
-                                         <*> peek (ptr `plusPtr` 52)
-                                         <*> peek (ptr `plusPtr` 60)
-  poke ptr poked = poke (ptr `plusPtr` 0) (supportedAlpha (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (minSrcPosition (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 12) (maxSrcPosition (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 20) (minSrcExtent (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 28) (maxSrcExtent (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (minDstPosition (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (maxDstPosition (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 52) (minDstExtent (poked :: DisplayPlaneCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: DisplayPlaneCapabilitiesKHR))
-
-
--- ** getDisplayModePropertiesKHR
-foreign import ccall "vkGetDisplayModePropertiesKHR" getDisplayModePropertiesKHR ::
-  PhysicalDevice ->
-  DisplayKHR ->
-    Ptr Word32 -> Ptr DisplayModePropertiesKHR -> IO Result
-
-
-data DisplayPropertiesKHR =
-  DisplayPropertiesKHR{ display :: DisplayKHR 
-                      , displayName :: Ptr CChar 
-                      , physicalDimensions :: Extent2D 
-                      , physicalResolution :: Extent2D 
-                      , supportedTransforms :: SurfaceTransformFlagsKHR 
-                      , planeReorderPossible :: Bool32 
-                      , persistentContent :: Bool32 
-                      }
-  deriving (Eq, Ord)
-
-instance Storable DisplayPropertiesKHR where
-  sizeOf ~_ = 48
-  alignment ~_ = 8
-  peek ptr = DisplayPropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-                                  <*> peek (ptr `plusPtr` 32)
-                                  <*> peek (ptr `plusPtr` 36)
-                                  <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (display (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (displayName (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 16) (physicalDimensions (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 24) (physicalResolution (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 32) (supportedTransforms (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 36) (planeReorderPossible (poked :: DisplayPropertiesKHR))
-                *> poke (ptr `plusPtr` 40) (persistentContent (poked :: DisplayPropertiesKHR))
-
-
--- ** getDisplayPlaneSupportedDisplaysKHR
-foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" getDisplayPlaneSupportedDisplaysKHR ::
-  PhysicalDevice ->
-  Word32 -> Ptr Word32 -> Ptr DisplayKHR -> IO Result
-
--- ** createDisplayModeKHR
-foreign import ccall "vkCreateDisplayModeKHR" createDisplayModeKHR ::
-  PhysicalDevice ->
-  DisplayKHR ->
-    Ptr DisplayModeCreateInfoKHR ->
-      Ptr AllocationCallbacks -> Ptr DisplayModeKHR -> IO Result
-
-
-data DisplayPlanePropertiesKHR =
-  DisplayPlanePropertiesKHR{ currentDisplay :: DisplayKHR 
-                           , currentStackIndex :: Word32 
-                           }
-  deriving (Eq, Ord)
-
-instance Storable DisplayPlanePropertiesKHR where
-  sizeOf ~_ = 16
-  alignment ~_ = 8
-  peek ptr = DisplayPlanePropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                       <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (currentDisplay (poked :: DisplayPlanePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: DisplayPlanePropertiesKHR))
-
-
--- ** getDisplayPlaneCapabilitiesKHR
-foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" getDisplayPlaneCapabilitiesKHR ::
-  PhysicalDevice ->
-  DisplayModeKHR ->
-    Word32 -> Ptr DisplayPlaneCapabilitiesKHR -> IO Result
-
-
-data DisplayModePropertiesKHR =
-  DisplayModePropertiesKHR{ displayMode :: DisplayModeKHR 
-                          , parameters :: DisplayModeParametersKHR 
+data DisplaySurfaceCreateInfo =
+  DisplaySurfaceCreateInfo{ sType :: StructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: DisplaySurfaceCreateFlags 
+                          , displayMode :: DisplayMode 
+                          , planeIndex :: Word32 
+                          , planeStackIndex :: Word32 
+                          , transform :: SurfaceTransformFlags 
+                          , globalAlpha :: CFloat 
+                          , alphaMode :: DisplayPlaneAlphaFlags 
+                          , imageExtent :: Extent2D 
                           }
   deriving (Eq, Ord)
 
-instance Storable DisplayModePropertiesKHR where
+instance Storable DisplaySurfaceCreateInfo where
+  sizeOf ~_ = 64
+  alignment ~_ = 8
+  peek ptr = DisplaySurfaceCreateInfo <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 24)
+                                      <*> peek (ptr `plusPtr` 32)
+                                      <*> peek (ptr `plusPtr` 36)
+                                      <*> peek (ptr `plusPtr` 40)
+                                      <*> peek (ptr `plusPtr` 44)
+                                      <*> peek (ptr `plusPtr` 48)
+                                      <*> peek (ptr `plusPtr` 52)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 24) (displayMode (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 32) (planeIndex (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 36) (planeStackIndex (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 40) (transform (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 44) (globalAlpha (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 48) (alphaMode (poked :: DisplaySurfaceCreateInfo))
+                *> poke (ptr `plusPtr` 52) (imageExtent (poked :: DisplaySurfaceCreateInfo))
+
+
+
+data DisplayPlaneCapabilities =
+  DisplayPlaneCapabilities{ supportedAlpha :: DisplayPlaneAlphaFlags 
+                          , minSrcPosition :: Offset2D 
+                          , maxSrcPosition :: Offset2D 
+                          , minSrcExtent :: Extent2D 
+                          , maxSrcExtent :: Extent2D 
+                          , minDstPosition :: Offset2D 
+                          , maxDstPosition :: Offset2D 
+                          , minDstExtent :: Extent2D 
+                          , maxDstExtent :: Extent2D 
+                          }
+  deriving (Eq, Ord)
+
+instance Storable DisplayPlaneCapabilities where
+  sizeOf ~_ = 68
+  alignment ~_ = 4
+  peek ptr = DisplayPlaneCapabilities <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 4)
+                                      <*> peek (ptr `plusPtr` 12)
+                                      <*> peek (ptr `plusPtr` 20)
+                                      <*> peek (ptr `plusPtr` 28)
+                                      <*> peek (ptr `plusPtr` 36)
+                                      <*> peek (ptr `plusPtr` 44)
+                                      <*> peek (ptr `plusPtr` 52)
+                                      <*> peek (ptr `plusPtr` 60)
+  poke ptr poked = poke (ptr `plusPtr` 0) (supportedAlpha (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 4) (minSrcPosition (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 12) (maxSrcPosition (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 20) (minSrcExtent (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 28) (maxSrcExtent (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 36) (minDstPosition (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 44) (maxDstPosition (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 52) (minDstExtent (poked :: DisplayPlaneCapabilities))
+                *> poke (ptr `plusPtr` 60) (maxDstExtent (poked :: DisplayPlaneCapabilities))
+
+
+-- ** getDisplayModeProperties
+foreign import ccall "vkGetDisplayModePropertiesKHR" getDisplayModeProperties ::
+  PhysicalDevice ->
+  Display -> Ptr Word32 -> Ptr DisplayModeProperties -> IO Result
+
+
+data DisplayProperties =
+  DisplayProperties{ display :: Display 
+                   , displayName :: Ptr CChar 
+                   , physicalDimensions :: Extent2D 
+                   , physicalResolution :: Extent2D 
+                   , supportedTransforms :: SurfaceTransformFlags 
+                   , planeReorderPossible :: Bool32 
+                   , persistentContent :: Bool32 
+                   }
+  deriving (Eq, Ord)
+
+instance Storable DisplayProperties where
+  sizeOf ~_ = 48
+  alignment ~_ = 8
+  peek ptr = DisplayProperties <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 24)
+                               <*> peek (ptr `plusPtr` 32)
+                               <*> peek (ptr `plusPtr` 36)
+                               <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (display (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 8) (displayName (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 16) (physicalDimensions (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 24) (physicalResolution (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 32) (supportedTransforms (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 36) (planeReorderPossible (poked :: DisplayProperties))
+                *> poke (ptr `plusPtr` 40) (persistentContent (poked :: DisplayProperties))
+
+
+-- ** getDisplayPlaneSupportedDisplays
+foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" getDisplayPlaneSupportedDisplays ::
+  PhysicalDevice -> Word32 -> Ptr Word32 -> Ptr Display -> IO Result
+
+-- ** createDisplayMode
+foreign import ccall "vkCreateDisplayModeKHR" createDisplayMode ::
+  PhysicalDevice ->
+  Display ->
+    Ptr DisplayModeCreateInfo ->
+      Ptr AllocationCallbacks -> Ptr DisplayMode -> IO Result
+
+
+data DisplayPlaneProperties =
+  DisplayPlaneProperties{ currentDisplay :: Display 
+                        , currentStackIndex :: Word32 
+                        }
+  deriving (Eq, Ord)
+
+instance Storable DisplayPlaneProperties where
+  sizeOf ~_ = 16
+  alignment ~_ = 8
+  peek ptr = DisplayPlaneProperties <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (currentDisplay (poked :: DisplayPlaneProperties))
+                *> poke (ptr `plusPtr` 8) (currentStackIndex (poked :: DisplayPlaneProperties))
+
+
+-- ** getDisplayPlaneCapabilities
+foreign import ccall "vkGetDisplayPlaneCapabilitiesKHR" getDisplayPlaneCapabilities ::
+  PhysicalDevice ->
+  DisplayMode -> Word32 -> Ptr DisplayPlaneCapabilities -> IO Result
+
+
+data DisplayModeProperties =
+  DisplayModeProperties{ displayMode :: DisplayMode 
+                       , parameters :: DisplayModeParameters 
+                       }
+  deriving (Eq, Ord)
+
+instance Storable DisplayModeProperties where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = DisplayModePropertiesKHR <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (displayMode (poked :: DisplayModePropertiesKHR))
-                *> poke (ptr `plusPtr` 8) (parameters (poked :: DisplayModePropertiesKHR))
+  peek ptr = DisplayModeProperties <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (displayMode (poked :: DisplayModeProperties))
+                *> poke (ptr `plusPtr` 8) (parameters (poked :: DisplayModeProperties))
 
 
--- ** DisplayPlaneAlphaFlagsKHR
+-- ** DisplayPlaneAlphaFlags
 
-newtype DisplayPlaneAlphaFlagsKHR = DisplayPlaneAlphaFlagsKHR Flags
+newtype DisplayPlaneAlphaFlags = DisplayPlaneAlphaFlags Flags
   deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
-instance Show DisplayPlaneAlphaFlagsKHR where
-  showsPrec _ DisplayPlaneAlphaOpaqueBitKhr = showString "DisplayPlaneAlphaOpaqueBitKhr"
-  showsPrec _ DisplayPlaneAlphaGlobalBitKhr = showString "DisplayPlaneAlphaGlobalBitKhr"
-  showsPrec _ DisplayPlaneAlphaPerPixelBitKhr = showString "DisplayPlaneAlphaPerPixelBitKhr"
-  showsPrec _ DisplayPlaneAlphaPerPixelPremultipliedBitKhr = showString "DisplayPlaneAlphaPerPixelPremultipliedBitKhr"
+instance Show DisplayPlaneAlphaFlags where
+  showsPrec _ DisplayPlaneAlphaOpaqueBit = showString "DisplayPlaneAlphaOpaqueBit"
+  showsPrec _ DisplayPlaneAlphaGlobalBit = showString "DisplayPlaneAlphaGlobalBit"
+  showsPrec _ DisplayPlaneAlphaPerPixelBit = showString "DisplayPlaneAlphaPerPixelBit"
+  showsPrec _ DisplayPlaneAlphaPerPixelPremultipliedBit = showString "DisplayPlaneAlphaPerPixelPremultipliedBit"
   
-  showsPrec p (DisplayPlaneAlphaFlagsKHR x) = showParen (p >= 11) (showString "DisplayPlaneAlphaFlagsKHR " . showsPrec 11 x)
+  showsPrec p (DisplayPlaneAlphaFlags x) = showParen (p >= 11) (showString "DisplayPlaneAlphaFlags " . showsPrec 11 x)
 
-instance Read DisplayPlaneAlphaFlagsKHR where
-  readPrec = parens ( choose [ ("DisplayPlaneAlphaOpaqueBitKhr", pure DisplayPlaneAlphaOpaqueBitKhr)
-                             , ("DisplayPlaneAlphaGlobalBitKhr", pure DisplayPlaneAlphaGlobalBitKhr)
-                             , ("DisplayPlaneAlphaPerPixelBitKhr", pure DisplayPlaneAlphaPerPixelBitKhr)
-                             , ("DisplayPlaneAlphaPerPixelPremultipliedBitKhr", pure DisplayPlaneAlphaPerPixelPremultipliedBitKhr)
+instance Read DisplayPlaneAlphaFlags where
+  readPrec = parens ( choose [ ("DisplayPlaneAlphaOpaqueBit", pure DisplayPlaneAlphaOpaqueBit)
+                             , ("DisplayPlaneAlphaGlobalBit", pure DisplayPlaneAlphaGlobalBit)
+                             , ("DisplayPlaneAlphaPerPixelBit", pure DisplayPlaneAlphaPerPixelBit)
+                             , ("DisplayPlaneAlphaPerPixelPremultipliedBit", pure DisplayPlaneAlphaPerPixelPremultipliedBit)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "DisplayPlaneAlphaFlagsKHR")
+                        expectP (Ident "DisplayPlaneAlphaFlags")
                         v <- step readPrec
-                        pure (DisplayPlaneAlphaFlagsKHR v)
+                        pure (DisplayPlaneAlphaFlags v)
                         )
                     )
 
 
-pattern DisplayPlaneAlphaOpaqueBitKhr = DisplayPlaneAlphaFlagsKHR 0x1
+pattern DisplayPlaneAlphaOpaqueBit = DisplayPlaneAlphaFlags 0x1
 
-pattern DisplayPlaneAlphaGlobalBitKhr = DisplayPlaneAlphaFlagsKHR 0x2
+pattern DisplayPlaneAlphaGlobalBit = DisplayPlaneAlphaFlags 0x2
 
-pattern DisplayPlaneAlphaPerPixelBitKhr = DisplayPlaneAlphaFlagsKHR 0x4
+pattern DisplayPlaneAlphaPerPixelBit = DisplayPlaneAlphaFlags 0x4
 
-pattern DisplayPlaneAlphaPerPixelPremultipliedBitKhr = DisplayPlaneAlphaFlagsKHR 0x8
+pattern DisplayPlaneAlphaPerPixelPremultipliedBit = DisplayPlaneAlphaFlags 0x8
 
 
--- ** DisplayModeCreateFlagsKHR
+-- ** DisplayModeCreateFlags
 -- | Opaque flag
-newtype DisplayModeCreateFlagsKHR = DisplayModeCreateFlagsKHR Flags
+newtype DisplayModeCreateFlags = DisplayModeCreateFlags Flags
   deriving (Eq, Ord, Storable)
 
 
-data DisplayModeCreateInfoKHR =
-  DisplayModeCreateInfoKHR{ sType :: StructureType 
-                          , pNext :: Ptr Void 
-                          , flags :: DisplayModeCreateFlagsKHR 
-                          , parameters :: DisplayModeParametersKHR 
-                          }
+data DisplayModeCreateInfo =
+  DisplayModeCreateInfo{ sType :: StructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: DisplayModeCreateFlags 
+                       , parameters :: DisplayModeParameters 
+                       }
   deriving (Eq, Ord)
 
-instance Storable DisplayModeCreateInfoKHR where
+instance Storable DisplayModeCreateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = DisplayModeCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplayModeCreateInfoKHR))
-                *> poke (ptr `plusPtr` 20) (parameters (poked :: DisplayModeCreateInfoKHR))
+  peek ptr = DisplayModeCreateInfo <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayModeCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayModeCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: DisplayModeCreateInfo))
+                *> poke (ptr `plusPtr` 20) (parameters (poked :: DisplayModeCreateInfo))
 
 
--- ** getPhysicalDeviceDisplayPlanePropertiesKHR
-foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" getPhysicalDeviceDisplayPlanePropertiesKHR ::
+-- ** getPhysicalDeviceDisplayPlaneProperties
+foreign import ccall "vkGetPhysicalDeviceDisplayPlanePropertiesKHR" getPhysicalDeviceDisplayPlaneProperties ::
   PhysicalDevice ->
-  Ptr Word32 -> Ptr DisplayPlanePropertiesKHR -> IO Result
+  Ptr Word32 -> Ptr DisplayPlaneProperties -> IO Result
 
-newtype DisplayModeKHR = DisplayModeKHR Word64
+newtype DisplayMode = DisplayMode Word64
   deriving (Eq, Ord, Storable)
 
 
-data DisplayModeParametersKHR =
-  DisplayModeParametersKHR{ visibleRegion :: Extent2D 
-                          , refreshRate :: Word32 
-                          }
+data DisplayModeParameters =
+  DisplayModeParameters{ visibleRegion :: Extent2D 
+                       , refreshRate :: Word32 
+                       }
   deriving (Eq, Ord)
 
-instance Storable DisplayModeParametersKHR where
+instance Storable DisplayModeParameters where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = DisplayModeParametersKHR <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (visibleRegion (poked :: DisplayModeParametersKHR))
-                *> poke (ptr `plusPtr` 8) (refreshRate (poked :: DisplayModeParametersKHR))
+  peek ptr = DisplayModeParameters <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (visibleRegion (poked :: DisplayModeParameters))
+                *> poke (ptr `plusPtr` 8) (refreshRate (poked :: DisplayModeParameters))
 
 
--- ** DisplaySurfaceCreateFlagsKHR
+-- ** DisplaySurfaceCreateFlags
 -- | Opaque flag
-newtype DisplaySurfaceCreateFlagsKHR = DisplaySurfaceCreateFlagsKHR Flags
+newtype DisplaySurfaceCreateFlags = DisplaySurfaceCreateFlags Flags
   deriving (Eq, Ord, Storable)
 
-newtype DisplayKHR = DisplayKHR Word64
+newtype Display = Display Word64
   deriving (Eq, Ord, Storable)
 
--- ** getPhysicalDeviceDisplayPropertiesKHR
-foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" getPhysicalDeviceDisplayPropertiesKHR ::
-  PhysicalDevice ->
-  Ptr Word32 -> Ptr DisplayPropertiesKHR -> IO Result
+-- ** getPhysicalDeviceDisplayProperties
+foreign import ccall "vkGetPhysicalDeviceDisplayPropertiesKHR" getPhysicalDeviceDisplayProperties ::
+  PhysicalDevice -> Ptr Word32 -> Ptr DisplayProperties -> IO Result
 
--- ** createDisplayPlaneSurfaceKHR
-foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" createDisplayPlaneSurfaceKHR ::
+-- ** createDisplayPlaneSurface
+foreign import ccall "vkCreateDisplayPlaneSurfaceKHR" createDisplayPlaneSurface ::
   Instance ->
-  Ptr DisplaySurfaceCreateInfoKHR ->
-    Ptr AllocationCallbacks -> Ptr SurfaceKHR -> IO Result
+  Ptr DisplaySurfaceCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Surface -> IO Result
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.KHR.DisplaySwapchain where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.KHR.Swapchain( VkSwapchainKHR(..)
+import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR(..)
                                     , VkSwapchainCreateInfoKHR(..)
                                     , VkSwapchainCreateFlagsKHR(..)
                                     )
@@ -18,7 +18,7 @@ import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
                                   , VkSurfaceTransformFlagBitsKHR(..)
                                   , VkPresentModeKHR(..)
                                   , VkCompositeAlphaFlagBitsKHR(..)
-                                  , VkSurfaceKHR(..)
+                                  , SurfaceKHR(..)
                                   )
 import Data.Int( Int32
                )
@@ -53,11 +53,11 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkDisplayPresentInfoKHR =
-  VkDisplayPresentInfoKHR{ vkSType :: VkStructureType 
-                         , vkPNext :: Ptr Void 
-                         , vkSrcRect :: VkRect2D 
-                         , vkDstRect :: VkRect2D 
-                         , vkPersistent :: VkBool32 
+  VkDisplayPresentInfoKHR{ sType :: VkStructureType 
+                         , pNext :: Ptr Void 
+                         , srcRect :: VkRect2D 
+                         , dstRect :: VkRect2D 
+                         , persistent :: VkBool32 
                          }
   deriving (Eq)
 
@@ -69,17 +69,17 @@ instance Storable VkDisplayPresentInfoKHR where
                                      <*> peek (ptr `plusPtr` 16)
                                      <*> peek (ptr `plusPtr` 32)
                                      <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (vkSrcRect (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (vkDstRect (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (vkPersistent (poked :: VkDisplayPresentInfoKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (srcRect (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (dstRect (poked :: VkDisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (persistent (poked :: VkDisplayPresentInfoKHR))
 
 
 -- ** vkCreateSharedSwapchainsKHR
 foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR ::
-  VkDevice ->
+  Device ->
   Word32 ->
     Ptr VkSwapchainCreateInfoKHR ->
-      Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
+      Ptr VkAllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -2,54 +2,15 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.KHR.DisplaySwapchain where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR(..)
-                                    , VkSwapchainCreateInfoKHR(..)
-                                    , VkSwapchainCreateFlagsKHR(..)
-                                    )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
-                                  , VkSurfaceTransformFlagBitsKHR(..)
-                                  , VkPresentModeKHR(..)
-                                  , VkCompositeAlphaFlagBitsKHR(..)
-                                  , SurfaceKHR(..)
-                                  )
-import Data.Int( Int32
-               )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , VkImageUsageFlagBits(..)
-                            )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkOffset2D(..)
-                           , VkRect2D(..)
-                           , VkStructureType(..)
-                           , VkSharingMode(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkDisplayPresentInfoKHR =

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -49,8 +49,8 @@ instance Storable DisplayPresentInfoKHR where
                 *> poke (ptr `plusPtr` 48) (persistent (poked :: DisplayPresentInfoKHR))
 
 
--- ** vkCreateSharedSwapchainsKHR
-foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR ::
+-- ** createSharedSwapchainsKHR
+foreign import ccall "vkCreateSharedSwapchainsKHR" createSharedSwapchainsKHR ::
   Device ->
   Word32 ->
     Ptr SwapchainCreateInfoKHR ->

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -2,26 +2,26 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.KHR.DisplaySwapchain where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR
-                                    , VkSwapchainCreateInfoKHR
+import Graphics.Vulkan.KHR.Swapchain( VkSwapchainCreateInfoKHR(..)
+                                    , SwapchainKHR(..)
                                     )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkRect2D
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkRect2D(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
 
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -4,7 +4,7 @@ module Graphics.Vulkan.KHR.DisplaySwapchain where
 
 import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.KHR.Swapchain( VkSwapchainCreateInfoKHR(..)
+import Graphics.Vulkan.KHR.Swapchain( SwapchainCreateInfoKHR(..)
                                     , SwapchainKHR(..)
                                     )
 import Data.Word( Word32(..)
@@ -16,43 +16,43 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkRect2D(..)
                            , VkBool32(..)
+                           , Rect2D(..)
                            , VkResult(..)
                            )
 
 
-data VkDisplayPresentInfoKHR =
-  VkDisplayPresentInfoKHR{ sType :: VkStructureType 
-                         , pNext :: Ptr Void 
-                         , srcRect :: VkRect2D 
-                         , dstRect :: VkRect2D 
-                         , persistent :: VkBool32 
-                         }
+data DisplayPresentInfoKHR =
+  DisplayPresentInfoKHR{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , srcRect :: Rect2D 
+                       , dstRect :: Rect2D 
+                       , persistent :: VkBool32 
+                       }
   deriving (Eq)
 
-instance Storable VkDisplayPresentInfoKHR where
+instance Storable DisplayPresentInfoKHR where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkDisplayPresentInfoKHR <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 32)
-                                     <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (srcRect (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (dstRect (poked :: VkDisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (persistent (poked :: VkDisplayPresentInfoKHR))
+  peek ptr = DisplayPresentInfoKHR <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 32)
+                                   <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (srcRect (poked :: DisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (dstRect (poked :: DisplayPresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (persistent (poked :: DisplayPresentInfoKHR))
 
 
 -- ** vkCreateSharedSwapchainsKHR
 foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR ::
   Device ->
   Word32 ->
-    Ptr VkSwapchainCreateInfoKHR ->
-      Ptr VkAllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
+    Ptr SwapchainCreateInfoKHR ->
+      Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -4,8 +4,8 @@ module Graphics.Vulkan.KHR.DisplaySwapchain where
 
 import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.KHR.Swapchain( SwapchainCreateInfoKHR(..)
-                                    , SwapchainKHR(..)
+import Graphics.Vulkan.KHR.Swapchain( Swapchain(..)
+                                    , SwapchainCreateInfo(..)
                                     )
 import Data.Word( Word32(..)
                 )
@@ -25,34 +25,34 @@ import Graphics.Vulkan.Core( Bool32(..)
                            )
 
 
-data DisplayPresentInfoKHR =
-  DisplayPresentInfoKHR{ sType :: StructureType 
-                       , pNext :: Ptr Void 
-                       , srcRect :: Rect2D 
-                       , dstRect :: Rect2D 
-                       , persistent :: Bool32 
-                       }
+data DisplayPresentInfo =
+  DisplayPresentInfo{ sType :: StructureType 
+                    , pNext :: Ptr Void 
+                    , srcRect :: Rect2D 
+                    , dstRect :: Rect2D 
+                    , persistent :: Bool32 
+                    }
   deriving (Eq, Ord)
 
-instance Storable DisplayPresentInfoKHR where
+instance Storable DisplayPresentInfo where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = DisplayPresentInfoKHR <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 32)
-                                   <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (srcRect (poked :: DisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (dstRect (poked :: DisplayPresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (persistent (poked :: DisplayPresentInfoKHR))
+  peek ptr = DisplayPresentInfo <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 32)
+                                <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: DisplayPresentInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: DisplayPresentInfo))
+                *> poke (ptr `plusPtr` 16) (srcRect (poked :: DisplayPresentInfo))
+                *> poke (ptr `plusPtr` 32) (dstRect (poked :: DisplayPresentInfo))
+                *> poke (ptr `plusPtr` 48) (persistent (poked :: DisplayPresentInfo))
 
 
--- ** createSharedSwapchainsKHR
-foreign import ccall "vkCreateSharedSwapchainsKHR" createSharedSwapchainsKHR ::
+-- ** createSharedSwapchains
+foreign import ccall "vkCreateSharedSwapchainsKHR" createSharedSwapchains ::
   Device ->
   Word32 ->
-    Ptr SwapchainCreateInfoKHR ->
-      Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO Result
+    Ptr SwapchainCreateInfo ->
+      Ptr AllocationCallbacks -> Ptr Swapchain -> IO Result
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -18,15 +18,15 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , VkBool32(..)
                            , Rect2D(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 
 
 data DisplayPresentInfoKHR =
-  DisplayPresentInfoKHR{ sType :: VkStructureType 
+  DisplayPresentInfoKHR{ sType :: StructureType 
                        , pNext :: Ptr Void 
                        , srcRect :: Rect2D 
                        , dstRect :: Rect2D 
@@ -54,5 +54,5 @@ foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR :
   Device ->
   Word32 ->
     Ptr SwapchainCreateInfoKHR ->
-      Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
+      Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO Result
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -18,8 +18,8 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( StructureType(..)
-                           , VkBool32(..)
+import Graphics.Vulkan.Core( Bool32(..)
+                           , StructureType(..)
                            , Rect2D(..)
                            , Result(..)
                            )
@@ -30,7 +30,7 @@ data DisplayPresentInfoKHR =
                        , pNext :: Ptr Void 
                        , srcRect :: Rect2D 
                        , dstRect :: Rect2D 
-                       , persistent :: VkBool32 
+                       , persistent :: Bool32 
                        }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -32,7 +32,7 @@ data DisplayPresentInfoKHR =
                        , dstRect :: Rect2D 
                        , persistent :: Bool32 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DisplayPresentInfoKHR where
   sizeOf ~_ = 56

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -2,6 +2,11 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.KHR.DisplaySwapchain where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR
+                                    , VkSwapchainCreateInfoKHR
+                                    )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -11,6 +16,13 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkRect2D
+                           , VkStructureType
+                           )
 
 
 data VkDisplayPresentInfoKHR =

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Surface where
 
-import Graphics.Vulkan.Device( VkPhysicalDevice(..)
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -45,7 +45,7 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Image( VkImageUsageFlags(..)
                             , VkImageUsageFlagBits(..)
                             )
-import Graphics.Vulkan.DeviceInitialization( VkInstance(..)
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkBool32(..)
@@ -58,13 +58,13 @@ import Foreign.C.Types( CSize(..)
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::
-  VkPhysicalDevice ->
-  VkSurfaceKHR -> Ptr Word32 -> Ptr VkSurfaceFormatKHR -> IO VkResult
+  PhysicalDevice ->
+  SurfaceKHR -> Ptr Word32 -> Ptr VkSurfaceFormatKHR -> IO VkResult
 
 -- ** vkGetPhysicalDeviceSurfaceCapabilitiesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDeviceSurfaceCapabilitiesKHR ::
-  VkPhysicalDevice ->
-  VkSurfaceKHR -> Ptr VkSurfaceCapabilitiesKHR -> IO VkResult
+  PhysicalDevice ->
+  SurfaceKHR -> Ptr VkSurfaceCapabilitiesKHR -> IO VkResult
 
 -- ** VkCompositeAlphaFlagsKHR
 
@@ -139,18 +139,18 @@ pattern VK_PRESENT_MODE_FIFO_KHR = VkPresentModeKHR 2
 
 pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = VkPresentModeKHR 3
 
-newtype VkSurfaceKHR = VkSurfaceKHR Word64
+newtype SurfaceKHR = SurfaceKHR Word64
   deriving (Eq, Storable)
 
 -- ** vkGetPhysicalDeviceSurfaceSupportKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceSurfaceSupportKHR ::
-  VkPhysicalDevice ->
-  Word32 -> VkSurfaceKHR -> Ptr VkBool32 -> IO VkResult
+  PhysicalDevice ->
+  Word32 -> SurfaceKHR -> Ptr VkBool32 -> IO VkResult
 
 
 data VkSurfaceFormatKHR =
-  VkSurfaceFormatKHR{ vkFormat :: VkFormat 
-                    , vkColorSpace :: VkColorSpaceKHR 
+  VkSurfaceFormatKHR{ format :: VkFormat 
+                    , colorSpace :: VkColorSpaceKHR 
                     }
   deriving (Eq)
 
@@ -159,13 +159,13 @@ instance Storable VkSurfaceFormatKHR where
   alignment ~_ = 4
   peek ptr = VkSurfaceFormatKHR <$> peek (ptr `plusPtr` 0)
                                 <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkFormat (poked :: VkSurfaceFormatKHR))
-                *> poke (ptr `plusPtr` 4) (vkColorSpace (poked :: VkSurfaceFormatKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (format (poked :: VkSurfaceFormatKHR))
+                *> poke (ptr `plusPtr` 4) (colorSpace (poked :: VkSurfaceFormatKHR))
 
 
 -- ** vkDestroySurfaceKHR
 foreign import ccall "vkDestroySurfaceKHR" vkDestroySurfaceKHR ::
-  VkInstance -> VkSurfaceKHR -> Ptr VkAllocationCallbacks -> IO ()
+  Instance -> SurfaceKHR -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkColorSpaceKHR
 
@@ -191,8 +191,8 @@ pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = VkColorSpaceKHR 0
 
 -- ** vkGetPhysicalDeviceSurfacePresentModesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDeviceSurfacePresentModesKHR ::
-  VkPhysicalDevice ->
-  VkSurfaceKHR -> Ptr Word32 -> Ptr VkPresentModeKHR -> IO VkResult
+  PhysicalDevice ->
+  SurfaceKHR -> Ptr Word32 -> Ptr VkPresentModeKHR -> IO VkResult
 
 -- ** VkSurfaceTransformFlagsKHR
 
@@ -255,16 +255,16 @@ pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x1
 
 
 data VkSurfaceCapabilitiesKHR =
-  VkSurfaceCapabilitiesKHR{ vkMinImageCount :: Word32 
-                          , vkMaxImageCount :: Word32 
-                          , vkCurrentExtent :: VkExtent2D 
-                          , vkMinImageExtent :: VkExtent2D 
-                          , vkMaxImageExtent :: VkExtent2D 
-                          , vkMaxImageArrayLayers :: Word32 
-                          , vkSupportedTransforms :: VkSurfaceTransformFlagsKHR 
-                          , vkCurrentTransform :: VkSurfaceTransformFlagBitsKHR 
-                          , vkSupportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
-                          , vkSupportedUsageFlags :: VkImageUsageFlags 
+  VkSurfaceCapabilitiesKHR{ minImageCount :: Word32 
+                          , maxImageCount :: Word32 
+                          , currentExtent :: VkExtent2D 
+                          , minImageExtent :: VkExtent2D 
+                          , maxImageExtent :: VkExtent2D 
+                          , maxImageArrayLayers :: Word32 
+                          , supportedTransforms :: VkSurfaceTransformFlagsKHR 
+                          , currentTransform :: VkSurfaceTransformFlagBitsKHR 
+                          , supportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
+                          , supportedUsageFlags :: VkImageUsageFlags 
                           }
   deriving (Eq)
 
@@ -281,15 +281,15 @@ instance Storable VkSurfaceCapabilitiesKHR where
                                       <*> peek (ptr `plusPtr` 40)
                                       <*> peek (ptr `plusPtr` 44)
                                       <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMinImageCount (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (vkMaxImageCount (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 8) (vkCurrentExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 16) (vkMinImageExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 24) (vkMaxImageExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 32) (vkMaxImageArrayLayers (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (vkSupportedTransforms (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 40) (vkCurrentTransform (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (vkSupportedCompositeAlpha (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 48) (vkSupportedUsageFlags (poked :: VkSurfaceCapabilitiesKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (minImageCount (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 4) (maxImageCount (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 8) (currentExtent (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 16) (minImageExtent (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 24) (maxImageExtent (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 32) (maxImageArrayLayers (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 36) (supportedTransforms (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 40) (currentTransform (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 44) (supportedCompositeAlpha (poked :: VkSurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 48) (supportedUsageFlags (poked :: VkSurfaceCapabilitiesKHR))
 
 

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Surface where
 
-import Graphics.Vulkan.Device( PhysicalDevice(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,17 +22,6 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
-                )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -42,19 +29,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , VkImageUsageFlagBits(..)
-                            )
-import Graphics.Vulkan.DeviceInitialization( Instance(..)
-                                           )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Surface where
 
+import Graphics.Vulkan.Device( PhysicalDevice
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -15,6 +17,15 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.KHR.Surface( VkCompositeAlphaFlagsKHR
+                                  , VkSurfaceFormatKHR
+                                  , VkSurfaceTransformFlagBitsKHR
+                                  , SurfaceKHR
+                                  , VkSurfaceCapabilitiesKHR
+                                  , VkPresentModeKHR
+                                  , VkSurfaceTransformFlagsKHR
+                                  , VkColorSpaceKHR
+                                  )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -22,6 +33,8 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +42,16 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Image( VkImageUsageFlags
+                            )
+import Graphics.Vulkan.DeviceInitialization( Instance
+                                           )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkExtent2D
+                           , VkFlags
+                           , VkFormat
+                           )
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -33,109 +33,108 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
+import Graphics.Vulkan.Image( ImageUsageFlags(..)
                             )
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkFormat(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Format(..)
+                           , Result(..)
                            , Extent2D(..)
                            )
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr Word32 -> Ptr SurfaceFormatKHR -> IO VkResult
+  SurfaceKHR -> Ptr Word32 -> Ptr SurfaceFormatKHR -> IO Result
 
 -- ** vkGetPhysicalDeviceSurfaceCapabilitiesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDeviceSurfaceCapabilitiesKHR ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO VkResult
+  SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO Result
 
 -- ** VkCompositeAlphaFlagsKHR
 
-newtype VkCompositeAlphaFlagsKHR = VkCompositeAlphaFlagsKHR VkFlags
+newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCompositeAlphaFlagsKHR where
+instance Show CompositeAlphaFlagsKHR where
   showsPrec _ VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = showString "VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = showString "VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR"
   
-  showsPrec p (VkCompositeAlphaFlagsKHR x) = showParen (p >= 11) (showString "VkCompositeAlphaFlagsKHR " . showsPrec 11 x)
+  showsPrec p (CompositeAlphaFlagsKHR x) = showParen (p >= 11) (showString "CompositeAlphaFlagsKHR " . showsPrec 11 x)
 
-instance Read VkCompositeAlphaFlagsKHR where
+instance Read CompositeAlphaFlagsKHR where
   readPrec = parens ( choose [ ("VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR", pure VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR", pure VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCompositeAlphaFlagsKHR")
+                        expectP (Ident "CompositeAlphaFlagsKHR")
                         v <- step readPrec
-                        pure (VkCompositeAlphaFlagsKHR v)
+                        pure (CompositeAlphaFlagsKHR v)
                         )
                     )
 
 
-pattern VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = VkCompositeAlphaFlagsKHR 0x1
+pattern VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = CompositeAlphaFlagsKHR 0x1
 
-pattern VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagsKHR 0x2
+pattern VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = CompositeAlphaFlagsKHR 0x2
 
-pattern VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagsKHR 0x4
+pattern VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = CompositeAlphaFlagsKHR 0x4
 
-pattern VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = VkCompositeAlphaFlagsKHR 0x8
+pattern VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = CompositeAlphaFlagsKHR 0x8
 
 
--- ** VkPresentModeKHR
+-- ** PresentModeKHR
 
-newtype VkPresentModeKHR = VkPresentModeKHR Int32
+newtype PresentModeKHR = PresentModeKHR Int32
   deriving (Eq, Storable)
 
-instance Show VkPresentModeKHR where
+instance Show PresentModeKHR where
   showsPrec _ VK_PRESENT_MODE_IMMEDIATE_KHR = showString "VK_PRESENT_MODE_IMMEDIATE_KHR"
   showsPrec _ VK_PRESENT_MODE_MAILBOX_KHR = showString "VK_PRESENT_MODE_MAILBOX_KHR"
   showsPrec _ VK_PRESENT_MODE_FIFO_KHR = showString "VK_PRESENT_MODE_FIFO_KHR"
   showsPrec _ VK_PRESENT_MODE_FIFO_RELAXED_KHR = showString "VK_PRESENT_MODE_FIFO_RELAXED_KHR"
-  showsPrec p (VkPresentModeKHR x) = showParen (p >= 11) (showString "VkPresentModeKHR " . showsPrec 11 x)
+  showsPrec p (PresentModeKHR x) = showParen (p >= 11) (showString "PresentModeKHR " . showsPrec 11 x)
 
-instance Read VkPresentModeKHR where
+instance Read PresentModeKHR where
   readPrec = parens ( choose [ ("VK_PRESENT_MODE_IMMEDIATE_KHR", pure VK_PRESENT_MODE_IMMEDIATE_KHR)
                              , ("VK_PRESENT_MODE_MAILBOX_KHR", pure VK_PRESENT_MODE_MAILBOX_KHR)
                              , ("VK_PRESENT_MODE_FIFO_KHR", pure VK_PRESENT_MODE_FIFO_KHR)
                              , ("VK_PRESENT_MODE_FIFO_RELAXED_KHR", pure VK_PRESENT_MODE_FIFO_RELAXED_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPresentModeKHR")
+                        expectP (Ident "PresentModeKHR")
                         v <- step readPrec
-                        pure (VkPresentModeKHR v)
+                        pure (PresentModeKHR v)
                         )
                     )
 
 
-pattern VK_PRESENT_MODE_IMMEDIATE_KHR = VkPresentModeKHR 0
+pattern VK_PRESENT_MODE_IMMEDIATE_KHR = PresentModeKHR 0
 
-pattern VK_PRESENT_MODE_MAILBOX_KHR = VkPresentModeKHR 1
+pattern VK_PRESENT_MODE_MAILBOX_KHR = PresentModeKHR 1
 
-pattern VK_PRESENT_MODE_FIFO_KHR = VkPresentModeKHR 2
+pattern VK_PRESENT_MODE_FIFO_KHR = PresentModeKHR 2
 
-pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = VkPresentModeKHR 3
+pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = PresentModeKHR 3
 
 newtype SurfaceKHR = SurfaceKHR Word64
   deriving (Eq, Storable)
 
 -- ** vkGetPhysicalDeviceSurfaceSupportKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceSurfaceSupportKHR ::
-  PhysicalDevice ->
-  Word32 -> SurfaceKHR -> Ptr VkBool32 -> IO VkResult
+  PhysicalDevice -> Word32 -> SurfaceKHR -> Ptr VkBool32 -> IO Result
 
 
 data SurfaceFormatKHR =
-  SurfaceFormatKHR{ format :: VkFormat 
-                  , colorSpace :: VkColorSpaceKHR 
+  SurfaceFormatKHR{ format :: Format 
+                  , colorSpace :: ColorSpaceKHR 
                   }
   deriving (Eq)
 
@@ -152,39 +151,39 @@ instance Storable SurfaceFormatKHR where
 foreign import ccall "vkDestroySurfaceKHR" vkDestroySurfaceKHR ::
   Instance -> SurfaceKHR -> Ptr AllocationCallbacks -> IO ()
 
--- ** VkColorSpaceKHR
+-- ** ColorSpaceKHR
 
-newtype VkColorSpaceKHR = VkColorSpaceKHR Int32
+newtype ColorSpaceKHR = ColorSpaceKHR Int32
   deriving (Eq, Storable)
 
-instance Show VkColorSpaceKHR where
+instance Show ColorSpaceKHR where
   showsPrec _ VK_COLORSPACE_SRGB_NONLINEAR_KHR = showString "VK_COLORSPACE_SRGB_NONLINEAR_KHR"
-  showsPrec p (VkColorSpaceKHR x) = showParen (p >= 11) (showString "VkColorSpaceKHR " . showsPrec 11 x)
+  showsPrec p (ColorSpaceKHR x) = showParen (p >= 11) (showString "ColorSpaceKHR " . showsPrec 11 x)
 
-instance Read VkColorSpaceKHR where
+instance Read ColorSpaceKHR where
   readPrec = parens ( choose [ ("VK_COLORSPACE_SRGB_NONLINEAR_KHR", pure VK_COLORSPACE_SRGB_NONLINEAR_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkColorSpaceKHR")
+                        expectP (Ident "ColorSpaceKHR")
                         v <- step readPrec
-                        pure (VkColorSpaceKHR v)
+                        pure (ColorSpaceKHR v)
                         )
                     )
 
 
-pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = VkColorSpaceKHR 0
+pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = ColorSpaceKHR 0
 
 -- ** vkGetPhysicalDeviceSurfacePresentModesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDeviceSurfacePresentModesKHR ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr Word32 -> Ptr VkPresentModeKHR -> IO VkResult
+  SurfaceKHR -> Ptr Word32 -> Ptr PresentModeKHR -> IO Result
 
 -- ** VkSurfaceTransformFlagsKHR
 
-newtype VkSurfaceTransformFlagsKHR = VkSurfaceTransformFlagsKHR VkFlags
+newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkSurfaceTransformFlagsKHR where
+instance Show SurfaceTransformFlagsKHR where
   showsPrec _ VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = showString "VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR"
@@ -195,9 +194,9 @@ instance Show VkSurfaceTransformFlagsKHR where
   showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = showString "VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR"
   
-  showsPrec p (VkSurfaceTransformFlagsKHR x) = showParen (p >= 11) (showString "VkSurfaceTransformFlagsKHR " . showsPrec 11 x)
+  showsPrec p (SurfaceTransformFlagsKHR x) = showParen (p >= 11) (showString "SurfaceTransformFlagsKHR " . showsPrec 11 x)
 
-instance Read VkSurfaceTransformFlagsKHR where
+instance Read SurfaceTransformFlagsKHR where
   readPrec = parens ( choose [ ("VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR", pure VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
                              , ("VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR)
                              , ("VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR)
@@ -209,30 +208,30 @@ instance Read VkSurfaceTransformFlagsKHR where
                              , ("VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR", pure VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSurfaceTransformFlagsKHR")
+                        expectP (Ident "SurfaceTransformFlagsKHR")
                         v <- step readPrec
-                        pure (VkSurfaceTransformFlagsKHR v)
+                        pure (SurfaceTransformFlagsKHR v)
                         )
                     )
 
 
-pattern VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = VkSurfaceTransformFlagsKHR 0x1
+pattern VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = SurfaceTransformFlagsKHR 0x1
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagsKHR 0x2
+pattern VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = SurfaceTransformFlagsKHR 0x2
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagsKHR 0x4
+pattern VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = SurfaceTransformFlagsKHR 0x4
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagsKHR 0x8
+pattern VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = SurfaceTransformFlagsKHR 0x8
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = VkSurfaceTransformFlagsKHR 0x10
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = SurfaceTransformFlagsKHR 0x10
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagsKHR 0x20
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = SurfaceTransformFlagsKHR 0x20
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagsKHR 0x40
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = SurfaceTransformFlagsKHR 0x40
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagsKHR 0x80
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = SurfaceTransformFlagsKHR 0x80
 
-pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = VkSurfaceTransformFlagsKHR 0x100
+pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = SurfaceTransformFlagsKHR 0x100
 
 
 
@@ -243,10 +242,10 @@ data SurfaceCapabilitiesKHR =
                         , minImageExtent :: Extent2D 
                         , maxImageExtent :: Extent2D 
                         , maxImageArrayLayers :: Word32 
-                        , supportedTransforms :: VkSurfaceTransformFlagsKHR 
-                        , currentTransform :: VkSurfaceTransformFlagsKHR 
-                        , supportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
-                        , supportedUsageFlags :: VkImageUsageFlags 
+                        , supportedTransforms :: SurfaceTransformFlagsKHR 
+                        , currentTransform :: SurfaceTransformFlagsKHR 
+                        , supportedCompositeAlpha :: CompositeAlphaFlagsKHR 
+                        , supportedUsageFlags :: ImageUsageFlags 
                         }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -60,18 +60,18 @@ newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CompositeAlphaFlagsKHR where
-  showsPrec _ VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = showString "VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR"
-  showsPrec _ VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR"
-  showsPrec _ VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR"
-  showsPrec _ VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = showString "VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR"
+  showsPrec _ CompositeAlphaOpaqueBitKhr = showString "CompositeAlphaOpaqueBitKhr"
+  showsPrec _ CompositeAlphaPreMultipliedBitKhr = showString "CompositeAlphaPreMultipliedBitKhr"
+  showsPrec _ CompositeAlphaPostMultipliedBitKhr = showString "CompositeAlphaPostMultipliedBitKhr"
+  showsPrec _ CompositeAlphaInheritBitKhr = showString "CompositeAlphaInheritBitKhr"
   
   showsPrec p (CompositeAlphaFlagsKHR x) = showParen (p >= 11) (showString "CompositeAlphaFlagsKHR " . showsPrec 11 x)
 
 instance Read CompositeAlphaFlagsKHR where
-  readPrec = parens ( choose [ ("VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR", pure VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
-                             , ("VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
-                             , ("VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR)
-                             , ("VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR", pure VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR)
+  readPrec = parens ( choose [ ("CompositeAlphaOpaqueBitKhr", pure CompositeAlphaOpaqueBitKhr)
+                             , ("CompositeAlphaPreMultipliedBitKhr", pure CompositeAlphaPreMultipliedBitKhr)
+                             , ("CompositeAlphaPostMultipliedBitKhr", pure CompositeAlphaPostMultipliedBitKhr)
+                             , ("CompositeAlphaInheritBitKhr", pure CompositeAlphaInheritBitKhr)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CompositeAlphaFlagsKHR")
@@ -81,13 +81,13 @@ instance Read CompositeAlphaFlagsKHR where
                     )
 
 
-pattern VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = CompositeAlphaFlagsKHR 0x1
+pattern CompositeAlphaOpaqueBitKhr = CompositeAlphaFlagsKHR 0x1
 
-pattern VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = CompositeAlphaFlagsKHR 0x2
+pattern CompositeAlphaPreMultipliedBitKhr = CompositeAlphaFlagsKHR 0x2
 
-pattern VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = CompositeAlphaFlagsKHR 0x4
+pattern CompositeAlphaPostMultipliedBitKhr = CompositeAlphaFlagsKHR 0x4
 
-pattern VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = CompositeAlphaFlagsKHR 0x8
+pattern CompositeAlphaInheritBitKhr = CompositeAlphaFlagsKHR 0x8
 
 
 -- ** PresentModeKHR
@@ -184,28 +184,28 @@ newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SurfaceTransformFlagsKHR where
-  showsPrec _ VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = showString "VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR"
-  showsPrec _ VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = showString "VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR"
+  showsPrec _ SurfaceTransformIdentityBitKhr = showString "SurfaceTransformIdentityBitKhr"
+  showsPrec _ SurfaceTransformRotate90BitKhr = showString "SurfaceTransformRotate90BitKhr"
+  showsPrec _ SurfaceTransformRotate180BitKhr = showString "SurfaceTransformRotate180BitKhr"
+  showsPrec _ SurfaceTransformRotate270BitKhr = showString "SurfaceTransformRotate270BitKhr"
+  showsPrec _ SurfaceTransformHorizontalMirrorBitKhr = showString "SurfaceTransformHorizontalMirrorBitKhr"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate90BitKhr = showString "SurfaceTransformHorizontalMirrorRotate90BitKhr"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate180BitKhr = showString "SurfaceTransformHorizontalMirrorRotate180BitKhr"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate270BitKhr = showString "SurfaceTransformHorizontalMirrorRotate270BitKhr"
+  showsPrec _ SurfaceTransformInheritBitKhr = showString "SurfaceTransformInheritBitKhr"
   
   showsPrec p (SurfaceTransformFlagsKHR x) = showParen (p >= 11) (showString "SurfaceTransformFlagsKHR " . showsPrec 11 x)
 
 instance Read SurfaceTransformFlagsKHR where
-  readPrec = parens ( choose [ ("VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR", pure VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR", pure VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR", pure VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR", pure VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR", pure VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR)
-                             , ("VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR", pure VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR)
+  readPrec = parens ( choose [ ("SurfaceTransformIdentityBitKhr", pure SurfaceTransformIdentityBitKhr)
+                             , ("SurfaceTransformRotate90BitKhr", pure SurfaceTransformRotate90BitKhr)
+                             , ("SurfaceTransformRotate180BitKhr", pure SurfaceTransformRotate180BitKhr)
+                             , ("SurfaceTransformRotate270BitKhr", pure SurfaceTransformRotate270BitKhr)
+                             , ("SurfaceTransformHorizontalMirrorBitKhr", pure SurfaceTransformHorizontalMirrorBitKhr)
+                             , ("SurfaceTransformHorizontalMirrorRotate90BitKhr", pure SurfaceTransformHorizontalMirrorRotate90BitKhr)
+                             , ("SurfaceTransformHorizontalMirrorRotate180BitKhr", pure SurfaceTransformHorizontalMirrorRotate180BitKhr)
+                             , ("SurfaceTransformHorizontalMirrorRotate270BitKhr", pure SurfaceTransformHorizontalMirrorRotate270BitKhr)
+                             , ("SurfaceTransformInheritBitKhr", pure SurfaceTransformInheritBitKhr)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SurfaceTransformFlagsKHR")
@@ -215,23 +215,23 @@ instance Read SurfaceTransformFlagsKHR where
                     )
 
 
-pattern VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = SurfaceTransformFlagsKHR 0x1
+pattern SurfaceTransformIdentityBitKhr = SurfaceTransformFlagsKHR 0x1
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = SurfaceTransformFlagsKHR 0x2
+pattern SurfaceTransformRotate90BitKhr = SurfaceTransformFlagsKHR 0x2
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = SurfaceTransformFlagsKHR 0x4
+pattern SurfaceTransformRotate180BitKhr = SurfaceTransformFlagsKHR 0x4
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = SurfaceTransformFlagsKHR 0x8
+pattern SurfaceTransformRotate270BitKhr = SurfaceTransformFlagsKHR 0x8
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = SurfaceTransformFlagsKHR 0x10
+pattern SurfaceTransformHorizontalMirrorBitKhr = SurfaceTransformFlagsKHR 0x10
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = SurfaceTransformFlagsKHR 0x20
+pattern SurfaceTransformHorizontalMirrorRotate90BitKhr = SurfaceTransformFlagsKHR 0x20
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = SurfaceTransformFlagsKHR 0x40
+pattern SurfaceTransformHorizontalMirrorRotate180BitKhr = SurfaceTransformFlagsKHR 0x40
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = SurfaceTransformFlagsKHR 0x80
+pattern SurfaceTransformHorizontalMirrorRotate270BitKhr = SurfaceTransformFlagsKHR 0x80
 
-pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = SurfaceTransformFlagsKHR 0x100
+pattern SurfaceTransformInheritBitKhr = SurfaceTransformFlagsKHR 0x100
 
 
 

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -44,13 +44,13 @@ import Graphics.Vulkan.Core( Bool32(..)
                            , Extent2D(..)
                            )
 
--- ** vkGetPhysicalDeviceSurfaceFormatsKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::
+-- ** getPhysicalDeviceSurfaceFormatsKHR
+foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" getPhysicalDeviceSurfaceFormatsKHR ::
   PhysicalDevice ->
   SurfaceKHR -> Ptr Word32 -> Ptr SurfaceFormatKHR -> IO Result
 
--- ** vkGetPhysicalDeviceSurfaceCapabilitiesKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDeviceSurfaceCapabilitiesKHR ::
+-- ** getPhysicalDeviceSurfaceCapabilitiesKHR
+foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" getPhysicalDeviceSurfaceCapabilitiesKHR ::
   PhysicalDevice ->
   SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO Result
 
@@ -127,8 +127,8 @@ pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = PresentModeKHR 3
 newtype SurfaceKHR = SurfaceKHR Word64
   deriving (Eq, Storable)
 
--- ** vkGetPhysicalDeviceSurfaceSupportKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceSurfaceSupportKHR ::
+-- ** getPhysicalDeviceSurfaceSupportKHR
+foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" getPhysicalDeviceSurfaceSupportKHR ::
   PhysicalDevice -> Word32 -> SurfaceKHR -> Ptr Bool32 -> IO Result
 
 
@@ -147,8 +147,8 @@ instance Storable SurfaceFormatKHR where
                 *> poke (ptr `plusPtr` 4) (colorSpace (poked :: SurfaceFormatKHR))
 
 
--- ** vkDestroySurfaceKHR
-foreign import ccall "vkDestroySurfaceKHR" vkDestroySurfaceKHR ::
+-- ** destroySurfaceKHR
+foreign import ccall "vkDestroySurfaceKHR" destroySurfaceKHR ::
   Instance -> SurfaceKHR -> Ptr AllocationCallbacks -> IO ()
 
 -- ** ColorSpaceKHR
@@ -173,8 +173,8 @@ instance Read ColorSpaceKHR where
 
 pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = ColorSpaceKHR 0
 
--- ** vkGetPhysicalDeviceSurfacePresentModesKHR
-foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDeviceSurfacePresentModesKHR ::
+-- ** getPhysicalDeviceSurfacePresentModesKHR
+foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDeviceSurfacePresentModesKHR ::
   PhysicalDevice ->
   SurfaceKHR -> Ptr Word32 -> Ptr PresentModeKHR -> IO Result
 

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -54,7 +54,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" getPhysicalDevi
   PhysicalDevice ->
   SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO Result
 
--- ** VkCompositeAlphaFlagsKHR
+-- ** CompositeAlphaFlagsKHR
 
 newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -178,7 +178,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDevi
   PhysicalDevice ->
   SurfaceKHR -> Ptr Word32 -> Ptr PresentModeKHR -> IO Result
 
--- ** VkSurfaceTransformFlagsKHR
+-- ** SurfaceTransformFlagsKHR
 
 newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -57,7 +57,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" getPhysicalDevi
 -- ** CompositeAlphaFlagsKHR
 
 newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CompositeAlphaFlagsKHR where
   showsPrec _ CompositeAlphaOpaqueBitKhr = showString "CompositeAlphaOpaqueBitKhr"
@@ -93,7 +93,7 @@ pattern CompositeAlphaInheritBitKhr = CompositeAlphaFlagsKHR 0x8
 -- ** PresentModeKHR
 
 newtype PresentModeKHR = PresentModeKHR Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PresentModeKHR where
   showsPrec _ PresentModeImmediateKhr = showString "PresentModeImmediateKhr"
@@ -125,7 +125,7 @@ pattern PresentModeFifoKhr = PresentModeKHR 2
 pattern PresentModeFifoRelaxedKhr = PresentModeKHR 3
 
 newtype SurfaceKHR = SurfaceKHR Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** getPhysicalDeviceSurfaceSupportKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" getPhysicalDeviceSurfaceSupportKHR ::
@@ -136,7 +136,7 @@ data SurfaceFormatKHR =
   SurfaceFormatKHR{ format :: Format 
                   , colorSpace :: ColorSpaceKHR 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SurfaceFormatKHR where
   sizeOf ~_ = 8
@@ -154,7 +154,7 @@ foreign import ccall "vkDestroySurfaceKHR" destroySurfaceKHR ::
 -- ** ColorSpaceKHR
 
 newtype ColorSpaceKHR = ColorSpaceKHR Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show ColorSpaceKHR where
   showsPrec _ ColorspaceSrgbNonlinearKhr = showString "ColorspaceSrgbNonlinearKhr"
@@ -181,7 +181,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDevi
 -- ** SurfaceTransformFlagsKHR
 
 newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show SurfaceTransformFlagsKHR where
   showsPrec _ SurfaceTransformIdentityBitKhr = showString "SurfaceTransformIdentityBitKhr"
@@ -247,7 +247,7 @@ data SurfaceCapabilitiesKHR =
                         , supportedCompositeAlpha :: CompositeAlphaFlagsKHR 
                         , supportedUsageFlags :: ImageUsageFlags 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SurfaceCapabilitiesKHR where
   sizeOf ~_ = 52

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -37,10 +37,10 @@ import Graphics.Vulkan.Image( ImageUsageFlags(..)
                             )
 import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , VkBool32(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , Format(..)
                            , Result(..)
+                           , Flags(..)
                            , Extent2D(..)
                            )
 
@@ -56,7 +56,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDe
 
 -- ** VkCompositeAlphaFlagsKHR
 
-newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR VkFlags
+newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CompositeAlphaFlagsKHR where
@@ -129,7 +129,7 @@ newtype SurfaceKHR = SurfaceKHR Word64
 
 -- ** vkGetPhysicalDeviceSurfaceSupportKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceSurfaceSupportKHR ::
-  PhysicalDevice -> Word32 -> SurfaceKHR -> Ptr VkBool32 -> IO Result
+  PhysicalDevice -> Word32 -> SurfaceKHR -> Ptr Bool32 -> IO Result
 
 
 data SurfaceFormatKHR =
@@ -180,7 +180,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDe
 
 -- ** VkSurfaceTransformFlagsKHR
 
-newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR VkFlags
+newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SurfaceTransformFlagsKHR where

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -96,17 +96,17 @@ newtype PresentModeKHR = PresentModeKHR Int32
   deriving (Eq, Storable)
 
 instance Show PresentModeKHR where
-  showsPrec _ VK_PRESENT_MODE_IMMEDIATE_KHR = showString "VK_PRESENT_MODE_IMMEDIATE_KHR"
-  showsPrec _ VK_PRESENT_MODE_MAILBOX_KHR = showString "VK_PRESENT_MODE_MAILBOX_KHR"
-  showsPrec _ VK_PRESENT_MODE_FIFO_KHR = showString "VK_PRESENT_MODE_FIFO_KHR"
-  showsPrec _ VK_PRESENT_MODE_FIFO_RELAXED_KHR = showString "VK_PRESENT_MODE_FIFO_RELAXED_KHR"
+  showsPrec _ PresentModeImmediateKhr = showString "PresentModeImmediateKhr"
+  showsPrec _ PresentModeMailboxKhr = showString "PresentModeMailboxKhr"
+  showsPrec _ PresentModeFifoKhr = showString "PresentModeFifoKhr"
+  showsPrec _ PresentModeFifoRelaxedKhr = showString "PresentModeFifoRelaxedKhr"
   showsPrec p (PresentModeKHR x) = showParen (p >= 11) (showString "PresentModeKHR " . showsPrec 11 x)
 
 instance Read PresentModeKHR where
-  readPrec = parens ( choose [ ("VK_PRESENT_MODE_IMMEDIATE_KHR", pure VK_PRESENT_MODE_IMMEDIATE_KHR)
-                             , ("VK_PRESENT_MODE_MAILBOX_KHR", pure VK_PRESENT_MODE_MAILBOX_KHR)
-                             , ("VK_PRESENT_MODE_FIFO_KHR", pure VK_PRESENT_MODE_FIFO_KHR)
-                             , ("VK_PRESENT_MODE_FIFO_RELAXED_KHR", pure VK_PRESENT_MODE_FIFO_RELAXED_KHR)
+  readPrec = parens ( choose [ ("PresentModeImmediateKhr", pure PresentModeImmediateKhr)
+                             , ("PresentModeMailboxKhr", pure PresentModeMailboxKhr)
+                             , ("PresentModeFifoKhr", pure PresentModeFifoKhr)
+                             , ("PresentModeFifoRelaxedKhr", pure PresentModeFifoRelaxedKhr)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PresentModeKHR")
@@ -116,13 +116,13 @@ instance Read PresentModeKHR where
                     )
 
 
-pattern VK_PRESENT_MODE_IMMEDIATE_KHR = PresentModeKHR 0
+pattern PresentModeImmediateKhr = PresentModeKHR 0
 
-pattern VK_PRESENT_MODE_MAILBOX_KHR = PresentModeKHR 1
+pattern PresentModeMailboxKhr = PresentModeKHR 1
 
-pattern VK_PRESENT_MODE_FIFO_KHR = PresentModeKHR 2
+pattern PresentModeFifoKhr = PresentModeKHR 2
 
-pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = PresentModeKHR 3
+pattern PresentModeFifoRelaxedKhr = PresentModeKHR 3
 
 newtype SurfaceKHR = SurfaceKHR Word64
   deriving (Eq, Storable)
@@ -157,11 +157,11 @@ newtype ColorSpaceKHR = ColorSpaceKHR Int32
   deriving (Eq, Storable)
 
 instance Show ColorSpaceKHR where
-  showsPrec _ VK_COLORSPACE_SRGB_NONLINEAR_KHR = showString "VK_COLORSPACE_SRGB_NONLINEAR_KHR"
+  showsPrec _ ColorspaceSrgbNonlinearKhr = showString "ColorspaceSrgbNonlinearKhr"
   showsPrec p (ColorSpaceKHR x) = showParen (p >= 11) (showString "ColorSpaceKHR " . showsPrec 11 x)
 
 instance Read ColorSpaceKHR where
-  readPrec = parens ( choose [ ("VK_COLORSPACE_SRGB_NONLINEAR_KHR", pure VK_COLORSPACE_SRGB_NONLINEAR_KHR)
+  readPrec = parens ( choose [ ("ColorspaceSrgbNonlinearKhr", pure ColorspaceSrgbNonlinearKhr)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ColorSpaceKHR")
@@ -171,7 +171,7 @@ instance Read ColorSpaceKHR where
                     )
 
 
-pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = ColorSpaceKHR 0
+pattern ColorspaceSrgbNonlinearKhr = ColorSpaceKHR 0
 
 -- ** getPhysicalDeviceSurfacePresentModesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDeviceSurfacePresentModesKHR ::

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -24,7 +24,7 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -41,18 +41,18 @@ import Graphics.Vulkan.Core( VkFormat(..)
                            , VkFlags(..)
                            , VkBool32(..)
                            , VkResult(..)
-                           , VkExtent2D(..)
+                           , Extent2D(..)
                            )
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr Word32 -> Ptr VkSurfaceFormatKHR -> IO VkResult
+  SurfaceKHR -> Ptr Word32 -> Ptr SurfaceFormatKHR -> IO VkResult
 
 -- ** vkGetPhysicalDeviceSurfaceCapabilitiesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDeviceSurfaceCapabilitiesKHR ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr VkSurfaceCapabilitiesKHR -> IO VkResult
+  SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO VkResult
 
 -- ** VkCompositeAlphaFlagsKHR
 
@@ -133,24 +133,24 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceS
   Word32 -> SurfaceKHR -> Ptr VkBool32 -> IO VkResult
 
 
-data VkSurfaceFormatKHR =
-  VkSurfaceFormatKHR{ format :: VkFormat 
-                    , colorSpace :: VkColorSpaceKHR 
-                    }
+data SurfaceFormatKHR =
+  SurfaceFormatKHR{ format :: VkFormat 
+                  , colorSpace :: VkColorSpaceKHR 
+                  }
   deriving (Eq)
 
-instance Storable VkSurfaceFormatKHR where
+instance Storable SurfaceFormatKHR where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkSurfaceFormatKHR <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (format (poked :: VkSurfaceFormatKHR))
-                *> poke (ptr `plusPtr` 4) (colorSpace (poked :: VkSurfaceFormatKHR))
+  peek ptr = SurfaceFormatKHR <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (format (poked :: SurfaceFormatKHR))
+                *> poke (ptr `plusPtr` 4) (colorSpace (poked :: SurfaceFormatKHR))
 
 
 -- ** vkDestroySurfaceKHR
 foreign import ccall "vkDestroySurfaceKHR" vkDestroySurfaceKHR ::
-  Instance -> SurfaceKHR -> Ptr VkAllocationCallbacks -> IO ()
+  Instance -> SurfaceKHR -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkColorSpaceKHR
 
@@ -236,42 +236,42 @@ pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = VkSurfaceTransformFlagsKHR 0x100
 
 
 
-data VkSurfaceCapabilitiesKHR =
-  VkSurfaceCapabilitiesKHR{ minImageCount :: Word32 
-                          , maxImageCount :: Word32 
-                          , currentExtent :: VkExtent2D 
-                          , minImageExtent :: VkExtent2D 
-                          , maxImageExtent :: VkExtent2D 
-                          , maxImageArrayLayers :: Word32 
-                          , supportedTransforms :: VkSurfaceTransformFlagsKHR 
-                          , currentTransform :: VkSurfaceTransformFlagsKHR 
-                          , supportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
-                          , supportedUsageFlags :: VkImageUsageFlags 
-                          }
+data SurfaceCapabilitiesKHR =
+  SurfaceCapabilitiesKHR{ minImageCount :: Word32 
+                        , maxImageCount :: Word32 
+                        , currentExtent :: Extent2D 
+                        , minImageExtent :: Extent2D 
+                        , maxImageExtent :: Extent2D 
+                        , maxImageArrayLayers :: Word32 
+                        , supportedTransforms :: VkSurfaceTransformFlagsKHR 
+                        , currentTransform :: VkSurfaceTransformFlagsKHR 
+                        , supportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
+                        , supportedUsageFlags :: VkImageUsageFlags 
+                        }
   deriving (Eq)
 
-instance Storable VkSurfaceCapabilitiesKHR where
+instance Storable SurfaceCapabilitiesKHR where
   sizeOf ~_ = 52
   alignment ~_ = 4
-  peek ptr = VkSurfaceCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 4)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 24)
-                                      <*> peek (ptr `plusPtr` 32)
-                                      <*> peek (ptr `plusPtr` 36)
-                                      <*> peek (ptr `plusPtr` 40)
-                                      <*> peek (ptr `plusPtr` 44)
-                                      <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (minImageCount (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (maxImageCount (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 8) (currentExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 16) (minImageExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 24) (maxImageExtent (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 32) (maxImageArrayLayers (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (supportedTransforms (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 40) (currentTransform (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (supportedCompositeAlpha (poked :: VkSurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 48) (supportedUsageFlags (poked :: VkSurfaceCapabilitiesKHR))
+  peek ptr = SurfaceCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 4)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 24)
+                                    <*> peek (ptr `plusPtr` 32)
+                                    <*> peek (ptr `plusPtr` 36)
+                                    <*> peek (ptr `plusPtr` 40)
+                                    <*> peek (ptr `plusPtr` 44)
+                                    <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (minImageCount (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 4) (maxImageCount (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 8) (currentExtent (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 16) (minImageExtent (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 24) (maxImageExtent (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 32) (maxImageArrayLayers (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 36) (supportedTransforms (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 40) (currentTransform (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 44) (supportedCompositeAlpha (poked :: SurfaceCapabilitiesKHR))
+                *> poke (ptr `plusPtr` 48) (supportedUsageFlags (poked :: SurfaceCapabilitiesKHR))
 
 

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -4,28 +4,19 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Surface where
 
-import Graphics.Vulkan.Device( PhysicalDevice
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkCompositeAlphaFlagsKHR
-                                  , VkSurfaceFormatKHR
-                                  , VkSurfaceTransformFlagBitsKHR
-                                  , SurfaceKHR
-                                  , VkSurfaceCapabilitiesKHR
-                                  , VkPresentModeKHR
-                                  , VkSurfaceTransformFlagsKHR
-                                  , VkColorSpaceKHR
-                                  )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -33,7 +24,7 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -42,15 +33,15 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Image( VkImageUsageFlags
+import Graphics.Vulkan.Image( VkImageUsageFlags(..)
                             )
-import Graphics.Vulkan.DeviceInitialization( Instance
+import Graphics.Vulkan.DeviceInitialization( Instance(..)
                                            )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkExtent2D
-                           , VkFlags
-                           , VkFormat
+import Graphics.Vulkan.Core( VkFormat(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
+                           , VkExtent2D(..)
                            )
 
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
@@ -65,41 +56,38 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDe
 
 -- ** VkCompositeAlphaFlagsKHR
 
-newtype VkCompositeAlphaFlagBitsKHR = VkCompositeAlphaFlagBitsKHR VkFlags
+newtype VkCompositeAlphaFlagsKHR = VkCompositeAlphaFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCompositeAlphaFlagBitsKHR
-type VkCompositeAlphaFlagsKHR = VkCompositeAlphaFlagBitsKHR
-
-instance Show VkCompositeAlphaFlagBitsKHR where
+instance Show VkCompositeAlphaFlagsKHR where
   showsPrec _ VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = showString "VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = showString "VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR"
   showsPrec _ VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = showString "VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR"
   
-  showsPrec p (VkCompositeAlphaFlagBitsKHR x) = showParen (p >= 11) (showString "VkCompositeAlphaFlagBitsKHR " . showsPrec 11 x)
+  showsPrec p (VkCompositeAlphaFlagsKHR x) = showParen (p >= 11) (showString "VkCompositeAlphaFlagsKHR " . showsPrec 11 x)
 
-instance Read VkCompositeAlphaFlagBitsKHR where
+instance Read VkCompositeAlphaFlagsKHR where
   readPrec = parens ( choose [ ("VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR", pure VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR", pure VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR)
                              , ("VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR", pure VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCompositeAlphaFlagBitsKHR")
+                        expectP (Ident "VkCompositeAlphaFlagsKHR")
                         v <- step readPrec
-                        pure (VkCompositeAlphaFlagBitsKHR v)
+                        pure (VkCompositeAlphaFlagsKHR v)
                         )
                     )
 
 
-pattern VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = VkCompositeAlphaFlagBitsKHR 0x1
+pattern VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR = VkCompositeAlphaFlagsKHR 0x1
 
-pattern VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagBitsKHR 0x2
+pattern VK_COMPOSITE_ALPHA_PRE_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagsKHR 0x2
 
-pattern VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagBitsKHR 0x4
+pattern VK_COMPOSITE_ALPHA_POST_MULTIPLIED_BIT_KHR = VkCompositeAlphaFlagsKHR 0x4
 
-pattern VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = VkCompositeAlphaFlagBitsKHR 0x8
+pattern VK_COMPOSITE_ALPHA_INHERIT_BIT_KHR = VkCompositeAlphaFlagsKHR 0x8
 
 
 -- ** VkPresentModeKHR
@@ -193,13 +181,10 @@ foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDe
 
 -- ** VkSurfaceTransformFlagsKHR
 
-newtype VkSurfaceTransformFlagBitsKHR = VkSurfaceTransformFlagBitsKHR VkFlags
+newtype VkSurfaceTransformFlagsKHR = VkSurfaceTransformFlagsKHR VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkSurfaceTransformFlagBitsKHR
-type VkSurfaceTransformFlagsKHR = VkSurfaceTransformFlagBitsKHR
-
-instance Show VkSurfaceTransformFlagBitsKHR where
+instance Show VkSurfaceTransformFlagsKHR where
   showsPrec _ VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = showString "VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = showString "VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR"
@@ -210,9 +195,9 @@ instance Show VkSurfaceTransformFlagBitsKHR where
   showsPrec _ VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = showString "VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR"
   showsPrec _ VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = showString "VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR"
   
-  showsPrec p (VkSurfaceTransformFlagBitsKHR x) = showParen (p >= 11) (showString "VkSurfaceTransformFlagBitsKHR " . showsPrec 11 x)
+  showsPrec p (VkSurfaceTransformFlagsKHR x) = showParen (p >= 11) (showString "VkSurfaceTransformFlagsKHR " . showsPrec 11 x)
 
-instance Read VkSurfaceTransformFlagBitsKHR where
+instance Read VkSurfaceTransformFlagsKHR where
   readPrec = parens ( choose [ ("VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR", pure VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
                              , ("VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR)
                              , ("VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR", pure VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR)
@@ -224,30 +209,30 @@ instance Read VkSurfaceTransformFlagBitsKHR where
                              , ("VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR", pure VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSurfaceTransformFlagBitsKHR")
+                        expectP (Ident "VkSurfaceTransformFlagsKHR")
                         v <- step readPrec
-                        pure (VkSurfaceTransformFlagBitsKHR v)
+                        pure (VkSurfaceTransformFlagsKHR v)
                         )
                     )
 
 
-pattern VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x1
+pattern VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR = VkSurfaceTransformFlagsKHR 0x1
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x2
+pattern VK_SURFACE_TRANSFORM_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagsKHR 0x2
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x4
+pattern VK_SURFACE_TRANSFORM_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagsKHR 0x4
 
-pattern VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x8
+pattern VK_SURFACE_TRANSFORM_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagsKHR 0x8
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x10
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_BIT_KHR = VkSurfaceTransformFlagsKHR 0x10
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x20
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_90_BIT_KHR = VkSurfaceTransformFlagsKHR 0x20
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x40
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_180_BIT_KHR = VkSurfaceTransformFlagsKHR 0x40
 
-pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x80
+pattern VK_SURFACE_TRANSFORM_HORIZONTAL_MIRROR_ROTATE_270_BIT_KHR = VkSurfaceTransformFlagsKHR 0x80
 
-pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = VkSurfaceTransformFlagBitsKHR 0x100
+pattern VK_SURFACE_TRANSFORM_INHERIT_BIT_KHR = VkSurfaceTransformFlagsKHR 0x100
 
 
 
@@ -259,7 +244,7 @@ data VkSurfaceCapabilitiesKHR =
                           , maxImageExtent :: VkExtent2D 
                           , maxImageArrayLayers :: Word32 
                           , supportedTransforms :: VkSurfaceTransformFlagsKHR 
-                          , currentTransform :: VkSurfaceTransformFlagBitsKHR 
+                          , currentTransform :: VkSurfaceTransformFlagsKHR 
                           , supportedCompositeAlpha :: VkCompositeAlphaFlagsKHR 
                           , supportedUsageFlags :: VkImageUsageFlags 
                           }

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -44,233 +44,232 @@ import Graphics.Vulkan.Core( Bool32(..)
                            , Extent2D(..)
                            )
 
--- ** getPhysicalDeviceSurfaceFormatsKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" getPhysicalDeviceSurfaceFormatsKHR ::
+-- ** getPhysicalDeviceSurfaceFormats
+foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" getPhysicalDeviceSurfaceFormats ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr Word32 -> Ptr SurfaceFormatKHR -> IO Result
+  Surface -> Ptr Word32 -> Ptr SurfaceFormat -> IO Result
 
--- ** getPhysicalDeviceSurfaceCapabilitiesKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" getPhysicalDeviceSurfaceCapabilitiesKHR ::
-  PhysicalDevice ->
-  SurfaceKHR -> Ptr SurfaceCapabilitiesKHR -> IO Result
+-- ** getPhysicalDeviceSurfaceCapabilities
+foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" getPhysicalDeviceSurfaceCapabilities ::
+  PhysicalDevice -> Surface -> Ptr SurfaceCapabilities -> IO Result
 
--- ** CompositeAlphaFlagsKHR
+-- ** CompositeAlphaFlags
 
-newtype CompositeAlphaFlagsKHR = CompositeAlphaFlagsKHR Flags
+newtype CompositeAlphaFlags = CompositeAlphaFlags Flags
   deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
-instance Show CompositeAlphaFlagsKHR where
-  showsPrec _ CompositeAlphaOpaqueBitKhr = showString "CompositeAlphaOpaqueBitKhr"
-  showsPrec _ CompositeAlphaPreMultipliedBitKhr = showString "CompositeAlphaPreMultipliedBitKhr"
-  showsPrec _ CompositeAlphaPostMultipliedBitKhr = showString "CompositeAlphaPostMultipliedBitKhr"
-  showsPrec _ CompositeAlphaInheritBitKhr = showString "CompositeAlphaInheritBitKhr"
+instance Show CompositeAlphaFlags where
+  showsPrec _ CompositeAlphaOpaqueBit = showString "CompositeAlphaOpaqueBit"
+  showsPrec _ CompositeAlphaPreMultipliedBit = showString "CompositeAlphaPreMultipliedBit"
+  showsPrec _ CompositeAlphaPostMultipliedBit = showString "CompositeAlphaPostMultipliedBit"
+  showsPrec _ CompositeAlphaInheritBit = showString "CompositeAlphaInheritBit"
   
-  showsPrec p (CompositeAlphaFlagsKHR x) = showParen (p >= 11) (showString "CompositeAlphaFlagsKHR " . showsPrec 11 x)
+  showsPrec p (CompositeAlphaFlags x) = showParen (p >= 11) (showString "CompositeAlphaFlags " . showsPrec 11 x)
 
-instance Read CompositeAlphaFlagsKHR where
-  readPrec = parens ( choose [ ("CompositeAlphaOpaqueBitKhr", pure CompositeAlphaOpaqueBitKhr)
-                             , ("CompositeAlphaPreMultipliedBitKhr", pure CompositeAlphaPreMultipliedBitKhr)
-                             , ("CompositeAlphaPostMultipliedBitKhr", pure CompositeAlphaPostMultipliedBitKhr)
-                             , ("CompositeAlphaInheritBitKhr", pure CompositeAlphaInheritBitKhr)
+instance Read CompositeAlphaFlags where
+  readPrec = parens ( choose [ ("CompositeAlphaOpaqueBit", pure CompositeAlphaOpaqueBit)
+                             , ("CompositeAlphaPreMultipliedBit", pure CompositeAlphaPreMultipliedBit)
+                             , ("CompositeAlphaPostMultipliedBit", pure CompositeAlphaPostMultipliedBit)
+                             , ("CompositeAlphaInheritBit", pure CompositeAlphaInheritBit)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "CompositeAlphaFlagsKHR")
+                        expectP (Ident "CompositeAlphaFlags")
                         v <- step readPrec
-                        pure (CompositeAlphaFlagsKHR v)
+                        pure (CompositeAlphaFlags v)
                         )
                     )
 
 
-pattern CompositeAlphaOpaqueBitKhr = CompositeAlphaFlagsKHR 0x1
+pattern CompositeAlphaOpaqueBit = CompositeAlphaFlags 0x1
 
-pattern CompositeAlphaPreMultipliedBitKhr = CompositeAlphaFlagsKHR 0x2
+pattern CompositeAlphaPreMultipliedBit = CompositeAlphaFlags 0x2
 
-pattern CompositeAlphaPostMultipliedBitKhr = CompositeAlphaFlagsKHR 0x4
+pattern CompositeAlphaPostMultipliedBit = CompositeAlphaFlags 0x4
 
-pattern CompositeAlphaInheritBitKhr = CompositeAlphaFlagsKHR 0x8
+pattern CompositeAlphaInheritBit = CompositeAlphaFlags 0x8
 
 
--- ** PresentModeKHR
+-- ** PresentMode
 
-newtype PresentModeKHR = PresentModeKHR Int32
+newtype PresentMode = PresentMode Int32
   deriving (Eq, Ord, Storable)
 
-instance Show PresentModeKHR where
-  showsPrec _ PresentModeImmediateKhr = showString "PresentModeImmediateKhr"
-  showsPrec _ PresentModeMailboxKhr = showString "PresentModeMailboxKhr"
-  showsPrec _ PresentModeFifoKhr = showString "PresentModeFifoKhr"
-  showsPrec _ PresentModeFifoRelaxedKhr = showString "PresentModeFifoRelaxedKhr"
-  showsPrec p (PresentModeKHR x) = showParen (p >= 11) (showString "PresentModeKHR " . showsPrec 11 x)
+instance Show PresentMode where
+  showsPrec _ PresentModeImmediate = showString "PresentModeImmediate"
+  showsPrec _ PresentModeMailbox = showString "PresentModeMailbox"
+  showsPrec _ PresentModeFifo = showString "PresentModeFifo"
+  showsPrec _ PresentModeFifoRelaxed = showString "PresentModeFifoRelaxed"
+  showsPrec p (PresentMode x) = showParen (p >= 11) (showString "PresentMode " . showsPrec 11 x)
 
-instance Read PresentModeKHR where
-  readPrec = parens ( choose [ ("PresentModeImmediateKhr", pure PresentModeImmediateKhr)
-                             , ("PresentModeMailboxKhr", pure PresentModeMailboxKhr)
-                             , ("PresentModeFifoKhr", pure PresentModeFifoKhr)
-                             , ("PresentModeFifoRelaxedKhr", pure PresentModeFifoRelaxedKhr)
+instance Read PresentMode where
+  readPrec = parens ( choose [ ("PresentModeImmediate", pure PresentModeImmediate)
+                             , ("PresentModeMailbox", pure PresentModeMailbox)
+                             , ("PresentModeFifo", pure PresentModeFifo)
+                             , ("PresentModeFifoRelaxed", pure PresentModeFifoRelaxed)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "PresentModeKHR")
+                        expectP (Ident "PresentMode")
                         v <- step readPrec
-                        pure (PresentModeKHR v)
+                        pure (PresentMode v)
                         )
                     )
 
 
-pattern PresentModeImmediateKhr = PresentModeKHR 0
+pattern PresentModeImmediate = PresentMode 0
 
-pattern PresentModeMailboxKhr = PresentModeKHR 1
+pattern PresentModeMailbox = PresentMode 1
 
-pattern PresentModeFifoKhr = PresentModeKHR 2
+pattern PresentModeFifo = PresentMode 2
 
-pattern PresentModeFifoRelaxedKhr = PresentModeKHR 3
+pattern PresentModeFifoRelaxed = PresentMode 3
 
-newtype SurfaceKHR = SurfaceKHR Word64
+newtype Surface = Surface Word64
   deriving (Eq, Ord, Storable)
 
--- ** getPhysicalDeviceSurfaceSupportKHR
-foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" getPhysicalDeviceSurfaceSupportKHR ::
-  PhysicalDevice -> Word32 -> SurfaceKHR -> Ptr Bool32 -> IO Result
+-- ** getPhysicalDeviceSurfaceSupport
+foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" getPhysicalDeviceSurfaceSupport ::
+  PhysicalDevice -> Word32 -> Surface -> Ptr Bool32 -> IO Result
 
 
-data SurfaceFormatKHR =
-  SurfaceFormatKHR{ format :: Format 
-                  , colorSpace :: ColorSpaceKHR 
-                  }
+data SurfaceFormat =
+  SurfaceFormat{ format :: Format 
+               , colorSpace :: ColorSpace 
+               }
   deriving (Eq, Ord)
 
-instance Storable SurfaceFormatKHR where
+instance Storable SurfaceFormat where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = SurfaceFormatKHR <$> peek (ptr `plusPtr` 0)
-                              <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (format (poked :: SurfaceFormatKHR))
-                *> poke (ptr `plusPtr` 4) (colorSpace (poked :: SurfaceFormatKHR))
+  peek ptr = SurfaceFormat <$> peek (ptr `plusPtr` 0)
+                           <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (format (poked :: SurfaceFormat))
+                *> poke (ptr `plusPtr` 4) (colorSpace (poked :: SurfaceFormat))
 
 
--- ** destroySurfaceKHR
-foreign import ccall "vkDestroySurfaceKHR" destroySurfaceKHR ::
-  Instance -> SurfaceKHR -> Ptr AllocationCallbacks -> IO ()
+-- ** destroySurface
+foreign import ccall "vkDestroySurfaceKHR" destroySurface ::
+  Instance -> Surface -> Ptr AllocationCallbacks -> IO ()
 
--- ** ColorSpaceKHR
+-- ** ColorSpace
 
-newtype ColorSpaceKHR = ColorSpaceKHR Int32
+newtype ColorSpace = ColorSpace Int32
   deriving (Eq, Ord, Storable)
 
-instance Show ColorSpaceKHR where
-  showsPrec _ ColorspaceSrgbNonlinearKhr = showString "ColorspaceSrgbNonlinearKhr"
-  showsPrec p (ColorSpaceKHR x) = showParen (p >= 11) (showString "ColorSpaceKHR " . showsPrec 11 x)
+instance Show ColorSpace where
+  showsPrec _ ColorspaceSrgbNonlinear = showString "ColorspaceSrgbNonlinear"
+  showsPrec p (ColorSpace x) = showParen (p >= 11) (showString "ColorSpace " . showsPrec 11 x)
 
-instance Read ColorSpaceKHR where
-  readPrec = parens ( choose [ ("ColorspaceSrgbNonlinearKhr", pure ColorspaceSrgbNonlinearKhr)
+instance Read ColorSpace where
+  readPrec = parens ( choose [ ("ColorspaceSrgbNonlinear", pure ColorspaceSrgbNonlinear)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "ColorSpaceKHR")
+                        expectP (Ident "ColorSpace")
                         v <- step readPrec
-                        pure (ColorSpaceKHR v)
+                        pure (ColorSpace v)
                         )
                     )
 
 
-pattern ColorspaceSrgbNonlinearKhr = ColorSpaceKHR 0
+pattern ColorspaceSrgbNonlinear = ColorSpace 0
 
--- ** getPhysicalDeviceSurfacePresentModesKHR
-foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDeviceSurfacePresentModesKHR ::
+-- ** getPhysicalDeviceSurfacePresentModes
+foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" getPhysicalDeviceSurfacePresentModes ::
   PhysicalDevice ->
-  SurfaceKHR -> Ptr Word32 -> Ptr PresentModeKHR -> IO Result
+  Surface -> Ptr Word32 -> Ptr PresentMode -> IO Result
 
--- ** SurfaceTransformFlagsKHR
+-- ** SurfaceTransformFlags
 
-newtype SurfaceTransformFlagsKHR = SurfaceTransformFlagsKHR Flags
+newtype SurfaceTransformFlags = SurfaceTransformFlags Flags
   deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
-instance Show SurfaceTransformFlagsKHR where
-  showsPrec _ SurfaceTransformIdentityBitKhr = showString "SurfaceTransformIdentityBitKhr"
-  showsPrec _ SurfaceTransformRotate90BitKhr = showString "SurfaceTransformRotate90BitKhr"
-  showsPrec _ SurfaceTransformRotate180BitKhr = showString "SurfaceTransformRotate180BitKhr"
-  showsPrec _ SurfaceTransformRotate270BitKhr = showString "SurfaceTransformRotate270BitKhr"
-  showsPrec _ SurfaceTransformHorizontalMirrorBitKhr = showString "SurfaceTransformHorizontalMirrorBitKhr"
-  showsPrec _ SurfaceTransformHorizontalMirrorRotate90BitKhr = showString "SurfaceTransformHorizontalMirrorRotate90BitKhr"
-  showsPrec _ SurfaceTransformHorizontalMirrorRotate180BitKhr = showString "SurfaceTransformHorizontalMirrorRotate180BitKhr"
-  showsPrec _ SurfaceTransformHorizontalMirrorRotate270BitKhr = showString "SurfaceTransformHorizontalMirrorRotate270BitKhr"
-  showsPrec _ SurfaceTransformInheritBitKhr = showString "SurfaceTransformInheritBitKhr"
+instance Show SurfaceTransformFlags where
+  showsPrec _ SurfaceTransformIdentityBit = showString "SurfaceTransformIdentityBit"
+  showsPrec _ SurfaceTransformRotate90Bit = showString "SurfaceTransformRotate90Bit"
+  showsPrec _ SurfaceTransformRotate180Bit = showString "SurfaceTransformRotate180Bit"
+  showsPrec _ SurfaceTransformRotate270Bit = showString "SurfaceTransformRotate270Bit"
+  showsPrec _ SurfaceTransformHorizontalMirrorBit = showString "SurfaceTransformHorizontalMirrorBit"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate90Bit = showString "SurfaceTransformHorizontalMirrorRotate90Bit"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate180Bit = showString "SurfaceTransformHorizontalMirrorRotate180Bit"
+  showsPrec _ SurfaceTransformHorizontalMirrorRotate270Bit = showString "SurfaceTransformHorizontalMirrorRotate270Bit"
+  showsPrec _ SurfaceTransformInheritBit = showString "SurfaceTransformInheritBit"
   
-  showsPrec p (SurfaceTransformFlagsKHR x) = showParen (p >= 11) (showString "SurfaceTransformFlagsKHR " . showsPrec 11 x)
+  showsPrec p (SurfaceTransformFlags x) = showParen (p >= 11) (showString "SurfaceTransformFlags " . showsPrec 11 x)
 
-instance Read SurfaceTransformFlagsKHR where
-  readPrec = parens ( choose [ ("SurfaceTransformIdentityBitKhr", pure SurfaceTransformIdentityBitKhr)
-                             , ("SurfaceTransformRotate90BitKhr", pure SurfaceTransformRotate90BitKhr)
-                             , ("SurfaceTransformRotate180BitKhr", pure SurfaceTransformRotate180BitKhr)
-                             , ("SurfaceTransformRotate270BitKhr", pure SurfaceTransformRotate270BitKhr)
-                             , ("SurfaceTransformHorizontalMirrorBitKhr", pure SurfaceTransformHorizontalMirrorBitKhr)
-                             , ("SurfaceTransformHorizontalMirrorRotate90BitKhr", pure SurfaceTransformHorizontalMirrorRotate90BitKhr)
-                             , ("SurfaceTransformHorizontalMirrorRotate180BitKhr", pure SurfaceTransformHorizontalMirrorRotate180BitKhr)
-                             , ("SurfaceTransformHorizontalMirrorRotate270BitKhr", pure SurfaceTransformHorizontalMirrorRotate270BitKhr)
-                             , ("SurfaceTransformInheritBitKhr", pure SurfaceTransformInheritBitKhr)
+instance Read SurfaceTransformFlags where
+  readPrec = parens ( choose [ ("SurfaceTransformIdentityBit", pure SurfaceTransformIdentityBit)
+                             , ("SurfaceTransformRotate90Bit", pure SurfaceTransformRotate90Bit)
+                             , ("SurfaceTransformRotate180Bit", pure SurfaceTransformRotate180Bit)
+                             , ("SurfaceTransformRotate270Bit", pure SurfaceTransformRotate270Bit)
+                             , ("SurfaceTransformHorizontalMirrorBit", pure SurfaceTransformHorizontalMirrorBit)
+                             , ("SurfaceTransformHorizontalMirrorRotate90Bit", pure SurfaceTransformHorizontalMirrorRotate90Bit)
+                             , ("SurfaceTransformHorizontalMirrorRotate180Bit", pure SurfaceTransformHorizontalMirrorRotate180Bit)
+                             , ("SurfaceTransformHorizontalMirrorRotate270Bit", pure SurfaceTransformHorizontalMirrorRotate270Bit)
+                             , ("SurfaceTransformInheritBit", pure SurfaceTransformInheritBit)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "SurfaceTransformFlagsKHR")
+                        expectP (Ident "SurfaceTransformFlags")
                         v <- step readPrec
-                        pure (SurfaceTransformFlagsKHR v)
+                        pure (SurfaceTransformFlags v)
                         )
                     )
 
 
-pattern SurfaceTransformIdentityBitKhr = SurfaceTransformFlagsKHR 0x1
+pattern SurfaceTransformIdentityBit = SurfaceTransformFlags 0x1
 
-pattern SurfaceTransformRotate90BitKhr = SurfaceTransformFlagsKHR 0x2
+pattern SurfaceTransformRotate90Bit = SurfaceTransformFlags 0x2
 
-pattern SurfaceTransformRotate180BitKhr = SurfaceTransformFlagsKHR 0x4
+pattern SurfaceTransformRotate180Bit = SurfaceTransformFlags 0x4
 
-pattern SurfaceTransformRotate270BitKhr = SurfaceTransformFlagsKHR 0x8
+pattern SurfaceTransformRotate270Bit = SurfaceTransformFlags 0x8
 
-pattern SurfaceTransformHorizontalMirrorBitKhr = SurfaceTransformFlagsKHR 0x10
+pattern SurfaceTransformHorizontalMirrorBit = SurfaceTransformFlags 0x10
 
-pattern SurfaceTransformHorizontalMirrorRotate90BitKhr = SurfaceTransformFlagsKHR 0x20
+pattern SurfaceTransformHorizontalMirrorRotate90Bit = SurfaceTransformFlags 0x20
 
-pattern SurfaceTransformHorizontalMirrorRotate180BitKhr = SurfaceTransformFlagsKHR 0x40
+pattern SurfaceTransformHorizontalMirrorRotate180Bit = SurfaceTransformFlags 0x40
 
-pattern SurfaceTransformHorizontalMirrorRotate270BitKhr = SurfaceTransformFlagsKHR 0x80
+pattern SurfaceTransformHorizontalMirrorRotate270Bit = SurfaceTransformFlags 0x80
 
-pattern SurfaceTransformInheritBitKhr = SurfaceTransformFlagsKHR 0x100
+pattern SurfaceTransformInheritBit = SurfaceTransformFlags 0x100
 
 
 
-data SurfaceCapabilitiesKHR =
-  SurfaceCapabilitiesKHR{ minImageCount :: Word32 
-                        , maxImageCount :: Word32 
-                        , currentExtent :: Extent2D 
-                        , minImageExtent :: Extent2D 
-                        , maxImageExtent :: Extent2D 
-                        , maxImageArrayLayers :: Word32 
-                        , supportedTransforms :: SurfaceTransformFlagsKHR 
-                        , currentTransform :: SurfaceTransformFlagsKHR 
-                        , supportedCompositeAlpha :: CompositeAlphaFlagsKHR 
-                        , supportedUsageFlags :: ImageUsageFlags 
-                        }
+data SurfaceCapabilities =
+  SurfaceCapabilities{ minImageCount :: Word32 
+                     , maxImageCount :: Word32 
+                     , currentExtent :: Extent2D 
+                     , minImageExtent :: Extent2D 
+                     , maxImageExtent :: Extent2D 
+                     , maxImageArrayLayers :: Word32 
+                     , supportedTransforms :: SurfaceTransformFlags 
+                     , currentTransform :: SurfaceTransformFlags 
+                     , supportedCompositeAlpha :: CompositeAlphaFlags 
+                     , supportedUsageFlags :: ImageUsageFlags 
+                     }
   deriving (Eq, Ord)
 
-instance Storable SurfaceCapabilitiesKHR where
+instance Storable SurfaceCapabilities where
   sizeOf ~_ = 52
   alignment ~_ = 4
-  peek ptr = SurfaceCapabilitiesKHR <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 4)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 36)
-                                    <*> peek (ptr `plusPtr` 40)
-                                    <*> peek (ptr `plusPtr` 44)
-                                    <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (minImageCount (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 4) (maxImageCount (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 8) (currentExtent (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 16) (minImageExtent (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 24) (maxImageExtent (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 32) (maxImageArrayLayers (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 36) (supportedTransforms (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 40) (currentTransform (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 44) (supportedCompositeAlpha (poked :: SurfaceCapabilitiesKHR))
-                *> poke (ptr `plusPtr` 48) (supportedUsageFlags (poked :: SurfaceCapabilitiesKHR))
+  peek ptr = SurfaceCapabilities <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 4)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 36)
+                                 <*> peek (ptr `plusPtr` 40)
+                                 <*> peek (ptr `plusPtr` 44)
+                                 <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (minImageCount (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 4) (maxImageCount (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 8) (currentExtent (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 16) (minImageExtent (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 24) (maxImageExtent (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 32) (maxImageArrayLayers (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 36) (supportedTransforms (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 40) (currentTransform (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 44) (supportedCompositeAlpha (poked :: SurfaceCapabilities))
+                *> poke (ptr `plusPtr` 48) (supportedUsageFlags (poked :: SurfaceCapabilities))
 
 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -3,53 +3,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Swapchain where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
-                                  , VkSurfaceTransformFlagBitsKHR(..)
-                                  , VkPresentModeKHR(..)
-                                  , VkCompositeAlphaFlagBitsKHR(..)
-                                  , SurfaceKHR(..)
-                                  )
-import Graphics.Vulkan.Queue( Queue(..)
-                            )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence(..)
-                            )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , Image(..)
-                            , VkImageUsageFlagBits(..)
-                            )
-import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
-                                     )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           , VkSharingMode(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkSwapchainCreateInfoKHR =

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Swapchain where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -15,13 +15,13 @@ import Graphics.Vulkan.KHR.Surface( VkColorSpaceKHR(..)
                                   , VkSurfaceTransformFlagBitsKHR(..)
                                   , VkPresentModeKHR(..)
                                   , VkCompositeAlphaFlagBitsKHR(..)
-                                  , VkSurfaceKHR(..)
+                                  , SurfaceKHR(..)
                                   )
-import Graphics.Vulkan.Queue( VkQueue(..)
+import Graphics.Vulkan.Queue( Queue(..)
                             )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( VkFence(..)
+import Graphics.Vulkan.Fence( Fence(..)
                             )
 import Data.Void( Void
                 )
@@ -35,10 +35,10 @@ import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
                              , PFN_vkInternalFreeNotification
                              )
 import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , VkImage(..)
+                            , Image(..)
                             , VkImageUsageFlagBits(..)
                             )
-import Graphics.Vulkan.QueueSemaphore( VkSemaphore(..)
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkBool32(..)
@@ -53,24 +53,24 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkSwapchainCreateInfoKHR =
-  VkSwapchainCreateInfoKHR{ vkSType :: VkStructureType 
-                          , vkPNext :: Ptr Void 
-                          , vkFlags :: VkSwapchainCreateFlagsKHR 
-                          , vkSurface :: VkSurfaceKHR 
-                          , vkMinImageCount :: Word32 
-                          , vkImageFormat :: VkFormat 
-                          , vkImageColorSpace :: VkColorSpaceKHR 
-                          , vkImageExtent :: VkExtent2D 
-                          , vkImageArrayLayers :: Word32 
-                          , vkImageUsage :: VkImageUsageFlags 
-                          , vkImageSharingMode :: VkSharingMode 
-                          , vkQueueFamilyIndexCount :: Word32 
-                          , vkPQueueFamilyIndices :: Ptr Word32 
-                          , vkPreTransform :: VkSurfaceTransformFlagBitsKHR 
-                          , vkCompositeAlpha :: VkCompositeAlphaFlagBitsKHR 
-                          , vkPresentMode :: VkPresentModeKHR 
-                          , vkClipped :: VkBool32 
-                          , vkOldSwapchain :: VkSwapchainKHR 
+  VkSwapchainCreateInfoKHR{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkSwapchainCreateFlagsKHR 
+                          , surface :: SurfaceKHR 
+                          , minImageCount :: Word32 
+                          , imageFormat :: VkFormat 
+                          , imageColorSpace :: VkColorSpaceKHR 
+                          , imageExtent :: VkExtent2D 
+                          , imageArrayLayers :: Word32 
+                          , imageUsage :: VkImageUsageFlags 
+                          , imageSharingMode :: VkSharingMode 
+                          , queueFamilyIndexCount :: Word32 
+                          , pQueueFamilyIndices :: Ptr Word32 
+                          , preTransform :: VkSurfaceTransformFlagBitsKHR 
+                          , compositeAlpha :: VkCompositeAlphaFlagBitsKHR 
+                          , presentMode :: VkPresentModeKHR 
+                          , clipped :: VkBool32 
+                          , oldSwapchain :: SwapchainKHR 
                           }
   deriving (Eq)
 
@@ -95,38 +95,37 @@ instance Storable VkSwapchainCreateInfoKHR where
                                       <*> peek (ptr `plusPtr` 88)
                                       <*> peek (ptr `plusPtr` 92)
                                       <*> peek (ptr `plusPtr` 96)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (vkSurface (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (vkMinImageCount (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (vkImageFormat (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (vkImageColorSpace (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (vkImageExtent (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (vkImageArrayLayers (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 56) (vkImageUsage (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 60) (vkImageSharingMode (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 64) (vkQueueFamilyIndexCount (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 72) (vkPQueueFamilyIndices (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 80) (vkPreTransform (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 84) (vkCompositeAlpha (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 88) (vkPresentMode (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 92) (vkClipped (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 96) (vkOldSwapchain (poked :: VkSwapchainCreateInfoKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (surface (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (minImageCount (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (imageFormat (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (imageColorSpace (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (imageArrayLayers (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 56) (imageUsage (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 60) (imageSharingMode (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 80) (preTransform (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 84) (compositeAlpha (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 88) (presentMode (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 92) (clipped (poked :: VkSwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: VkSwapchainCreateInfoKHR))
 
 
 -- ** vkGetSwapchainImagesKHR
 foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
-  VkDevice ->
-  VkSwapchainKHR -> Ptr Word32 -> Ptr VkImage -> IO VkResult
+  Device -> SwapchainKHR -> Ptr Word32 -> Ptr Image -> IO VkResult
 
 -- ** vkDestroySwapchainKHR
 foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
-  VkDevice -> VkSwapchainKHR -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> SwapchainKHR -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** vkQueuePresentKHR
 foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
-  VkQueue -> Ptr VkPresentInfoKHR -> IO VkResult
+  Queue -> Ptr VkPresentInfoKHR -> IO VkResult
 
 -- ** VkSwapchainCreateFlagsKHR
 -- | Opaque flag
@@ -135,26 +134,26 @@ newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
 
 -- ** vkCreateSwapchainKHR
 foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
-  VkDevice ->
+  Device ->
   Ptr VkSwapchainCreateInfoKHR ->
-    Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
 
 -- ** vkAcquireNextImageKHR
 foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
-  VkDevice ->
-  VkSwapchainKHR ->
-    Word64 -> VkSemaphore -> VkFence -> Ptr Word32 -> IO VkResult
+  Device ->
+  SwapchainKHR ->
+    Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO VkResult
 
 
 data VkPresentInfoKHR =
-  VkPresentInfoKHR{ vkSType :: VkStructureType 
-                  , vkPNext :: Ptr Void 
-                  , vkWaitSemaphoreCount :: Word32 
-                  , vkPWaitSemaphores :: Ptr VkSemaphore 
-                  , vkSwapchainCount :: Word32 
-                  , vkPSwapchains :: Ptr VkSwapchainKHR 
-                  , vkPImageIndices :: Ptr Word32 
-                  , vkPResults :: Ptr VkResult 
+  VkPresentInfoKHR{ sType :: VkStructureType 
+                  , pNext :: Ptr Void 
+                  , waitSemaphoreCount :: Word32 
+                  , pWaitSemaphores :: Ptr Semaphore 
+                  , swapchainCount :: Word32 
+                  , pSwapchains :: Ptr SwapchainKHR 
+                  , pImageIndices :: Ptr Word32 
+                  , pResults :: Ptr VkResult 
                   }
   deriving (Eq)
 
@@ -169,16 +168,16 @@ instance Storable VkPresentInfoKHR where
                               <*> peek (ptr `plusPtr` 40)
                               <*> peek (ptr `plusPtr` 48)
                               <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (vkWaitSemaphoreCount (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 24) (vkPWaitSemaphores (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (vkSwapchainCount (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 40) (vkPSwapchains (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (vkPImageIndices (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 56) (vkPResults (poked :: VkPresentInfoKHR))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (swapchainCount (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 40) (pSwapchains (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (pImageIndices (poked :: VkPresentInfoKHR))
+                *> poke (ptr `plusPtr` 56) (pResults (poked :: VkPresentInfoKHR))
 
 
-newtype VkSwapchainKHR = VkSwapchainKHR Word64
+newtype SwapchainKHR = SwapchainKHR Word64
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -105,16 +105,16 @@ instance Storable SwapchainCreateInfoKHR where
                 *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: SwapchainCreateInfoKHR))
 
 
--- ** vkGetSwapchainImagesKHR
-foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
+-- ** getSwapchainImagesKHR
+foreign import ccall "vkGetSwapchainImagesKHR" getSwapchainImagesKHR ::
   Device -> SwapchainKHR -> Ptr Word32 -> Ptr Image -> IO Result
 
--- ** vkDestroySwapchainKHR
-foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
+-- ** destroySwapchainKHR
+foreign import ccall "vkDestroySwapchainKHR" destroySwapchainKHR ::
   Device -> SwapchainKHR -> Ptr AllocationCallbacks -> IO ()
 
--- ** vkQueuePresentKHR
-foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
+-- ** queuePresentKHR
+foreign import ccall "vkQueuePresentKHR" queuePresentKHR ::
   Queue -> Ptr PresentInfoKHR -> IO Result
 
 -- ** SwapchainCreateFlagsKHR
@@ -122,14 +122,14 @@ foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
 newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR Flags
   deriving (Eq, Storable)
 
--- ** vkCreateSwapchainKHR
-foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
+-- ** createSwapchainKHR
+foreign import ccall "vkCreateSwapchainKHR" createSwapchainKHR ::
   Device ->
   Ptr SwapchainCreateInfoKHR ->
     Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO Result
 
--- ** vkAcquireNextImageKHR
-foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
+-- ** acquireNextImageKHR
+foreign import ccall "vkAcquireNextImageKHR" acquireNextImageKHR ::
   Device ->
   SwapchainKHR ->
     Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO Result

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -11,11 +11,11 @@ import Data.Word( Word64(..)
 import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( SurfaceKHR(..)
-                                  , VkCompositeAlphaFlagsKHR(..)
-                                  , VkColorSpaceKHR(..)
-                                  , VkSurfaceTransformFlagsKHR(..)
-                                  , VkPresentModeKHR(..)
+import Graphics.Vulkan.KHR.Surface( SurfaceTransformFlagsKHR(..)
+                                  , PresentModeKHR(..)
+                                  , ColorSpaceKHR(..)
+                                  , SurfaceKHR(..)
+                                  , CompositeAlphaFlagsKHR(..)
                                   )
 import Graphics.Vulkan.Queue( Queue(..)
                             )
@@ -28,37 +28,37 @@ import Data.Void( Void(..)
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Image( Image(..)
-                            , VkImageUsageFlags(..)
+                            , ImageUsageFlags(..)
                             )
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , SharingMode(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
-                           , VkSharingMode(..)
+                           , Format(..)
+                           , Result(..)
                            , Extent2D(..)
                            )
 
 
 data SwapchainCreateInfoKHR =
-  SwapchainCreateInfoKHR{ sType :: VkStructureType 
+  SwapchainCreateInfoKHR{ sType :: StructureType 
                         , pNext :: Ptr Void 
-                        , flags :: VkSwapchainCreateFlagsKHR 
+                        , flags :: SwapchainCreateFlagsKHR 
                         , surface :: SurfaceKHR 
                         , minImageCount :: Word32 
-                        , imageFormat :: VkFormat 
-                        , imageColorSpace :: VkColorSpaceKHR 
+                        , imageFormat :: Format 
+                        , imageColorSpace :: ColorSpaceKHR 
                         , imageExtent :: Extent2D 
                         , imageArrayLayers :: Word32 
-                        , imageUsage :: VkImageUsageFlags 
-                        , imageSharingMode :: VkSharingMode 
+                        , imageUsage :: ImageUsageFlags 
+                        , imageSharingMode :: SharingMode 
                         , queueFamilyIndexCount :: Word32 
                         , pQueueFamilyIndices :: Ptr Word32 
-                        , preTransform :: VkSurfaceTransformFlagsKHR 
-                        , compositeAlpha :: VkCompositeAlphaFlagsKHR 
-                        , presentMode :: VkPresentModeKHR 
+                        , preTransform :: SurfaceTransformFlagsKHR 
+                        , compositeAlpha :: CompositeAlphaFlagsKHR 
+                        , presentMode :: PresentModeKHR 
                         , clipped :: VkBool32 
                         , oldSwapchain :: SwapchainKHR 
                         }
@@ -107,7 +107,7 @@ instance Storable SwapchainCreateInfoKHR where
 
 -- ** vkGetSwapchainImagesKHR
 foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
-  Device -> SwapchainKHR -> Ptr Word32 -> Ptr Image -> IO VkResult
+  Device -> SwapchainKHR -> Ptr Word32 -> Ptr Image -> IO Result
 
 -- ** vkDestroySwapchainKHR
 foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
@@ -115,35 +115,35 @@ foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
 
 -- ** vkQueuePresentKHR
 foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
-  Queue -> Ptr PresentInfoKHR -> IO VkResult
+  Queue -> Ptr PresentInfoKHR -> IO Result
 
--- ** VkSwapchainCreateFlagsKHR
+-- ** SwapchainCreateFlagsKHR
 -- | Opaque flag
-newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
+newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR VkFlags
   deriving (Eq, Storable)
 
 -- ** vkCreateSwapchainKHR
 foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
   Device ->
   Ptr SwapchainCreateInfoKHR ->
-    Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO Result
 
 -- ** vkAcquireNextImageKHR
 foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
   Device ->
   SwapchainKHR ->
-    Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO VkResult
+    Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO Result
 
 
 data PresentInfoKHR =
-  PresentInfoKHR{ sType :: VkStructureType 
+  PresentInfoKHR{ sType :: StructureType 
                 , pNext :: Ptr Void 
                 , waitSemaphoreCount :: Word32 
                 , pWaitSemaphores :: Ptr Semaphore 
                 , swapchainCount :: Word32 
                 , pSwapchains :: Ptr SwapchainKHR 
                 , pImageIndices :: Ptr Word32 
-                , pResults :: Ptr VkResult 
+                , pResults :: Ptr Result 
                 }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -3,47 +3,42 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Swapchain where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR
-                                    , VkSwapchainCreateInfoKHR
-                                    , VkSwapchainCreateFlagsKHR
-                                    , VkPresentInfoKHR
-                                    )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR
-                                  , SurfaceKHR
-                                  , VkPresentModeKHR
-                                  , VkCompositeAlphaFlagBitsKHR
-                                  , VkColorSpaceKHR
+import Graphics.Vulkan.KHR.Surface( SurfaceKHR(..)
+                                  , VkCompositeAlphaFlagsKHR(..)
+                                  , VkColorSpaceKHR(..)
+                                  , VkSurfaceTransformFlagsKHR(..)
+                                  , VkPresentModeKHR(..)
                                   )
-import Graphics.Vulkan.Queue( Queue
+import Graphics.Vulkan.Queue( Queue(..)
                             )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence
+import Graphics.Vulkan.Fence( Fence(..)
                             )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Image( Image
-                            , VkImageUsageFlags
+import Graphics.Vulkan.Image( Image(..)
+                            , VkImageUsageFlags(..)
                             )
-import Graphics.Vulkan.QueueSemaphore( Semaphore
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkExtent2D
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
-                           , VkSharingMode
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
+                           , VkExtent2D(..)
+                           , VkSharingMode(..)
                            )
 
 
@@ -61,8 +56,8 @@ data VkSwapchainCreateInfoKHR =
                           , imageSharingMode :: VkSharingMode 
                           , queueFamilyIndexCount :: Word32 
                           , pQueueFamilyIndices :: Ptr Word32 
-                          , preTransform :: VkSurfaceTransformFlagBitsKHR 
-                          , compositeAlpha :: VkCompositeAlphaFlagBitsKHR 
+                          , preTransform :: VkSurfaceTransformFlagsKHR 
+                          , compositeAlpha :: VkCompositeAlphaFlagsKHR 
                           , presentMode :: VkPresentModeKHR 
                           , clipped :: VkBool32 
                           , oldSwapchain :: SwapchainKHR 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -3,16 +3,48 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Swapchain where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.KHR.Swapchain( SwapchainKHR
+                                    , VkSwapchainCreateInfoKHR
+                                    , VkSwapchainCreateFlagsKHR
+                                    , VkPresentInfoKHR
+                                    )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.KHR.Surface( VkSurfaceTransformFlagBitsKHR
+                                  , SurfaceKHR
+                                  , VkPresentModeKHR
+                                  , VkCompositeAlphaFlagBitsKHR
+                                  , VkColorSpaceKHR
+                                  )
+import Graphics.Vulkan.Queue( Queue
+                            )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Fence( Fence
+                            )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.Image( Image
+                            , VkImageUsageFlags
+                            )
+import Graphics.Vulkan.QueueSemaphore( Semaphore
+                                     )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkExtent2D
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           , VkSharingMode
+                           )
 
 
 data VkSwapchainCreateInfoKHR =

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -32,12 +32,12 @@ import Graphics.Vulkan.Image( Image(..)
                             )
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , SharingMode(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Format(..)
                            , Result(..)
+                           , Flags(..)
                            , Extent2D(..)
                            )
 
@@ -59,7 +59,7 @@ data SwapchainCreateInfoKHR =
                         , preTransform :: SurfaceTransformFlagsKHR 
                         , compositeAlpha :: CompositeAlphaFlagsKHR 
                         , presentMode :: PresentModeKHR 
-                        , clipped :: VkBool32 
+                        , clipped :: Bool32 
                         , oldSwapchain :: SwapchainKHR 
                         }
   deriving (Eq)
@@ -119,7 +119,7 @@ foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
 
 -- ** SwapchainCreateFlagsKHR
 -- | Opaque flag
-newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR VkFlags
+newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR Flags
   deriving (Eq, Storable)
 
 -- ** vkCreateSwapchainKHR

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -62,7 +62,7 @@ data SwapchainCreateInfoKHR =
                         , clipped :: Bool32 
                         , oldSwapchain :: SwapchainKHR 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SwapchainCreateInfoKHR where
   sizeOf ~_ = 104
@@ -120,7 +120,7 @@ foreign import ccall "vkQueuePresentKHR" queuePresentKHR ::
 -- ** SwapchainCreateFlagsKHR
 -- | Opaque flag
 newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** createSwapchainKHR
 foreign import ccall "vkCreateSwapchainKHR" createSwapchainKHR ::
@@ -145,7 +145,7 @@ data PresentInfoKHR =
                 , pImageIndices :: Ptr Word32 
                 , pResults :: Ptr Result 
                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PresentInfoKHR where
   sizeOf ~_ = 64
@@ -169,5 +169,5 @@ instance Storable PresentInfoKHR where
 
 
 newtype SwapchainKHR = SwapchainKHR Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -11,11 +11,11 @@ import Data.Word( Word64(..)
 import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.KHR.Surface( SurfaceTransformFlagsKHR(..)
-                                  , PresentModeKHR(..)
-                                  , ColorSpaceKHR(..)
-                                  , SurfaceKHR(..)
-                                  , CompositeAlphaFlagsKHR(..)
+import Graphics.Vulkan.KHR.Surface( PresentMode(..)
+                                  , Surface(..)
+                                  , ColorSpace(..)
+                                  , CompositeAlphaFlags(..)
+                                  , SurfaceTransformFlags(..)
                                   )
 import Graphics.Vulkan.Queue( Queue(..)
                             )
@@ -42,132 +42,132 @@ import Graphics.Vulkan.Core( Bool32(..)
                            )
 
 
-data SwapchainCreateInfoKHR =
-  SwapchainCreateInfoKHR{ sType :: StructureType 
-                        , pNext :: Ptr Void 
-                        , flags :: SwapchainCreateFlagsKHR 
-                        , surface :: SurfaceKHR 
-                        , minImageCount :: Word32 
-                        , imageFormat :: Format 
-                        , imageColorSpace :: ColorSpaceKHR 
-                        , imageExtent :: Extent2D 
-                        , imageArrayLayers :: Word32 
-                        , imageUsage :: ImageUsageFlags 
-                        , imageSharingMode :: SharingMode 
-                        , queueFamilyIndexCount :: Word32 
-                        , pQueueFamilyIndices :: Ptr Word32 
-                        , preTransform :: SurfaceTransformFlagsKHR 
-                        , compositeAlpha :: CompositeAlphaFlagsKHR 
-                        , presentMode :: PresentModeKHR 
-                        , clipped :: Bool32 
-                        , oldSwapchain :: SwapchainKHR 
-                        }
+data SwapchainCreateInfo =
+  SwapchainCreateInfo{ sType :: StructureType 
+                     , pNext :: Ptr Void 
+                     , flags :: SwapchainCreateFlags 
+                     , surface :: Surface 
+                     , minImageCount :: Word32 
+                     , imageFormat :: Format 
+                     , imageColorSpace :: ColorSpace 
+                     , imageExtent :: Extent2D 
+                     , imageArrayLayers :: Word32 
+                     , imageUsage :: ImageUsageFlags 
+                     , imageSharingMode :: SharingMode 
+                     , queueFamilyIndexCount :: Word32 
+                     , pQueueFamilyIndices :: Ptr Word32 
+                     , preTransform :: SurfaceTransformFlags 
+                     , compositeAlpha :: CompositeAlphaFlags 
+                     , presentMode :: PresentMode 
+                     , clipped :: Bool32 
+                     , oldSwapchain :: Swapchain 
+                     }
   deriving (Eq, Ord)
 
-instance Storable SwapchainCreateInfoKHR where
+instance Storable SwapchainCreateInfo where
   sizeOf ~_ = 104
   alignment ~_ = 8
-  peek ptr = SwapchainCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 36)
-                                    <*> peek (ptr `plusPtr` 40)
-                                    <*> peek (ptr `plusPtr` 44)
-                                    <*> peek (ptr `plusPtr` 52)
-                                    <*> peek (ptr `plusPtr` 56)
-                                    <*> peek (ptr `plusPtr` 60)
-                                    <*> peek (ptr `plusPtr` 64)
-                                    <*> peek (ptr `plusPtr` 72)
-                                    <*> peek (ptr `plusPtr` 80)
-                                    <*> peek (ptr `plusPtr` 84)
-                                    <*> peek (ptr `plusPtr` 88)
-                                    <*> peek (ptr `plusPtr` 92)
-                                    <*> peek (ptr `plusPtr` 96)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (surface (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (minImageCount (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (imageFormat (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (imageColorSpace (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (imageArrayLayers (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 56) (imageUsage (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 60) (imageSharingMode (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 80) (preTransform (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 84) (compositeAlpha (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 88) (presentMode (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 92) (clipped (poked :: SwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: SwapchainCreateInfoKHR))
+  peek ptr = SwapchainCreateInfo <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 36)
+                                 <*> peek (ptr `plusPtr` 40)
+                                 <*> peek (ptr `plusPtr` 44)
+                                 <*> peek (ptr `plusPtr` 52)
+                                 <*> peek (ptr `plusPtr` 56)
+                                 <*> peek (ptr `plusPtr` 60)
+                                 <*> peek (ptr `plusPtr` 64)
+                                 <*> peek (ptr `plusPtr` 72)
+                                 <*> peek (ptr `plusPtr` 80)
+                                 <*> peek (ptr `plusPtr` 84)
+                                 <*> peek (ptr `plusPtr` 88)
+                                 <*> peek (ptr `plusPtr` 92)
+                                 <*> peek (ptr `plusPtr` 96)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 24) (surface (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 32) (minImageCount (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 36) (imageFormat (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 40) (imageColorSpace (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 52) (imageArrayLayers (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 56) (imageUsage (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 60) (imageSharingMode (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 80) (preTransform (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 84) (compositeAlpha (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 88) (presentMode (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 92) (clipped (poked :: SwapchainCreateInfo))
+                *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: SwapchainCreateInfo))
 
 
--- ** getSwapchainImagesKHR
-foreign import ccall "vkGetSwapchainImagesKHR" getSwapchainImagesKHR ::
-  Device -> SwapchainKHR -> Ptr Word32 -> Ptr Image -> IO Result
+-- ** getSwapchainImages
+foreign import ccall "vkGetSwapchainImagesKHR" getSwapchainImages ::
+  Device -> Swapchain -> Ptr Word32 -> Ptr Image -> IO Result
 
--- ** destroySwapchainKHR
-foreign import ccall "vkDestroySwapchainKHR" destroySwapchainKHR ::
-  Device -> SwapchainKHR -> Ptr AllocationCallbacks -> IO ()
+-- ** destroySwapchain
+foreign import ccall "vkDestroySwapchainKHR" destroySwapchain ::
+  Device -> Swapchain -> Ptr AllocationCallbacks -> IO ()
 
--- ** queuePresentKHR
-foreign import ccall "vkQueuePresentKHR" queuePresentKHR ::
-  Queue -> Ptr PresentInfoKHR -> IO Result
+-- ** queuePresent
+foreign import ccall "vkQueuePresentKHR" queuePresent ::
+  Queue -> Ptr PresentInfo -> IO Result
 
--- ** SwapchainCreateFlagsKHR
+-- ** SwapchainCreateFlags
 -- | Opaque flag
-newtype SwapchainCreateFlagsKHR = SwapchainCreateFlagsKHR Flags
+newtype SwapchainCreateFlags = SwapchainCreateFlags Flags
   deriving (Eq, Ord, Storable)
 
--- ** createSwapchainKHR
-foreign import ccall "vkCreateSwapchainKHR" createSwapchainKHR ::
+-- ** createSwapchain
+foreign import ccall "vkCreateSwapchainKHR" createSwapchain ::
   Device ->
-  Ptr SwapchainCreateInfoKHR ->
-    Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO Result
+  Ptr SwapchainCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Swapchain -> IO Result
 
--- ** acquireNextImageKHR
-foreign import ccall "vkAcquireNextImageKHR" acquireNextImageKHR ::
+-- ** acquireNextImage
+foreign import ccall "vkAcquireNextImageKHR" acquireNextImage ::
   Device ->
-  SwapchainKHR ->
+  Swapchain ->
     Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO Result
 
 
-data PresentInfoKHR =
-  PresentInfoKHR{ sType :: StructureType 
-                , pNext :: Ptr Void 
-                , waitSemaphoreCount :: Word32 
-                , pWaitSemaphores :: Ptr Semaphore 
-                , swapchainCount :: Word32 
-                , pSwapchains :: Ptr SwapchainKHR 
-                , pImageIndices :: Ptr Word32 
-                , pResults :: Ptr Result 
-                }
+data PresentInfo =
+  PresentInfo{ sType :: StructureType 
+             , pNext :: Ptr Void 
+             , waitSemaphoreCount :: Word32 
+             , pWaitSemaphores :: Ptr Semaphore 
+             , swapchainCount :: Word32 
+             , pSwapchains :: Ptr Swapchain 
+             , pImageIndices :: Ptr Word32 
+             , pResults :: Ptr Result 
+             }
   deriving (Eq, Ord)
 
-instance Storable PresentInfoKHR where
+instance Storable PresentInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = PresentInfoKHR <$> peek (ptr `plusPtr` 0)
-                            <*> peek (ptr `plusPtr` 8)
-                            <*> peek (ptr `plusPtr` 16)
-                            <*> peek (ptr `plusPtr` 24)
-                            <*> peek (ptr `plusPtr` 32)
-                            <*> peek (ptr `plusPtr` 40)
-                            <*> peek (ptr `plusPtr` 48)
-                            <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (swapchainCount (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 40) (pSwapchains (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (pImageIndices (poked :: PresentInfoKHR))
-                *> poke (ptr `plusPtr` 56) (pResults (poked :: PresentInfoKHR))
+  peek ptr = PresentInfo <$> peek (ptr `plusPtr` 0)
+                         <*> peek (ptr `plusPtr` 8)
+                         <*> peek (ptr `plusPtr` 16)
+                         <*> peek (ptr `plusPtr` 24)
+                         <*> peek (ptr `plusPtr` 32)
+                         <*> peek (ptr `plusPtr` 40)
+                         <*> peek (ptr `plusPtr` 48)
+                         <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 32) (swapchainCount (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 40) (pSwapchains (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 48) (pImageIndices (poked :: PresentInfo))
+                *> poke (ptr `plusPtr` 56) (pResults (poked :: PresentInfo))
 
 
-newtype SwapchainKHR = SwapchainKHR Word64
+newtype Swapchain = Swapchain Word64
   deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -25,7 +25,7 @@ import Graphics.Vulkan.Fence( Fence(..)
                             )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Image( Image(..)
                             , VkImageUsageFlags(..)
@@ -37,72 +37,72 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFlags(..)
                            , VkBool32(..)
                            , VkResult(..)
-                           , VkExtent2D(..)
                            , VkSharingMode(..)
+                           , Extent2D(..)
                            )
 
 
-data VkSwapchainCreateInfoKHR =
-  VkSwapchainCreateInfoKHR{ sType :: VkStructureType 
-                          , pNext :: Ptr Void 
-                          , flags :: VkSwapchainCreateFlagsKHR 
-                          , surface :: SurfaceKHR 
-                          , minImageCount :: Word32 
-                          , imageFormat :: VkFormat 
-                          , imageColorSpace :: VkColorSpaceKHR 
-                          , imageExtent :: VkExtent2D 
-                          , imageArrayLayers :: Word32 
-                          , imageUsage :: VkImageUsageFlags 
-                          , imageSharingMode :: VkSharingMode 
-                          , queueFamilyIndexCount :: Word32 
-                          , pQueueFamilyIndices :: Ptr Word32 
-                          , preTransform :: VkSurfaceTransformFlagsKHR 
-                          , compositeAlpha :: VkCompositeAlphaFlagsKHR 
-                          , presentMode :: VkPresentModeKHR 
-                          , clipped :: VkBool32 
-                          , oldSwapchain :: SwapchainKHR 
-                          }
+data SwapchainCreateInfoKHR =
+  SwapchainCreateInfoKHR{ sType :: VkStructureType 
+                        , pNext :: Ptr Void 
+                        , flags :: VkSwapchainCreateFlagsKHR 
+                        , surface :: SurfaceKHR 
+                        , minImageCount :: Word32 
+                        , imageFormat :: VkFormat 
+                        , imageColorSpace :: VkColorSpaceKHR 
+                        , imageExtent :: Extent2D 
+                        , imageArrayLayers :: Word32 
+                        , imageUsage :: VkImageUsageFlags 
+                        , imageSharingMode :: VkSharingMode 
+                        , queueFamilyIndexCount :: Word32 
+                        , pQueueFamilyIndices :: Ptr Word32 
+                        , preTransform :: VkSurfaceTransformFlagsKHR 
+                        , compositeAlpha :: VkCompositeAlphaFlagsKHR 
+                        , presentMode :: VkPresentModeKHR 
+                        , clipped :: VkBool32 
+                        , oldSwapchain :: SwapchainKHR 
+                        }
   deriving (Eq)
 
-instance Storable VkSwapchainCreateInfoKHR where
+instance Storable SwapchainCreateInfoKHR where
   sizeOf ~_ = 104
   alignment ~_ = 8
-  peek ptr = VkSwapchainCreateInfoKHR <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 24)
-                                      <*> peek (ptr `plusPtr` 32)
-                                      <*> peek (ptr `plusPtr` 36)
-                                      <*> peek (ptr `plusPtr` 40)
-                                      <*> peek (ptr `plusPtr` 44)
-                                      <*> peek (ptr `plusPtr` 52)
-                                      <*> peek (ptr `plusPtr` 56)
-                                      <*> peek (ptr `plusPtr` 60)
-                                      <*> peek (ptr `plusPtr` 64)
-                                      <*> peek (ptr `plusPtr` 72)
-                                      <*> peek (ptr `plusPtr` 80)
-                                      <*> peek (ptr `plusPtr` 84)
-                                      <*> peek (ptr `plusPtr` 88)
-                                      <*> peek (ptr `plusPtr` 92)
-                                      <*> peek (ptr `plusPtr` 96)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 24) (surface (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 32) (minImageCount (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 36) (imageFormat (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 40) (imageColorSpace (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 52) (imageArrayLayers (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 56) (imageUsage (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 60) (imageSharingMode (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 80) (preTransform (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 84) (compositeAlpha (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 88) (presentMode (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 92) (clipped (poked :: VkSwapchainCreateInfoKHR))
-                *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: VkSwapchainCreateInfoKHR))
+  peek ptr = SwapchainCreateInfoKHR <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 24)
+                                    <*> peek (ptr `plusPtr` 32)
+                                    <*> peek (ptr `plusPtr` 36)
+                                    <*> peek (ptr `plusPtr` 40)
+                                    <*> peek (ptr `plusPtr` 44)
+                                    <*> peek (ptr `plusPtr` 52)
+                                    <*> peek (ptr `plusPtr` 56)
+                                    <*> peek (ptr `plusPtr` 60)
+                                    <*> peek (ptr `plusPtr` 64)
+                                    <*> peek (ptr `plusPtr` 72)
+                                    <*> peek (ptr `plusPtr` 80)
+                                    <*> peek (ptr `plusPtr` 84)
+                                    <*> peek (ptr `plusPtr` 88)
+                                    <*> peek (ptr `plusPtr` 92)
+                                    <*> peek (ptr `plusPtr` 96)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 24) (surface (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 32) (minImageCount (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 36) (imageFormat (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 40) (imageColorSpace (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 44) (imageExtent (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 52) (imageArrayLayers (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 56) (imageUsage (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 60) (imageSharingMode (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 64) (queueFamilyIndexCount (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 72) (pQueueFamilyIndices (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 80) (preTransform (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 84) (compositeAlpha (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 88) (presentMode (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 92) (clipped (poked :: SwapchainCreateInfoKHR))
+                *> poke (ptr `plusPtr` 96) (oldSwapchain (poked :: SwapchainCreateInfoKHR))
 
 
 -- ** vkGetSwapchainImagesKHR
@@ -111,11 +111,11 @@ foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
 
 -- ** vkDestroySwapchainKHR
 foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
-  Device -> SwapchainKHR -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> SwapchainKHR -> Ptr AllocationCallbacks -> IO ()
 
 -- ** vkQueuePresentKHR
 foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
-  Queue -> Ptr VkPresentInfoKHR -> IO VkResult
+  Queue -> Ptr PresentInfoKHR -> IO VkResult
 
 -- ** VkSwapchainCreateFlagsKHR
 -- | Opaque flag
@@ -125,8 +125,8 @@ newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
 -- ** vkCreateSwapchainKHR
 foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
   Device ->
-  Ptr VkSwapchainCreateInfoKHR ->
-    Ptr VkAllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
+  Ptr SwapchainCreateInfoKHR ->
+    Ptr AllocationCallbacks -> Ptr SwapchainKHR -> IO VkResult
 
 -- ** vkAcquireNextImageKHR
 foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
@@ -135,37 +135,37 @@ foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
     Word64 -> Semaphore -> Fence -> Ptr Word32 -> IO VkResult
 
 
-data VkPresentInfoKHR =
-  VkPresentInfoKHR{ sType :: VkStructureType 
-                  , pNext :: Ptr Void 
-                  , waitSemaphoreCount :: Word32 
-                  , pWaitSemaphores :: Ptr Semaphore 
-                  , swapchainCount :: Word32 
-                  , pSwapchains :: Ptr SwapchainKHR 
-                  , pImageIndices :: Ptr Word32 
-                  , pResults :: Ptr VkResult 
-                  }
+data PresentInfoKHR =
+  PresentInfoKHR{ sType :: VkStructureType 
+                , pNext :: Ptr Void 
+                , waitSemaphoreCount :: Word32 
+                , pWaitSemaphores :: Ptr Semaphore 
+                , swapchainCount :: Word32 
+                , pSwapchains :: Ptr SwapchainKHR 
+                , pImageIndices :: Ptr Word32 
+                , pResults :: Ptr VkResult 
+                }
   deriving (Eq)
 
-instance Storable VkPresentInfoKHR where
+instance Storable PresentInfoKHR where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkPresentInfoKHR <$> peek (ptr `plusPtr` 0)
-                              <*> peek (ptr `plusPtr` 8)
-                              <*> peek (ptr `plusPtr` 16)
-                              <*> peek (ptr `plusPtr` 24)
-                              <*> peek (ptr `plusPtr` 32)
-                              <*> peek (ptr `plusPtr` 40)
-                              <*> peek (ptr `plusPtr` 48)
-                              <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 32) (swapchainCount (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 40) (pSwapchains (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 48) (pImageIndices (poked :: VkPresentInfoKHR))
-                *> poke (ptr `plusPtr` 56) (pResults (poked :: VkPresentInfoKHR))
+  peek ptr = PresentInfoKHR <$> peek (ptr `plusPtr` 0)
+                            <*> peek (ptr `plusPtr` 8)
+                            <*> peek (ptr `plusPtr` 16)
+                            <*> peek (ptr `plusPtr` 24)
+                            <*> peek (ptr `plusPtr` 32)
+                            <*> peek (ptr `plusPtr` 40)
+                            <*> peek (ptr `plusPtr` 48)
+                            <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 32) (swapchainCount (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 40) (pSwapchains (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 48) (pImageIndices (poked :: PresentInfoKHR))
+                *> poke (ptr `plusPtr` 56) (pResults (poked :: PresentInfoKHR))
 
 
 newtype SwapchainKHR = SwapchainKHR Word64

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -5,7 +5,7 @@ module Graphics.Vulkan.LayerDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( VkPhysicalDevice(..)
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
 import Data.Word( Word32
                 )
@@ -24,10 +24,10 @@ import Foreign.C.Types( CChar
 
 
 data VkLayerProperties =
-  VkLayerProperties{ vkLayerName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
-                   , vkSpecVersion :: Word32 
-                   , vkImplementationVersion :: Word32 
-                   , vkDescription :: Vector VK_MAX_DESCRIPTION_SIZE CChar 
+  VkLayerProperties{ layerName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+                   , specVersion :: Word32 
+                   , implementationVersion :: Word32 
+                   , description :: Vector VK_MAX_DESCRIPTION_SIZE CChar 
                    }
   deriving (Eq)
 
@@ -38,10 +38,10 @@ instance Storable VkLayerProperties where
                                <*> peek (ptr `plusPtr` 256)
                                <*> peek (ptr `plusPtr` 260)
                                <*> peek (ptr `plusPtr` 264)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkLayerName (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 256) (vkSpecVersion (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 260) (vkImplementationVersion (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 264) (vkDescription (poked :: VkLayerProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (layerName (poked :: VkLayerProperties))
+                *> poke (ptr `plusPtr` 256) (specVersion (poked :: VkLayerProperties))
+                *> poke (ptr `plusPtr` 260) (implementationVersion (poked :: VkLayerProperties))
+                *> poke (ptr `plusPtr` 264) (description (poked :: VkLayerProperties))
 
 
 -- ** vkEnumerateInstanceLayerProperties
@@ -50,6 +50,6 @@ foreign import ccall "vkEnumerateInstanceLayerProperties" vkEnumerateInstanceLay
 
 -- ** vkEnumerateDeviceLayerProperties
 foreign import ccall "vkEnumerateDeviceLayerProperties" vkEnumerateDeviceLayerProperties ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   Ptr Word32 -> Ptr VkLayerProperties -> IO VkResult
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -5,8 +5,6 @@ module Graphics.Vulkan.LayerDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( PhysicalDevice(..)
-                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -14,11 +12,6 @@ import Foreign.Ptr( Ptr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_EXTENSION_NAME_SIZE
-                                , VK_MAX_DESCRIPTION_SIZE
-                                )
-import Graphics.Vulkan.Core( VkResult(..)
-                           )
 import Foreign.C.Types( CChar
                       )
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -29,7 +29,7 @@ data LayerProperties =
                  , implementationVersion :: Word32 
                  , description :: Vector MaxDescriptionSize CChar 
                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable LayerProperties where
   sizeOf ~_ = 520

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -17,7 +17,7 @@ import Foreign.Storable( Storable(..)
 import Graphics.Vulkan.Constants( VK_MAX_DESCRIPTION_SIZE
                                 , VK_MAX_EXTENSION_NAME_SIZE
                                 )
-import Graphics.Vulkan.Core( VkResult(..)
+import Graphics.Vulkan.Core( Result(..)
                            )
 import Foreign.C.Types( CChar(..)
                       )
@@ -46,9 +46,9 @@ instance Storable LayerProperties where
 
 -- ** vkEnumerateInstanceLayerProperties
 foreign import ccall "vkEnumerateInstanceLayerProperties" vkEnumerateInstanceLayerProperties ::
-  Ptr Word32 -> Ptr LayerProperties -> IO VkResult
+  Ptr Word32 -> Ptr LayerProperties -> IO Result
 
 -- ** vkEnumerateDeviceLayerProperties
 foreign import ccall "vkEnumerateDeviceLayerProperties" vkEnumerateDeviceLayerProperties ::
-  PhysicalDevice -> Ptr Word32 -> Ptr LayerProperties -> IO VkResult
+  PhysicalDevice -> Ptr Word32 -> Ptr LayerProperties -> IO Result
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -14,8 +14,8 @@ import Foreign.Ptr( Ptr(..)
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Constants( VK_MAX_DESCRIPTION_SIZE
-                                , VK_MAX_EXTENSION_NAME_SIZE
+import Graphics.Vulkan.Constants( MaxDescriptionSize
+                                , MaxExtensionNameSize
                                 )
 import Graphics.Vulkan.Core( Result(..)
                            )
@@ -24,10 +24,10 @@ import Foreign.C.Types( CChar(..)
 
 
 data LayerProperties =
-  LayerProperties{ layerName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+  LayerProperties{ layerName :: Vector MaxExtensionNameSize CChar 
                  , specVersion :: Word32 
                  , implementationVersion :: Word32 
-                 , description :: Vector VK_MAX_DESCRIPTION_SIZE CChar 
+                 , description :: Vector MaxDescriptionSize CChar 
                  }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -5,6 +5,8 @@ module Graphics.Vulkan.LayerDiscovery where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
+import Graphics.Vulkan.Device( PhysicalDevice
+                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +14,10 @@ import Foreign.Ptr( Ptr
                   )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Core( VkResult
+                           )
+import Graphics.Vulkan.LayerDiscovery( VkLayerProperties
+                                     )
 import Foreign.C.Types( CChar
                       )
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -23,33 +23,32 @@ import Foreign.C.Types( CChar(..)
                       )
 
 
-data VkLayerProperties =
-  VkLayerProperties{ layerName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
-                   , specVersion :: Word32 
-                   , implementationVersion :: Word32 
-                   , description :: Vector VK_MAX_DESCRIPTION_SIZE CChar 
-                   }
+data LayerProperties =
+  LayerProperties{ layerName :: Vector VK_MAX_EXTENSION_NAME_SIZE CChar 
+                 , specVersion :: Word32 
+                 , implementationVersion :: Word32 
+                 , description :: Vector VK_MAX_DESCRIPTION_SIZE CChar 
+                 }
   deriving (Eq)
 
-instance Storable VkLayerProperties where
+instance Storable LayerProperties where
   sizeOf ~_ = 520
   alignment ~_ = 4
-  peek ptr = VkLayerProperties <$> peek (ptr `plusPtr` 0)
-                               <*> peek (ptr `plusPtr` 256)
-                               <*> peek (ptr `plusPtr` 260)
-                               <*> peek (ptr `plusPtr` 264)
-  poke ptr poked = poke (ptr `plusPtr` 0) (layerName (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 256) (specVersion (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 260) (implementationVersion (poked :: VkLayerProperties))
-                *> poke (ptr `plusPtr` 264) (description (poked :: VkLayerProperties))
+  peek ptr = LayerProperties <$> peek (ptr `plusPtr` 0)
+                             <*> peek (ptr `plusPtr` 256)
+                             <*> peek (ptr `plusPtr` 260)
+                             <*> peek (ptr `plusPtr` 264)
+  poke ptr poked = poke (ptr `plusPtr` 0) (layerName (poked :: LayerProperties))
+                *> poke (ptr `plusPtr` 256) (specVersion (poked :: LayerProperties))
+                *> poke (ptr `plusPtr` 260) (implementationVersion (poked :: LayerProperties))
+                *> poke (ptr `plusPtr` 264) (description (poked :: LayerProperties))
 
 
 -- ** vkEnumerateInstanceLayerProperties
 foreign import ccall "vkEnumerateInstanceLayerProperties" vkEnumerateInstanceLayerProperties ::
-  Ptr Word32 -> Ptr VkLayerProperties -> IO VkResult
+  Ptr Word32 -> Ptr LayerProperties -> IO VkResult
 
 -- ** vkEnumerateDeviceLayerProperties
 foreign import ccall "vkEnumerateDeviceLayerProperties" vkEnumerateDeviceLayerProperties ::
-  PhysicalDevice ->
-  Ptr Word32 -> Ptr VkLayerProperties -> IO VkResult
+  PhysicalDevice -> Ptr Word32 -> Ptr LayerProperties -> IO VkResult
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -3,22 +3,23 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.LayerDiscovery where
 
-import Data.Vector.Storable.Sized( Vector
+import Data.Vector.Storable.Sized( Vector(..)
                                  )
-import Graphics.Vulkan.Device( PhysicalDevice
+import Graphics.Vulkan.Device( PhysicalDevice(..)
                              )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Core( VkResult
+import Graphics.Vulkan.Constants( VK_MAX_DESCRIPTION_SIZE
+                                , VK_MAX_EXTENSION_NAME_SIZE
+                                )
+import Graphics.Vulkan.Core( VkResult(..)
                            )
-import Graphics.Vulkan.LayerDiscovery( VkLayerProperties
-                                     )
-import Foreign.C.Types( CChar
+import Foreign.C.Types( CChar(..)
                       )
 
 

--- a/src/Graphics/Vulkan/LayerDiscovery.hs
+++ b/src/Graphics/Vulkan/LayerDiscovery.hs
@@ -44,11 +44,11 @@ instance Storable LayerProperties where
                 *> poke (ptr `plusPtr` 264) (description (poked :: LayerProperties))
 
 
--- ** vkEnumerateInstanceLayerProperties
-foreign import ccall "vkEnumerateInstanceLayerProperties" vkEnumerateInstanceLayerProperties ::
+-- ** enumerateInstanceLayerProperties
+foreign import ccall "vkEnumerateInstanceLayerProperties" enumerateInstanceLayerProperties ::
   Ptr Word32 -> Ptr LayerProperties -> IO Result
 
--- ** vkEnumerateDeviceLayerProperties
-foreign import ccall "vkEnumerateDeviceLayerProperties" vkEnumerateDeviceLayerProperties ::
+-- ** enumerateDeviceLayerProperties
+foreign import ccall "vkEnumerateDeviceLayerProperties" enumerateDeviceLayerProperties ::
   PhysicalDevice -> Ptr Word32 -> Ptr LayerProperties -> IO Result
 

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Memory where
 
-import {-# SOURCE #-} Graphics.Vulkan.Device( VkDevice(..)
+import {-# SOURCE #-} Graphics.Vulkan.Device( Device(..)
                                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -40,13 +40,13 @@ import Foreign.C.Types( CSize
                       , CSize(..)
                       )
 
-newtype VkDeviceMemory = VkDeviceMemory Word64
+newtype DeviceMemory = DeviceMemory Word64
   deriving (Eq, Storable)
 
 -- ** vkMapMemory
 foreign import ccall "vkMapMemory" vkMapMemory ::
-  VkDevice ->
-  VkDeviceMemory ->
+  Device ->
+  DeviceMemory ->
     VkDeviceSize ->
       VkDeviceSize -> VkMemoryMapFlags -> Ptr (Ptr Void) -> IO VkResult
 
@@ -57,12 +57,12 @@ type PFN_vkInternalFreeNotification = FunPtr
 
 
 data VkAllocationCallbacks =
-  VkAllocationCallbacks{ vkPUserData :: Ptr Void 
-                       , vkPfnAllocation :: PFN_vkAllocationFunction 
-                       , vkPfnReallocation :: PFN_vkReallocationFunction 
-                       , vkPfnFree :: PFN_vkFreeFunction 
-                       , vkPfnInternalAllocation :: PFN_vkInternalAllocationNotification 
-                       , vkPfnInternalFree :: PFN_vkInternalFreeNotification 
+  VkAllocationCallbacks{ pUserData :: Ptr Void 
+                       , pfnAllocation :: PFN_vkAllocationFunction 
+                       , pfnReallocation :: PFN_vkReallocationFunction 
+                       , pfnFree :: PFN_vkFreeFunction 
+                       , pfnInternalAllocation :: PFN_vkInternalAllocationNotification 
+                       , pfnInternalFree :: PFN_vkInternalFreeNotification 
                        }
   deriving (Eq)
 
@@ -75,17 +75,17 @@ instance Storable VkAllocationCallbacks where
                                    <*> peek (ptr `plusPtr` 24)
                                    <*> peek (ptr `plusPtr` 32)
                                    <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkPUserData (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 8) (vkPfnAllocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 16) (vkPfnReallocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 24) (vkPfnFree (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 32) (vkPfnInternalAllocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 40) (vkPfnInternalFree (poked :: VkAllocationCallbacks))
+  poke ptr poked = poke (ptr `plusPtr` 0) (pUserData (poked :: VkAllocationCallbacks))
+                *> poke (ptr `plusPtr` 8) (pfnAllocation (poked :: VkAllocationCallbacks))
+                *> poke (ptr `plusPtr` 16) (pfnReallocation (poked :: VkAllocationCallbacks))
+                *> poke (ptr `plusPtr` 24) (pfnFree (poked :: VkAllocationCallbacks))
+                *> poke (ptr `plusPtr` 32) (pfnInternalAllocation (poked :: VkAllocationCallbacks))
+                *> poke (ptr `plusPtr` 40) (pfnInternalFree (poked :: VkAllocationCallbacks))
 
 
 -- ** vkInvalidateMappedMemoryRanges
 foreign import ccall "vkInvalidateMappedMemoryRanges" vkInvalidateMappedMemoryRanges ::
-  VkDevice -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
 
 -- ** VkSystemAllocationScope
 
@@ -127,7 +127,7 @@ pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = VkSystemAllocationScope 4
 
 -- ** vkFlushMappedMemoryRanges
 foreign import ccall "vkFlushMappedMemoryRanges" vkFlushMappedMemoryRanges ::
-  VkDevice -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
 
 -- ** VkMemoryMapFlags
 -- | Opaque flag
@@ -141,7 +141,7 @@ type PFN_vkInternalAllocationNotification = FunPtr
 
 -- ** vkFreeMemory
 foreign import ccall "vkFreeMemory" vkFreeMemory ::
-  VkDevice -> VkDeviceMemory -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DeviceMemory -> Ptr VkAllocationCallbacks -> IO ()
 
 type PFN_vkReallocationFunction = FunPtr
   (Ptr Void ->
@@ -150,7 +150,7 @@ type PFN_vkReallocationFunction = FunPtr
 
 -- ** vkUnmapMemory
 foreign import ccall "vkUnmapMemory" vkUnmapMemory ::
-  VkDevice -> VkDeviceMemory -> IO ()
+  Device -> DeviceMemory -> IO ()
 
 type PFN_vkAllocationFunction = FunPtr
   (Ptr Void ->
@@ -182,21 +182,21 @@ type PFN_vkFreeFunction = FunPtr (Ptr Void -> Ptr Void -> IO ())
 
 -- ** vkGetDeviceMemoryCommitment
 foreign import ccall "vkGetDeviceMemoryCommitment" vkGetDeviceMemoryCommitment ::
-  VkDevice -> VkDeviceMemory -> Ptr VkDeviceSize -> IO ()
+  Device -> DeviceMemory -> Ptr VkDeviceSize -> IO ()
 
 -- ** vkAllocateMemory
 foreign import ccall "vkAllocateMemory" vkAllocateMemory ::
-  VkDevice ->
+  Device ->
   Ptr VkMemoryAllocateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkDeviceMemory -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr DeviceMemory -> IO VkResult
 
 
 data VkMappedMemoryRange =
-  VkMappedMemoryRange{ vkSType :: VkStructureType 
-                     , vkPNext :: Ptr Void 
-                     , vkMemory :: VkDeviceMemory 
-                     , vkOffset :: VkDeviceSize 
-                     , vkSize :: VkDeviceSize 
+  VkMappedMemoryRange{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , memory :: DeviceMemory 
+                     , offset :: VkDeviceSize 
+                     , size :: VkDeviceSize 
                      }
   deriving (Eq)
 
@@ -208,19 +208,19 @@ instance Storable VkMappedMemoryRange where
                                  <*> peek (ptr `plusPtr` 16)
                                  <*> peek (ptr `plusPtr` 24)
                                  <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 16) (vkMemory (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 24) (vkOffset (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 32) (vkSize (poked :: VkMappedMemoryRange))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMappedMemoryRange))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMappedMemoryRange))
+                *> poke (ptr `plusPtr` 16) (memory (poked :: VkMappedMemoryRange))
+                *> poke (ptr `plusPtr` 24) (offset (poked :: VkMappedMemoryRange))
+                *> poke (ptr `plusPtr` 32) (size (poked :: VkMappedMemoryRange))
 
 
 
 data VkMemoryAllocateInfo =
-  VkMemoryAllocateInfo{ vkSType :: VkStructureType 
-                      , vkPNext :: Ptr Void 
-                      , vkAllocationSize :: VkDeviceSize 
-                      , vkMemoryTypeIndex :: Word32 
+  VkMemoryAllocateInfo{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , allocationSize :: VkDeviceSize 
+                      , memoryTypeIndex :: Word32 
                       }
   deriving (Eq)
 
@@ -231,9 +231,9 @@ instance Storable VkMemoryAllocateInfo where
                                   <*> peek (ptr `plusPtr` 8)
                                   <*> peek (ptr `plusPtr` 16)
                                   <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (vkAllocationSize (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (vkMemoryTypeIndex (poked :: VkMemoryAllocateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (allocationSize (poked :: VkMemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (memoryTypeIndex (poked :: VkMemoryAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Memory where
 
-import {-# SOURCE #-} Graphics.Vulkan.Device( Device(..)
-                                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -31,13 +29,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
-                      , CSize(..)
                       )
 
 newtype DeviceMemory = DeviceMemory Word64

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -40,7 +40,7 @@ import Foreign.C.Types( CSize(..)
                       )
 
 newtype DeviceMemory = DeviceMemory Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** mapMemory
 foreign import ccall "vkMapMemory" mapMemory ::
@@ -62,7 +62,7 @@ data AllocationCallbacks =
                      , pfnInternalAllocation :: PFN_vkInternalAllocationNotification 
                      , pfnInternalFree :: PFN_vkInternalFreeNotification 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable AllocationCallbacks where
   sizeOf ~_ = 48
@@ -88,7 +88,7 @@ foreign import ccall "vkInvalidateMappedMemoryRanges" invalidateMappedMemoryRang
 -- ** SystemAllocationScope
 
 newtype SystemAllocationScope = SystemAllocationScope Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show SystemAllocationScope where
   showsPrec _ SystemAllocationScopeCommand = showString "SystemAllocationScopeCommand"
@@ -130,7 +130,7 @@ foreign import ccall "vkFlushMappedMemoryRanges" flushMappedMemoryRanges ::
 -- ** MemoryMapFlags
 -- | Opaque flag
 newtype MemoryMapFlags = MemoryMapFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 type PFN_vkInternalAllocationNotification = FunPtr
   (Ptr Void ->
@@ -156,7 +156,7 @@ type PFN_vkAllocationFunction = FunPtr
 -- ** InternalAllocationType
 
 newtype InternalAllocationType = InternalAllocationType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show InternalAllocationType where
   showsPrec _ InternalAllocationTypeExecutable = showString "InternalAllocationTypeExecutable"
@@ -195,7 +195,7 @@ data MappedMemoryRange =
                    , offset :: DeviceSize 
                    , size :: DeviceSize 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MappedMemoryRange where
   sizeOf ~_ = 40
@@ -219,7 +219,7 @@ data MemoryAllocateInfo =
                     , allocationSize :: DeviceSize 
                     , memoryTypeIndex :: Word32 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MemoryAllocateInfo where
   sizeOf ~_ = 32

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -91,19 +91,19 @@ newtype SystemAllocationScope = SystemAllocationScope Int32
   deriving (Eq, Storable)
 
 instance Show SystemAllocationScope where
-  showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = showString "VK_SYSTEM_ALLOCATION_SCOPE_COMMAND"
-  showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = showString "VK_SYSTEM_ALLOCATION_SCOPE_OBJECT"
-  showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_CACHE = showString "VK_SYSTEM_ALLOCATION_SCOPE_CACHE"
-  showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = showString "VK_SYSTEM_ALLOCATION_SCOPE_DEVICE"
-  showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = showString "VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE"
+  showsPrec _ SystemAllocationScopeCommand = showString "SystemAllocationScopeCommand"
+  showsPrec _ SystemAllocationScopeObject = showString "SystemAllocationScopeObject"
+  showsPrec _ SystemAllocationScopeCache = showString "SystemAllocationScopeCache"
+  showsPrec _ SystemAllocationScopeDevice = showString "SystemAllocationScopeDevice"
+  showsPrec _ SystemAllocationScopeInstance = showString "SystemAllocationScopeInstance"
   showsPrec p (SystemAllocationScope x) = showParen (p >= 11) (showString "SystemAllocationScope " . showsPrec 11 x)
 
 instance Read SystemAllocationScope where
-  readPrec = parens ( choose [ ("VK_SYSTEM_ALLOCATION_SCOPE_COMMAND", pure VK_SYSTEM_ALLOCATION_SCOPE_COMMAND)
-                             , ("VK_SYSTEM_ALLOCATION_SCOPE_OBJECT", pure VK_SYSTEM_ALLOCATION_SCOPE_OBJECT)
-                             , ("VK_SYSTEM_ALLOCATION_SCOPE_CACHE", pure VK_SYSTEM_ALLOCATION_SCOPE_CACHE)
-                             , ("VK_SYSTEM_ALLOCATION_SCOPE_DEVICE", pure VK_SYSTEM_ALLOCATION_SCOPE_DEVICE)
-                             , ("VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE", pure VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE)
+  readPrec = parens ( choose [ ("SystemAllocationScopeCommand", pure SystemAllocationScopeCommand)
+                             , ("SystemAllocationScopeObject", pure SystemAllocationScopeObject)
+                             , ("SystemAllocationScopeCache", pure SystemAllocationScopeCache)
+                             , ("SystemAllocationScopeDevice", pure SystemAllocationScopeDevice)
+                             , ("SystemAllocationScopeInstance", pure SystemAllocationScopeInstance)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SystemAllocationScope")
@@ -113,15 +113,15 @@ instance Read SystemAllocationScope where
                     )
 
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = SystemAllocationScope 0
+pattern SystemAllocationScopeCommand = SystemAllocationScope 0
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = SystemAllocationScope 1
+pattern SystemAllocationScopeObject = SystemAllocationScope 1
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_CACHE = SystemAllocationScope 2
+pattern SystemAllocationScopeCache = SystemAllocationScope 2
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = SystemAllocationScope 3
+pattern SystemAllocationScopeDevice = SystemAllocationScope 3
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = SystemAllocationScope 4
+pattern SystemAllocationScopeInstance = SystemAllocationScope 4
 
 -- ** flushMappedMemoryRanges
 foreign import ccall "vkFlushMappedMemoryRanges" flushMappedMemoryRanges ::
@@ -159,11 +159,11 @@ newtype InternalAllocationType = InternalAllocationType Int32
   deriving (Eq, Storable)
 
 instance Show InternalAllocationType where
-  showsPrec _ VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = showString "VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE"
+  showsPrec _ InternalAllocationTypeExecutable = showString "InternalAllocationTypeExecutable"
   showsPrec p (InternalAllocationType x) = showParen (p >= 11) (showString "InternalAllocationType " . showsPrec 11 x)
 
 instance Read InternalAllocationType where
-  readPrec = parens ( choose [ ("VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE", pure VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE)
+  readPrec = parens ( choose [ ("InternalAllocationTypeExecutable", pure InternalAllocationTypeExecutable)
                              ] +++
                       prec 10 (do
                         expectP (Ident "InternalAllocationType")
@@ -173,7 +173,7 @@ instance Read InternalAllocationType where
                     )
 
 
-pattern VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = InternalAllocationType 0
+pattern InternalAllocationTypeExecutable = InternalAllocationType 0
 
 type PFN_vkFreeFunction = FunPtr (Ptr Void -> Ptr Void -> IO ())
 

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Memory where
 
+import {-# SOURCE #-} Graphics.Vulkan.Device( Device
+                                            )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -22,6 +24,19 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( PFN_vkAllocationFunction
+                             , VkMemoryMapFlags
+                             , VkSystemAllocationScope
+                             , PFN_vkFreeFunction
+                             , PFN_vkReallocationFunction
+                             , VkInternalAllocationType
+                             , VkAllocationCallbacks
+                             , DeviceMemory
+                             , VkMappedMemoryRange
+                             , VkMemoryAllocateInfo
+                             , PFN_vkInternalFreeNotification
+                             , PFN_vkInternalAllocationNotification
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +44,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       )
 

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -31,10 +31,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
@@ -46,8 +46,8 @@ newtype DeviceMemory = DeviceMemory Word64
 foreign import ccall "vkMapMemory" vkMapMemory ::
   Device ->
   DeviceMemory ->
-    VkDeviceSize ->
-      VkDeviceSize -> MemoryMapFlags -> Ptr (Ptr Void) -> IO Result
+    DeviceSize ->
+      DeviceSize -> MemoryMapFlags -> Ptr (Ptr Void) -> IO Result
 
 type PFN_vkInternalFreeNotification = FunPtr
   (Ptr Void ->
@@ -129,7 +129,7 @@ foreign import ccall "vkFlushMappedMemoryRanges" vkFlushMappedMemoryRanges ::
 
 -- ** MemoryMapFlags
 -- | Opaque flag
-newtype MemoryMapFlags = MemoryMapFlags VkFlags
+newtype MemoryMapFlags = MemoryMapFlags Flags
   deriving (Eq, Storable)
 
 type PFN_vkInternalAllocationNotification = FunPtr
@@ -179,7 +179,7 @@ type PFN_vkFreeFunction = FunPtr (Ptr Void -> Ptr Void -> IO ())
 
 -- ** vkGetDeviceMemoryCommitment
 foreign import ccall "vkGetDeviceMemoryCommitment" vkGetDeviceMemoryCommitment ::
-  Device -> DeviceMemory -> Ptr VkDeviceSize -> IO ()
+  Device -> DeviceMemory -> Ptr DeviceSize -> IO ()
 
 -- ** vkAllocateMemory
 foreign import ccall "vkAllocateMemory" vkAllocateMemory ::
@@ -192,8 +192,8 @@ data MappedMemoryRange =
   MappedMemoryRange{ sType :: StructureType 
                    , pNext :: Ptr Void 
                    , memory :: DeviceMemory 
-                   , offset :: VkDeviceSize 
-                   , size :: VkDeviceSize 
+                   , offset :: DeviceSize 
+                   , size :: DeviceSize 
                    }
   deriving (Eq)
 
@@ -216,7 +216,7 @@ instance Storable MappedMemoryRange where
 data MemoryAllocateInfo =
   MemoryAllocateInfo{ sType :: StructureType 
                     , pNext :: Ptr Void 
-                    , allocationSize :: VkDeviceSize 
+                    , allocationSize :: DeviceSize 
                     , memoryTypeIndex :: Word32 
                     }
   deriving (Eq)

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -42,8 +42,8 @@ import Foreign.C.Types( CSize(..)
 newtype DeviceMemory = DeviceMemory Word64
   deriving (Eq, Storable)
 
--- ** vkMapMemory
-foreign import ccall "vkMapMemory" vkMapMemory ::
+-- ** mapMemory
+foreign import ccall "vkMapMemory" mapMemory ::
   Device ->
   DeviceMemory ->
     DeviceSize ->
@@ -81,8 +81,8 @@ instance Storable AllocationCallbacks where
                 *> poke (ptr `plusPtr` 40) (pfnInternalFree (poked :: AllocationCallbacks))
 
 
--- ** vkInvalidateMappedMemoryRanges
-foreign import ccall "vkInvalidateMappedMemoryRanges" vkInvalidateMappedMemoryRanges ::
+-- ** invalidateMappedMemoryRanges
+foreign import ccall "vkInvalidateMappedMemoryRanges" invalidateMappedMemoryRanges ::
   Device -> Word32 -> Ptr MappedMemoryRange -> IO Result
 
 -- ** SystemAllocationScope
@@ -123,8 +123,8 @@ pattern VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = SystemAllocationScope 3
 
 pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = SystemAllocationScope 4
 
--- ** vkFlushMappedMemoryRanges
-foreign import ccall "vkFlushMappedMemoryRanges" vkFlushMappedMemoryRanges ::
+-- ** flushMappedMemoryRanges
+foreign import ccall "vkFlushMappedMemoryRanges" flushMappedMemoryRanges ::
   Device -> Word32 -> Ptr MappedMemoryRange -> IO Result
 
 -- ** MemoryMapFlags
@@ -136,8 +136,8 @@ type PFN_vkInternalAllocationNotification = FunPtr
   (Ptr Void ->
      CSize -> InternalAllocationType -> SystemAllocationScope -> IO ())
 
--- ** vkFreeMemory
-foreign import ccall "vkFreeMemory" vkFreeMemory ::
+-- ** freeMemory
+foreign import ccall "vkFreeMemory" freeMemory ::
   Device -> DeviceMemory -> Ptr AllocationCallbacks -> IO ()
 
 type PFN_vkReallocationFunction = FunPtr
@@ -145,8 +145,8 @@ type PFN_vkReallocationFunction = FunPtr
      Ptr Void ->
        CSize -> CSize -> SystemAllocationScope -> IO (Ptr Void))
 
--- ** vkUnmapMemory
-foreign import ccall "vkUnmapMemory" vkUnmapMemory ::
+-- ** unmapMemory
+foreign import ccall "vkUnmapMemory" unmapMemory ::
   Device -> DeviceMemory -> IO ()
 
 type PFN_vkAllocationFunction = FunPtr
@@ -177,12 +177,12 @@ pattern VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = InternalAllocationType 0
 
 type PFN_vkFreeFunction = FunPtr (Ptr Void -> Ptr Void -> IO ())
 
--- ** vkGetDeviceMemoryCommitment
-foreign import ccall "vkGetDeviceMemoryCommitment" vkGetDeviceMemoryCommitment ::
+-- ** getDeviceMemoryCommitment
+foreign import ccall "vkGetDeviceMemoryCommitment" getDeviceMemoryCommitment ::
   Device -> DeviceMemory -> Ptr DeviceSize -> IO ()
 
--- ** vkAllocateMemory
-foreign import ccall "vkAllocateMemory" vkAllocateMemory ::
+-- ** allocateMemory
+foreign import ccall "vkAllocateMemory" allocateMemory ::
   Device ->
   Ptr MemoryAllocateInfo ->
     Ptr AllocationCallbacks -> Ptr DeviceMemory -> IO Result

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -4,39 +4,26 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Memory where
 
-import {-# SOURCE #-} Graphics.Vulkan.Device( Device
+import {-# SOURCE #-} Graphics.Vulkan.Device( Device(..)
                                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
-                  , FunPtr
+import Foreign.Ptr( Ptr(..)
+                  , FunPtr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
                )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( PFN_vkAllocationFunction
-                             , VkMemoryMapFlags
-                             , VkSystemAllocationScope
-                             , PFN_vkFreeFunction
-                             , PFN_vkReallocationFunction
-                             , VkInternalAllocationType
-                             , VkAllocationCallbacks
-                             , DeviceMemory
-                             , VkMappedMemoryRange
-                             , VkMemoryAllocateInfo
-                             , PFN_vkInternalFreeNotification
-                             , PFN_vkInternalAllocationNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -44,12 +31,12 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
                            )
-import Foreign.C.Types( CSize
+import Foreign.C.Types( CSize(..)
                       )
 
 newtype DeviceMemory = DeviceMemory Word64

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -55,36 +55,36 @@ type PFN_vkInternalFreeNotification = FunPtr
        VkInternalAllocationType -> VkSystemAllocationScope -> IO ())
 
 
-data VkAllocationCallbacks =
-  VkAllocationCallbacks{ pUserData :: Ptr Void 
-                       , pfnAllocation :: PFN_vkAllocationFunction 
-                       , pfnReallocation :: PFN_vkReallocationFunction 
-                       , pfnFree :: PFN_vkFreeFunction 
-                       , pfnInternalAllocation :: PFN_vkInternalAllocationNotification 
-                       , pfnInternalFree :: PFN_vkInternalFreeNotification 
-                       }
+data AllocationCallbacks =
+  AllocationCallbacks{ pUserData :: Ptr Void 
+                     , pfnAllocation :: PFN_vkAllocationFunction 
+                     , pfnReallocation :: PFN_vkReallocationFunction 
+                     , pfnFree :: PFN_vkFreeFunction 
+                     , pfnInternalAllocation :: PFN_vkInternalAllocationNotification 
+                     , pfnInternalFree :: PFN_vkInternalFreeNotification 
+                     }
   deriving (Eq)
 
-instance Storable VkAllocationCallbacks where
+instance Storable AllocationCallbacks where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkAllocationCallbacks <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 24)
-                                   <*> peek (ptr `plusPtr` 32)
-                                   <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (pUserData (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 8) (pfnAllocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 16) (pfnReallocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 24) (pfnFree (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 32) (pfnInternalAllocation (poked :: VkAllocationCallbacks))
-                *> poke (ptr `plusPtr` 40) (pfnInternalFree (poked :: VkAllocationCallbacks))
+  peek ptr = AllocationCallbacks <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (pUserData (poked :: AllocationCallbacks))
+                *> poke (ptr `plusPtr` 8) (pfnAllocation (poked :: AllocationCallbacks))
+                *> poke (ptr `plusPtr` 16) (pfnReallocation (poked :: AllocationCallbacks))
+                *> poke (ptr `plusPtr` 24) (pfnFree (poked :: AllocationCallbacks))
+                *> poke (ptr `plusPtr` 32) (pfnInternalAllocation (poked :: AllocationCallbacks))
+                *> poke (ptr `plusPtr` 40) (pfnInternalFree (poked :: AllocationCallbacks))
 
 
 -- ** vkInvalidateMappedMemoryRanges
 foreign import ccall "vkInvalidateMappedMemoryRanges" vkInvalidateMappedMemoryRanges ::
-  Device -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr MappedMemoryRange -> IO VkResult
 
 -- ** VkSystemAllocationScope
 
@@ -126,7 +126,7 @@ pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = VkSystemAllocationScope 4
 
 -- ** vkFlushMappedMemoryRanges
 foreign import ccall "vkFlushMappedMemoryRanges" vkFlushMappedMemoryRanges ::
-  Device -> Word32 -> Ptr VkMappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr MappedMemoryRange -> IO VkResult
 
 -- ** VkMemoryMapFlags
 -- | Opaque flag
@@ -140,7 +140,7 @@ type PFN_vkInternalAllocationNotification = FunPtr
 
 -- ** vkFreeMemory
 foreign import ccall "vkFreeMemory" vkFreeMemory ::
-  Device -> DeviceMemory -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> DeviceMemory -> Ptr AllocationCallbacks -> IO ()
 
 type PFN_vkReallocationFunction = FunPtr
   (Ptr Void ->
@@ -186,53 +186,53 @@ foreign import ccall "vkGetDeviceMemoryCommitment" vkGetDeviceMemoryCommitment :
 -- ** vkAllocateMemory
 foreign import ccall "vkAllocateMemory" vkAllocateMemory ::
   Device ->
-  Ptr VkMemoryAllocateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr DeviceMemory -> IO VkResult
+  Ptr MemoryAllocateInfo ->
+    Ptr AllocationCallbacks -> Ptr DeviceMemory -> IO VkResult
 
 
-data VkMappedMemoryRange =
-  VkMappedMemoryRange{ sType :: VkStructureType 
-                     , pNext :: Ptr Void 
-                     , memory :: DeviceMemory 
-                     , offset :: VkDeviceSize 
-                     , size :: VkDeviceSize 
-                     }
+data MappedMemoryRange =
+  MappedMemoryRange{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , memory :: DeviceMemory 
+                   , offset :: VkDeviceSize 
+                   , size :: VkDeviceSize 
+                   }
   deriving (Eq)
 
-instance Storable VkMappedMemoryRange where
+instance Storable MappedMemoryRange where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkMappedMemoryRange <$> peek (ptr `plusPtr` 0)
-                                 <*> peek (ptr `plusPtr` 8)
-                                 <*> peek (ptr `plusPtr` 16)
-                                 <*> peek (ptr `plusPtr` 24)
-                                 <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 16) (memory (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 24) (offset (poked :: VkMappedMemoryRange))
-                *> poke (ptr `plusPtr` 32) (size (poked :: VkMappedMemoryRange))
+  peek ptr = MappedMemoryRange <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 24)
+                               <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: MappedMemoryRange))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: MappedMemoryRange))
+                *> poke (ptr `plusPtr` 16) (memory (poked :: MappedMemoryRange))
+                *> poke (ptr `plusPtr` 24) (offset (poked :: MappedMemoryRange))
+                *> poke (ptr `plusPtr` 32) (size (poked :: MappedMemoryRange))
 
 
 
-data VkMemoryAllocateInfo =
-  VkMemoryAllocateInfo{ sType :: VkStructureType 
-                      , pNext :: Ptr Void 
-                      , allocationSize :: VkDeviceSize 
-                      , memoryTypeIndex :: Word32 
-                      }
+data MemoryAllocateInfo =
+  MemoryAllocateInfo{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , allocationSize :: VkDeviceSize 
+                    , memoryTypeIndex :: Word32 
+                    }
   deriving (Eq)
 
-instance Storable VkMemoryAllocateInfo where
+instance Storable MemoryAllocateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkMemoryAllocateInfo <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 16) (allocationSize (poked :: VkMemoryAllocateInfo))
-                *> poke (ptr `plusPtr` 24) (memoryTypeIndex (poked :: VkMemoryAllocateInfo))
+  peek ptr = MemoryAllocateInfo <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: MemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: MemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 16) (allocationSize (poked :: MemoryAllocateInfo))
+                *> poke (ptr `plusPtr` 24) (memoryTypeIndex (poked :: MemoryAllocateInfo))
 
 

--- a/src/Graphics/Vulkan/Memory.hs
+++ b/src/Graphics/Vulkan/Memory.hs
@@ -31,9 +31,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 import Foreign.C.Types( CSize(..)
@@ -47,12 +47,11 @@ foreign import ccall "vkMapMemory" vkMapMemory ::
   Device ->
   DeviceMemory ->
     VkDeviceSize ->
-      VkDeviceSize -> VkMemoryMapFlags -> Ptr (Ptr Void) -> IO VkResult
+      VkDeviceSize -> MemoryMapFlags -> Ptr (Ptr Void) -> IO Result
 
 type PFN_vkInternalFreeNotification = FunPtr
   (Ptr Void ->
-     CSize ->
-       VkInternalAllocationType -> VkSystemAllocationScope -> IO ())
+     CSize -> InternalAllocationType -> SystemAllocationScope -> IO ())
 
 
 data AllocationCallbacks =
@@ -84,22 +83,22 @@ instance Storable AllocationCallbacks where
 
 -- ** vkInvalidateMappedMemoryRanges
 foreign import ccall "vkInvalidateMappedMemoryRanges" vkInvalidateMappedMemoryRanges ::
-  Device -> Word32 -> Ptr MappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr MappedMemoryRange -> IO Result
 
--- ** VkSystemAllocationScope
+-- ** SystemAllocationScope
 
-newtype VkSystemAllocationScope = VkSystemAllocationScope Int32
+newtype SystemAllocationScope = SystemAllocationScope Int32
   deriving (Eq, Storable)
 
-instance Show VkSystemAllocationScope where
+instance Show SystemAllocationScope where
   showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = showString "VK_SYSTEM_ALLOCATION_SCOPE_COMMAND"
   showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = showString "VK_SYSTEM_ALLOCATION_SCOPE_OBJECT"
   showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_CACHE = showString "VK_SYSTEM_ALLOCATION_SCOPE_CACHE"
   showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = showString "VK_SYSTEM_ALLOCATION_SCOPE_DEVICE"
   showsPrec _ VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = showString "VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE"
-  showsPrec p (VkSystemAllocationScope x) = showParen (p >= 11) (showString "VkSystemAllocationScope " . showsPrec 11 x)
+  showsPrec p (SystemAllocationScope x) = showParen (p >= 11) (showString "SystemAllocationScope " . showsPrec 11 x)
 
-instance Read VkSystemAllocationScope where
+instance Read SystemAllocationScope where
   readPrec = parens ( choose [ ("VK_SYSTEM_ALLOCATION_SCOPE_COMMAND", pure VK_SYSTEM_ALLOCATION_SCOPE_COMMAND)
                              , ("VK_SYSTEM_ALLOCATION_SCOPE_OBJECT", pure VK_SYSTEM_ALLOCATION_SCOPE_OBJECT)
                              , ("VK_SYSTEM_ALLOCATION_SCOPE_CACHE", pure VK_SYSTEM_ALLOCATION_SCOPE_CACHE)
@@ -107,36 +106,35 @@ instance Read VkSystemAllocationScope where
                              , ("VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE", pure VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSystemAllocationScope")
+                        expectP (Ident "SystemAllocationScope")
                         v <- step readPrec
-                        pure (VkSystemAllocationScope v)
+                        pure (SystemAllocationScope v)
                         )
                     )
 
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = VkSystemAllocationScope 0
+pattern VK_SYSTEM_ALLOCATION_SCOPE_COMMAND = SystemAllocationScope 0
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = VkSystemAllocationScope 1
+pattern VK_SYSTEM_ALLOCATION_SCOPE_OBJECT = SystemAllocationScope 1
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_CACHE = VkSystemAllocationScope 2
+pattern VK_SYSTEM_ALLOCATION_SCOPE_CACHE = SystemAllocationScope 2
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = VkSystemAllocationScope 3
+pattern VK_SYSTEM_ALLOCATION_SCOPE_DEVICE = SystemAllocationScope 3
 
-pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = VkSystemAllocationScope 4
+pattern VK_SYSTEM_ALLOCATION_SCOPE_INSTANCE = SystemAllocationScope 4
 
 -- ** vkFlushMappedMemoryRanges
 foreign import ccall "vkFlushMappedMemoryRanges" vkFlushMappedMemoryRanges ::
-  Device -> Word32 -> Ptr MappedMemoryRange -> IO VkResult
+  Device -> Word32 -> Ptr MappedMemoryRange -> IO Result
 
--- ** VkMemoryMapFlags
+-- ** MemoryMapFlags
 -- | Opaque flag
-newtype VkMemoryMapFlags = VkMemoryMapFlags VkFlags
+newtype MemoryMapFlags = MemoryMapFlags VkFlags
   deriving (Eq, Storable)
 
 type PFN_vkInternalAllocationNotification = FunPtr
   (Ptr Void ->
-     CSize ->
-       VkInternalAllocationType -> VkSystemAllocationScope -> IO ())
+     CSize -> InternalAllocationType -> SystemAllocationScope -> IO ())
 
 -- ** vkFreeMemory
 foreign import ccall "vkFreeMemory" vkFreeMemory ::
@@ -145,7 +143,7 @@ foreign import ccall "vkFreeMemory" vkFreeMemory ::
 type PFN_vkReallocationFunction = FunPtr
   (Ptr Void ->
      Ptr Void ->
-       CSize -> CSize -> VkSystemAllocationScope -> IO (Ptr Void))
+       CSize -> CSize -> SystemAllocationScope -> IO (Ptr Void))
 
 -- ** vkUnmapMemory
 foreign import ccall "vkUnmapMemory" vkUnmapMemory ::
@@ -153,29 +151,29 @@ foreign import ccall "vkUnmapMemory" vkUnmapMemory ::
 
 type PFN_vkAllocationFunction = FunPtr
   (Ptr Void ->
-     CSize -> CSize -> VkSystemAllocationScope -> IO (Ptr Void))
+     CSize -> CSize -> SystemAllocationScope -> IO (Ptr Void))
 
--- ** VkInternalAllocationType
+-- ** InternalAllocationType
 
-newtype VkInternalAllocationType = VkInternalAllocationType Int32
+newtype InternalAllocationType = InternalAllocationType Int32
   deriving (Eq, Storable)
 
-instance Show VkInternalAllocationType where
+instance Show InternalAllocationType where
   showsPrec _ VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = showString "VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE"
-  showsPrec p (VkInternalAllocationType x) = showParen (p >= 11) (showString "VkInternalAllocationType " . showsPrec 11 x)
+  showsPrec p (InternalAllocationType x) = showParen (p >= 11) (showString "InternalAllocationType " . showsPrec 11 x)
 
-instance Read VkInternalAllocationType where
+instance Read InternalAllocationType where
   readPrec = parens ( choose [ ("VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE", pure VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkInternalAllocationType")
+                        expectP (Ident "InternalAllocationType")
                         v <- step readPrec
-                        pure (VkInternalAllocationType v)
+                        pure (InternalAllocationType v)
                         )
                     )
 
 
-pattern VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = VkInternalAllocationType 0
+pattern VK_INTERNAL_ALLOCATION_TYPE_EXECUTABLE = InternalAllocationType 0
 
 type PFN_vkFreeFunction = FunPtr (Ptr Void -> Ptr Void -> IO ())
 
@@ -187,11 +185,11 @@ foreign import ccall "vkGetDeviceMemoryCommitment" vkGetDeviceMemoryCommitment :
 foreign import ccall "vkAllocateMemory" vkAllocateMemory ::
   Device ->
   Ptr MemoryAllocateInfo ->
-    Ptr AllocationCallbacks -> Ptr DeviceMemory -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr DeviceMemory -> IO Result
 
 
 data MappedMemoryRange =
-  MappedMemoryRange{ sType :: VkStructureType 
+  MappedMemoryRange{ sType :: StructureType 
                    , pNext :: Ptr Void 
                    , memory :: DeviceMemory 
                    , offset :: VkDeviceSize 
@@ -216,7 +214,7 @@ instance Storable MappedMemoryRange where
 
 
 data MemoryAllocateInfo =
-  MemoryAllocateInfo{ sType :: VkStructureType 
+  MemoryAllocateInfo{ sType :: StructureType 
                     , pNext :: Ptr Void 
                     , allocationSize :: VkDeviceSize 
                     , memoryTypeIndex :: Word32 

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -2,9 +2,9 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.MemoryManagement where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -16,9 +16,9 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkDeviceMemory(..)
+import Graphics.Vulkan.Memory( DeviceMemory(..)
                              )
-import Graphics.Vulkan.Image( VkImage(..)
+import Graphics.Vulkan.Image( Image(..)
                             )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkDeviceSize(..)
@@ -26,13 +26,13 @@ import Graphics.Vulkan.Core( VkResult(..)
 
 -- ** vkGetImageMemoryRequirements
 foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements ::
-  VkDevice -> VkImage -> Ptr VkMemoryRequirements -> IO ()
+  Device -> Image -> Ptr VkMemoryRequirements -> IO ()
 
 
 data VkMemoryRequirements =
-  VkMemoryRequirements{ vkSize :: VkDeviceSize 
-                      , vkAlignment :: VkDeviceSize 
-                      , vkMemoryTypeBits :: Word32 
+  VkMemoryRequirements{ size :: VkDeviceSize 
+                      , _alignment :: VkDeviceSize 
+                      , memoryTypeBits :: Word32 
                       }
   deriving (Eq)
 
@@ -42,22 +42,20 @@ instance Storable VkMemoryRequirements where
   peek ptr = VkMemoryRequirements <$> peek (ptr `plusPtr` 0)
                                   <*> peek (ptr `plusPtr` 8)
                                   <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSize (poked :: VkMemoryRequirements))
-                *> poke (ptr `plusPtr` 8) (vkAlignment (poked :: VkMemoryRequirements))
-                *> poke (ptr `plusPtr` 16) (vkMemoryTypeBits (poked :: VkMemoryRequirements))
+  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: VkMemoryRequirements))
+                *> poke (ptr `plusPtr` 8) (_alignment (poked :: VkMemoryRequirements))
+                *> poke (ptr `plusPtr` 16) (memoryTypeBits (poked :: VkMemoryRequirements))
 
 
 -- ** vkGetBufferMemoryRequirements
 foreign import ccall "vkGetBufferMemoryRequirements" vkGetBufferMemoryRequirements ::
-  VkDevice -> VkBuffer -> Ptr VkMemoryRequirements -> IO ()
+  Device -> Buffer -> Ptr VkMemoryRequirements -> IO ()
 
 -- ** vkBindBufferMemory
 foreign import ccall "vkBindBufferMemory" vkBindBufferMemory ::
-  VkDevice ->
-  VkBuffer -> VkDeviceMemory -> VkDeviceSize -> IO VkResult
+  Device -> Buffer -> DeviceMemory -> VkDeviceSize -> IO VkResult
 
 -- ** vkBindImageMemory
 foreign import ccall "vkBindImageMemory" vkBindImageMemory ::
-  VkDevice ->
-  VkImage -> VkDeviceMemory -> VkDeviceSize -> IO VkResult
+  Device -> Image -> DeviceMemory -> VkDeviceSize -> IO VkResult
 

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -2,27 +2,13 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.MemoryManagement where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
-                )
-import Graphics.Vulkan.Memory( DeviceMemory(..)
-                             )
-import Graphics.Vulkan.Image( Image(..)
-                            )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           )
 
 -- ** vkGetImageMemoryRequirements
 foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements ::

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -17,7 +17,7 @@ import Graphics.Vulkan.Memory( DeviceMemory(..)
                              )
 import Graphics.Vulkan.Image( Image(..)
                             )
-import Graphics.Vulkan.Core( VkResult(..)
+import Graphics.Vulkan.Core( Result(..)
                            , VkDeviceSize(..)
                            )
 
@@ -50,9 +50,9 @@ foreign import ccall "vkGetBufferMemoryRequirements" vkGetBufferMemoryRequiremen
 
 -- ** vkBindBufferMemory
 foreign import ccall "vkBindBufferMemory" vkBindBufferMemory ::
-  Device -> Buffer -> DeviceMemory -> VkDeviceSize -> IO VkResult
+  Device -> Buffer -> DeviceMemory -> VkDeviceSize -> IO Result
 
 -- ** vkBindImageMemory
 foreign import ccall "vkBindImageMemory" vkBindImageMemory ::
-  Device -> Image -> DeviceMemory -> VkDeviceSize -> IO VkResult
+  Device -> Image -> DeviceMemory -> VkDeviceSize -> IO Result
 

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -21,8 +21,8 @@ import Graphics.Vulkan.Core( Result(..)
                            , DeviceSize(..)
                            )
 
--- ** vkGetImageMemoryRequirements
-foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements ::
+-- ** getImageMemoryRequirements
+foreign import ccall "vkGetImageMemoryRequirements" getImageMemoryRequirements ::
   Device -> Image -> Ptr MemoryRequirements -> IO ()
 
 
@@ -44,15 +44,15 @@ instance Storable MemoryRequirements where
                 *> poke (ptr `plusPtr` 16) (memoryTypeBits (poked :: MemoryRequirements))
 
 
--- ** vkGetBufferMemoryRequirements
-foreign import ccall "vkGetBufferMemoryRequirements" vkGetBufferMemoryRequirements ::
+-- ** getBufferMemoryRequirements
+foreign import ccall "vkGetBufferMemoryRequirements" getBufferMemoryRequirements ::
   Device -> Buffer -> Ptr MemoryRequirements -> IO ()
 
--- ** vkBindBufferMemory
-foreign import ccall "vkBindBufferMemory" vkBindBufferMemory ::
+-- ** bindBufferMemory
+foreign import ccall "vkBindBufferMemory" bindBufferMemory ::
   Device -> Buffer -> DeviceMemory -> DeviceSize -> IO Result
 
--- ** vkBindImageMemory
-foreign import ccall "vkBindImageMemory" vkBindImageMemory ::
+-- ** bindImageMemory
+foreign import ccall "vkBindImageMemory" bindImageMemory ::
   Device -> Image -> DeviceMemory -> DeviceSize -> IO Result
 

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -2,25 +2,23 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.MemoryManagement where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.MemoryManagement( VkMemoryRequirements
-                                       )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Memory( DeviceMemory
+import Graphics.Vulkan.Memory( DeviceMemory(..)
                              )
-import Graphics.Vulkan.Image( Image
+import Graphics.Vulkan.Image( Image(..)
                             )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkDeviceSize(..)
                            )
 
 -- ** vkGetImageMemoryRequirements

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -2,13 +2,26 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.MemoryManagement where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Buffer( Buffer
+                             )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.MemoryManagement( VkMemoryRequirements
+                                       )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Memory( DeviceMemory
+                             )
+import Graphics.Vulkan.Image( Image
+                            )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           )
 
 -- ** vkGetImageMemoryRequirements
 foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements ::

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -18,7 +18,7 @@ import Graphics.Vulkan.Memory( DeviceMemory(..)
 import Graphics.Vulkan.Image( Image(..)
                             )
 import Graphics.Vulkan.Core( Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
                            )
 
 -- ** vkGetImageMemoryRequirements
@@ -27,8 +27,8 @@ foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements
 
 
 data MemoryRequirements =
-  MemoryRequirements{ size :: VkDeviceSize 
-                    , _alignment :: VkDeviceSize 
+  MemoryRequirements{ size :: DeviceSize 
+                    , _alignment :: DeviceSize 
                     , memoryTypeBits :: Word32 
                     }
   deriving (Eq)
@@ -50,9 +50,9 @@ foreign import ccall "vkGetBufferMemoryRequirements" vkGetBufferMemoryRequiremen
 
 -- ** vkBindBufferMemory
 foreign import ccall "vkBindBufferMemory" vkBindBufferMemory ::
-  Device -> Buffer -> DeviceMemory -> VkDeviceSize -> IO Result
+  Device -> Buffer -> DeviceMemory -> DeviceSize -> IO Result
 
 -- ** vkBindImageMemory
 foreign import ccall "vkBindImageMemory" vkBindImageMemory ::
-  Device -> Image -> DeviceMemory -> VkDeviceSize -> IO Result
+  Device -> Image -> DeviceMemory -> DeviceSize -> IO Result
 

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -23,30 +23,30 @@ import Graphics.Vulkan.Core( VkResult(..)
 
 -- ** vkGetImageMemoryRequirements
 foreign import ccall "vkGetImageMemoryRequirements" vkGetImageMemoryRequirements ::
-  Device -> Image -> Ptr VkMemoryRequirements -> IO ()
+  Device -> Image -> Ptr MemoryRequirements -> IO ()
 
 
-data VkMemoryRequirements =
-  VkMemoryRequirements{ size :: VkDeviceSize 
-                      , _alignment :: VkDeviceSize 
-                      , memoryTypeBits :: Word32 
-                      }
+data MemoryRequirements =
+  MemoryRequirements{ size :: VkDeviceSize 
+                    , _alignment :: VkDeviceSize 
+                    , memoryTypeBits :: Word32 
+                    }
   deriving (Eq)
 
-instance Storable VkMemoryRequirements where
+instance Storable MemoryRequirements where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkMemoryRequirements <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: VkMemoryRequirements))
-                *> poke (ptr `plusPtr` 8) (_alignment (poked :: VkMemoryRequirements))
-                *> poke (ptr `plusPtr` 16) (memoryTypeBits (poked :: VkMemoryRequirements))
+  peek ptr = MemoryRequirements <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (size (poked :: MemoryRequirements))
+                *> poke (ptr `plusPtr` 8) (_alignment (poked :: MemoryRequirements))
+                *> poke (ptr `plusPtr` 16) (memoryTypeBits (poked :: MemoryRequirements))
 
 
 -- ** vkGetBufferMemoryRequirements
 foreign import ccall "vkGetBufferMemoryRequirements" vkGetBufferMemoryRequirements ::
-  Device -> Buffer -> Ptr VkMemoryRequirements -> IO ()
+  Device -> Buffer -> Ptr MemoryRequirements -> IO ()
 
 -- ** vkBindBufferMemory
 foreign import ccall "vkBindBufferMemory" vkBindBufferMemory ::

--- a/src/Graphics/Vulkan/MemoryManagement.hs
+++ b/src/Graphics/Vulkan/MemoryManagement.hs
@@ -31,7 +31,7 @@ data MemoryRequirements =
                     , _alignment :: DeviceSize 
                     , memoryTypeBits :: Word32 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MemoryRequirements where
   sizeOf ~_ = 24

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -2,13 +2,7 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.OtherTypes where
 
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
-import Graphics.Vulkan.Pass( VkAccessFlags(..)
-                           , VkAccessFlagBits(..)
-                           )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -19,16 +13,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Image( Image(..)
-                            , VkImageLayout(..)
-                            , VkImageAspectFlagBits(..)
-                            , VkImageSubresourceRange(..)
-                            , VkImageAspectFlags(..)
-                            )
-import Graphics.Vulkan.Core( VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 
 
 data VkBufferMemoryBarrier =

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.OtherTypes where
 
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Graphics.Vulkan.Pass( VkAccessFlags(..)
                            , VkAccessFlagBits(..)
@@ -19,7 +19,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Image( VkImage(..)
+import Graphics.Vulkan.Image( Image(..)
                             , VkImageLayout(..)
                             , VkImageAspectFlagBits(..)
                             , VkImageSubresourceRange(..)
@@ -32,15 +32,15 @@ import Graphics.Vulkan.Core( VkDeviceSize(..)
 
 
 data VkBufferMemoryBarrier =
-  VkBufferMemoryBarrier{ vkSType :: VkStructureType 
-                       , vkPNext :: Ptr Void 
-                       , vkSrcAccessMask :: VkAccessFlags 
-                       , vkDstAccessMask :: VkAccessFlags 
-                       , vkSrcQueueFamilyIndex :: Word32 
-                       , vkDstQueueFamilyIndex :: Word32 
-                       , vkBuffer :: VkBuffer 
-                       , vkOffset :: VkDeviceSize 
-                       , vkSize :: VkDeviceSize 
+  VkBufferMemoryBarrier{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , srcAccessMask :: VkAccessFlags 
+                       , dstAccessMask :: VkAccessFlags 
+                       , srcQueueFamilyIndex :: Word32 
+                       , dstQueueFamilyIndex :: Word32 
+                       , buffer :: Buffer 
+                       , offset :: VkDeviceSize 
+                       , size :: VkDeviceSize 
                        }
   deriving (Eq)
 
@@ -56,24 +56,24 @@ instance Storable VkBufferMemoryBarrier where
                                    <*> peek (ptr `plusPtr` 32)
                                    <*> peek (ptr `plusPtr` 40)
                                    <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (vkSrcAccessMask (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (vkDstAccessMask (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 24) (vkSrcQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 28) (vkDstQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 32) (vkBuffer (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 40) (vkOffset (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 48) (vkSize (poked :: VkBufferMemoryBarrier))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 24) (srcQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 28) (dstQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 32) (buffer (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 40) (offset (poked :: VkBufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 48) (size (poked :: VkBufferMemoryBarrier))
 
 
 
 data VkDrawIndexedIndirectCommand =
-  VkDrawIndexedIndirectCommand{ vkIndexCount :: Word32 
-                              , vkInstanceCount :: Word32 
-                              , vkFirstIndex :: Word32 
-                              , vkVertexOffset :: Int32 
-                              , vkFirstInstance :: Word32 
+  VkDrawIndexedIndirectCommand{ indexCount :: Word32 
+                              , instanceCount :: Word32 
+                              , firstIndex :: Word32 
+                              , vertexOffset :: Int32 
+                              , firstInstance :: Word32 
                               }
   deriving (Eq)
 
@@ -85,25 +85,25 @@ instance Storable VkDrawIndexedIndirectCommand where
                                           <*> peek (ptr `plusPtr` 8)
                                           <*> peek (ptr `plusPtr` 12)
                                           <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkIndexCount (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (vkInstanceCount (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (vkFirstIndex (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 12) (vkVertexOffset (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 16) (vkFirstInstance (poked :: VkDrawIndexedIndirectCommand))
+  poke ptr poked = poke (ptr `plusPtr` 0) (indexCount (poked :: VkDrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: VkDrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (firstIndex (poked :: VkDrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 12) (vertexOffset (poked :: VkDrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 16) (firstInstance (poked :: VkDrawIndexedIndirectCommand))
 
 
 
 data VkImageMemoryBarrier =
-  VkImageMemoryBarrier{ vkSType :: VkStructureType 
-                      , vkPNext :: Ptr Void 
-                      , vkSrcAccessMask :: VkAccessFlags 
-                      , vkDstAccessMask :: VkAccessFlags 
-                      , vkOldLayout :: VkImageLayout 
-                      , vkNewLayout :: VkImageLayout 
-                      , vkSrcQueueFamilyIndex :: Word32 
-                      , vkDstQueueFamilyIndex :: Word32 
-                      , vkImage :: VkImage 
-                      , vkSubresourceRange :: VkImageSubresourceRange 
+  VkImageMemoryBarrier{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , srcAccessMask :: VkAccessFlags 
+                      , dstAccessMask :: VkAccessFlags 
+                      , oldLayout :: VkImageLayout 
+                      , newLayout :: VkImageLayout 
+                      , srcQueueFamilyIndex :: Word32 
+                      , dstQueueFamilyIndex :: Word32 
+                      , image :: Image 
+                      , subresourceRange :: VkImageSubresourceRange 
                       }
   deriving (Eq)
 
@@ -120,24 +120,24 @@ instance Storable VkImageMemoryBarrier where
                                   <*> peek (ptr `plusPtr` 36)
                                   <*> peek (ptr `plusPtr` 40)
                                   <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (vkSrcAccessMask (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (vkDstAccessMask (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 24) (vkOldLayout (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 28) (vkNewLayout (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 32) (vkSrcQueueFamilyIndex (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 36) (vkDstQueueFamilyIndex (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 40) (vkImage (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 48) (vkSubresourceRange (poked :: VkImageMemoryBarrier))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 24) (oldLayout (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 28) (newLayout (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 32) (srcQueueFamilyIndex (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 36) (dstQueueFamilyIndex (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 40) (image (poked :: VkImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 48) (subresourceRange (poked :: VkImageMemoryBarrier))
 
 
 
 data VkMemoryBarrier =
-  VkMemoryBarrier{ vkSType :: VkStructureType 
-                 , vkPNext :: Ptr Void 
-                 , vkSrcAccessMask :: VkAccessFlags 
-                 , vkDstAccessMask :: VkAccessFlags 
+  VkMemoryBarrier{ sType :: VkStructureType 
+                 , pNext :: Ptr Void 
+                 , srcAccessMask :: VkAccessFlags 
+                 , dstAccessMask :: VkAccessFlags 
                  }
   deriving (Eq)
 
@@ -148,18 +148,18 @@ instance Storable VkMemoryBarrier where
                              <*> peek (ptr `plusPtr` 8)
                              <*> peek (ptr `plusPtr` 16)
                              <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (vkSrcAccessMask (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (vkDstAccessMask (poked :: VkMemoryBarrier))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkMemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkMemoryBarrier))
 
 
 
 data VkDrawIndirectCommand =
-  VkDrawIndirectCommand{ vkVertexCount :: Word32 
-                       , vkInstanceCount :: Word32 
-                       , vkFirstVertex :: Word32 
-                       , vkFirstInstance :: Word32 
+  VkDrawIndirectCommand{ vertexCount :: Word32 
+                       , instanceCount :: Word32 
+                       , firstVertex :: Word32 
+                       , firstInstance :: Word32 
                        }
   deriving (Eq)
 
@@ -170,17 +170,17 @@ instance Storable VkDrawIndirectCommand where
                                    <*> peek (ptr `plusPtr` 4)
                                    <*> peek (ptr `plusPtr` 8)
                                    <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkVertexCount (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (vkInstanceCount (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (vkFirstVertex (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 12) (vkFirstInstance (poked :: VkDrawIndirectCommand))
+  poke ptr poked = poke (ptr `plusPtr` 0) (vertexCount (poked :: VkDrawIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: VkDrawIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (firstVertex (poked :: VkDrawIndirectCommand))
+                *> poke (ptr `plusPtr` 12) (firstInstance (poked :: VkDrawIndirectCommand))
 
 
 
 data VkDispatchIndirectCommand =
-  VkDispatchIndirectCommand{ vkX :: Word32 
-                           , vkY :: Word32 
-                           , vkZ :: Word32 
+  VkDispatchIndirectCommand{ x :: Word32 
+                           , y :: Word32 
+                           , z :: Word32 
                            }
   deriving (Eq)
 
@@ -190,8 +190,8 @@ instance Storable VkDispatchIndirectCommand where
   peek ptr = VkDispatchIndirectCommand <$> peek (ptr `plusPtr` 0)
                                        <*> peek (ptr `plusPtr` 4)
                                        <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkX (poked :: VkDispatchIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (vkY (poked :: VkDispatchIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (vkZ (poked :: VkDispatchIndirectCommand))
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkDispatchIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (y (poked :: VkDispatchIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (z (poked :: VkDispatchIndirectCommand))
 
 

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -37,7 +37,7 @@ data BufferMemoryBarrier =
                      , offset :: DeviceSize 
                      , size :: DeviceSize 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BufferMemoryBarrier where
   sizeOf ~_ = 56
@@ -70,7 +70,7 @@ data DrawIndexedIndirectCommand =
                             , vertexOffset :: Int32 
                             , firstInstance :: Word32 
                             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DrawIndexedIndirectCommand where
   sizeOf ~_ = 20
@@ -100,7 +100,7 @@ data ImageMemoryBarrier =
                     , image :: Image 
                     , subresourceRange :: ImageSubresourceRange 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ImageMemoryBarrier where
   sizeOf ~_ = 72
@@ -134,7 +134,7 @@ data MemoryBarrier =
                , srcAccessMask :: AccessFlags 
                , dstAccessMask :: AccessFlags 
                }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable MemoryBarrier where
   sizeOf ~_ = 24
@@ -156,7 +156,7 @@ data DrawIndirectCommand =
                      , firstVertex :: Word32 
                      , firstInstance :: Word32 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DrawIndirectCommand where
   sizeOf ~_ = 16
@@ -177,7 +177,7 @@ data DispatchIndirectCommand =
                          , y :: Word32 
                          , z :: Word32 
                          }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable DispatchIndirectCommand where
   sizeOf ~_ = 12

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -2,6 +2,10 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.OtherTypes where
 
+import Graphics.Vulkan.Buffer( Buffer
+                             )
+import Graphics.Vulkan.Pass( VkAccessFlags
+                           )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
@@ -13,6 +17,13 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Image( VkImageSubresourceRange
+                            , VkImageLayout
+                            , Image
+                            )
+import Graphics.Vulkan.Core( VkDeviceSize
+                           , VkStructureType
+                           )
 
 
 data VkBufferMemoryBarrier =

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -4,7 +4,7 @@ module Graphics.Vulkan.OtherTypes where
 
 import Graphics.Vulkan.Buffer( Buffer(..)
                              )
-import Graphics.Vulkan.Pass( VkAccessFlags(..)
+import Graphics.Vulkan.Pass( AccessFlags(..)
                            )
 import Data.Word( Word32(..)
                 )
@@ -18,19 +18,19 @@ import Foreign.Storable( Storable(..)
 import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Image( Image(..)
+                            , ImageLayout(..)
                             , ImageSubresourceRange(..)
-                            , VkImageLayout(..)
                             )
-import Graphics.Vulkan.Core( VkStructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , VkDeviceSize(..)
                            )
 
 
 data BufferMemoryBarrier =
-  BufferMemoryBarrier{ sType :: VkStructureType 
+  BufferMemoryBarrier{ sType :: StructureType 
                      , pNext :: Ptr Void 
-                     , srcAccessMask :: VkAccessFlags 
-                     , dstAccessMask :: VkAccessFlags 
+                     , srcAccessMask :: AccessFlags 
+                     , dstAccessMask :: AccessFlags 
                      , srcQueueFamilyIndex :: Word32 
                      , dstQueueFamilyIndex :: Word32 
                      , buffer :: Buffer 
@@ -89,12 +89,12 @@ instance Storable DrawIndexedIndirectCommand where
 
 
 data ImageMemoryBarrier =
-  ImageMemoryBarrier{ sType :: VkStructureType 
+  ImageMemoryBarrier{ sType :: StructureType 
                     , pNext :: Ptr Void 
-                    , srcAccessMask :: VkAccessFlags 
-                    , dstAccessMask :: VkAccessFlags 
-                    , oldLayout :: VkImageLayout 
-                    , newLayout :: VkImageLayout 
+                    , srcAccessMask :: AccessFlags 
+                    , dstAccessMask :: AccessFlags 
+                    , oldLayout :: ImageLayout 
+                    , newLayout :: ImageLayout 
                     , srcQueueFamilyIndex :: Word32 
                     , dstQueueFamilyIndex :: Word32 
                     , image :: Image 
@@ -129,10 +129,10 @@ instance Storable ImageMemoryBarrier where
 
 
 data MemoryBarrier =
-  MemoryBarrier{ sType :: VkStructureType 
+  MemoryBarrier{ sType :: StructureType 
                , pNext :: Ptr Void 
-               , srcAccessMask :: VkAccessFlags 
-               , dstAccessMask :: VkAccessFlags 
+               , srcAccessMask :: AccessFlags 
+               , dstAccessMask :: AccessFlags 
                }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -2,27 +2,27 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.OtherTypes where
 
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
-import Graphics.Vulkan.Pass( VkAccessFlags
+import Graphics.Vulkan.Pass( VkAccessFlags(..)
                            )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Data.Int( Int32
+import Data.Int( Int32(..)
                )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Image( VkImageSubresourceRange
-                            , VkImageLayout
-                            , Image
+import Graphics.Vulkan.Image( Image(..)
+                            , VkImageSubresourceRange(..)
+                            , VkImageLayout(..)
                             )
-import Graphics.Vulkan.Core( VkDeviceSize
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkDeviceSize(..)
                            )
 
 

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -22,7 +22,7 @@ import Graphics.Vulkan.Image( Image(..)
                             , ImageSubresourceRange(..)
                             )
 import Graphics.Vulkan.Core( StructureType(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
                            )
 
 
@@ -34,8 +34,8 @@ data BufferMemoryBarrier =
                      , srcQueueFamilyIndex :: Word32 
                      , dstQueueFamilyIndex :: Word32 
                      , buffer :: Buffer 
-                     , offset :: VkDeviceSize 
-                     , size :: VkDeviceSize 
+                     , offset :: DeviceSize 
+                     , size :: DeviceSize 
                      }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/OtherTypes.hs
+++ b/src/Graphics/Vulkan/OtherTypes.hs
@@ -18,7 +18,7 @@ import Foreign.Storable( Storable(..)
 import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Image( Image(..)
-                            , VkImageSubresourceRange(..)
+                            , ImageSubresourceRange(..)
                             , VkImageLayout(..)
                             )
 import Graphics.Vulkan.Core( VkStructureType(..)
@@ -26,167 +26,167 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            )
 
 
-data VkBufferMemoryBarrier =
-  VkBufferMemoryBarrier{ sType :: VkStructureType 
-                       , pNext :: Ptr Void 
-                       , srcAccessMask :: VkAccessFlags 
-                       , dstAccessMask :: VkAccessFlags 
-                       , srcQueueFamilyIndex :: Word32 
-                       , dstQueueFamilyIndex :: Word32 
-                       , buffer :: Buffer 
-                       , offset :: VkDeviceSize 
-                       , size :: VkDeviceSize 
-                       }
+data BufferMemoryBarrier =
+  BufferMemoryBarrier{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , srcAccessMask :: VkAccessFlags 
+                     , dstAccessMask :: VkAccessFlags 
+                     , srcQueueFamilyIndex :: Word32 
+                     , dstQueueFamilyIndex :: Word32 
+                     , buffer :: Buffer 
+                     , offset :: VkDeviceSize 
+                     , size :: VkDeviceSize 
+                     }
   deriving (Eq)
 
-instance Storable VkBufferMemoryBarrier where
+instance Storable BufferMemoryBarrier where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkBufferMemoryBarrier <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 20)
-                                   <*> peek (ptr `plusPtr` 24)
-                                   <*> peek (ptr `plusPtr` 28)
-                                   <*> peek (ptr `plusPtr` 32)
-                                   <*> peek (ptr `plusPtr` 40)
-                                   <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 24) (srcQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 28) (dstQueueFamilyIndex (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 32) (buffer (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 40) (offset (poked :: VkBufferMemoryBarrier))
-                *> poke (ptr `plusPtr` 48) (size (poked :: VkBufferMemoryBarrier))
+  peek ptr = BufferMemoryBarrier <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 20)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 28)
+                                 <*> peek (ptr `plusPtr` 32)
+                                 <*> peek (ptr `plusPtr` 40)
+                                 <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 24) (srcQueueFamilyIndex (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 28) (dstQueueFamilyIndex (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 32) (buffer (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 40) (offset (poked :: BufferMemoryBarrier))
+                *> poke (ptr `plusPtr` 48) (size (poked :: BufferMemoryBarrier))
 
 
 
-data VkDrawIndexedIndirectCommand =
-  VkDrawIndexedIndirectCommand{ indexCount :: Word32 
-                              , instanceCount :: Word32 
-                              , firstIndex :: Word32 
-                              , vertexOffset :: Int32 
-                              , firstInstance :: Word32 
-                              }
+data DrawIndexedIndirectCommand =
+  DrawIndexedIndirectCommand{ indexCount :: Word32 
+                            , instanceCount :: Word32 
+                            , firstIndex :: Word32 
+                            , vertexOffset :: Int32 
+                            , firstInstance :: Word32 
+                            }
   deriving (Eq)
 
-instance Storable VkDrawIndexedIndirectCommand where
+instance Storable DrawIndexedIndirectCommand where
   sizeOf ~_ = 20
   alignment ~_ = 4
-  peek ptr = VkDrawIndexedIndirectCommand <$> peek (ptr `plusPtr` 0)
-                                          <*> peek (ptr `plusPtr` 4)
-                                          <*> peek (ptr `plusPtr` 8)
-                                          <*> peek (ptr `plusPtr` 12)
-                                          <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (indexCount (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (firstIndex (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 12) (vertexOffset (poked :: VkDrawIndexedIndirectCommand))
-                *> poke (ptr `plusPtr` 16) (firstInstance (poked :: VkDrawIndexedIndirectCommand))
+  peek ptr = DrawIndexedIndirectCommand <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 4)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 12)
+                                        <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (indexCount (poked :: DrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: DrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (firstIndex (poked :: DrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 12) (vertexOffset (poked :: DrawIndexedIndirectCommand))
+                *> poke (ptr `plusPtr` 16) (firstInstance (poked :: DrawIndexedIndirectCommand))
 
 
 
-data VkImageMemoryBarrier =
-  VkImageMemoryBarrier{ sType :: VkStructureType 
-                      , pNext :: Ptr Void 
-                      , srcAccessMask :: VkAccessFlags 
-                      , dstAccessMask :: VkAccessFlags 
-                      , oldLayout :: VkImageLayout 
-                      , newLayout :: VkImageLayout 
-                      , srcQueueFamilyIndex :: Word32 
-                      , dstQueueFamilyIndex :: Word32 
-                      , image :: Image 
-                      , subresourceRange :: VkImageSubresourceRange 
-                      }
+data ImageMemoryBarrier =
+  ImageMemoryBarrier{ sType :: VkStructureType 
+                    , pNext :: Ptr Void 
+                    , srcAccessMask :: VkAccessFlags 
+                    , dstAccessMask :: VkAccessFlags 
+                    , oldLayout :: VkImageLayout 
+                    , newLayout :: VkImageLayout 
+                    , srcQueueFamilyIndex :: Word32 
+                    , dstQueueFamilyIndex :: Word32 
+                    , image :: Image 
+                    , subresourceRange :: ImageSubresourceRange 
+                    }
   deriving (Eq)
 
-instance Storable VkImageMemoryBarrier where
+instance Storable ImageMemoryBarrier where
   sizeOf ~_ = 72
   alignment ~_ = 8
-  peek ptr = VkImageMemoryBarrier <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 20)
-                                  <*> peek (ptr `plusPtr` 24)
-                                  <*> peek (ptr `plusPtr` 28)
-                                  <*> peek (ptr `plusPtr` 32)
-                                  <*> peek (ptr `plusPtr` 36)
-                                  <*> peek (ptr `plusPtr` 40)
-                                  <*> peek (ptr `plusPtr` 48)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 24) (oldLayout (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 28) (newLayout (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 32) (srcQueueFamilyIndex (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 36) (dstQueueFamilyIndex (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 40) (image (poked :: VkImageMemoryBarrier))
-                *> poke (ptr `plusPtr` 48) (subresourceRange (poked :: VkImageMemoryBarrier))
+  peek ptr = ImageMemoryBarrier <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 20)
+                                <*> peek (ptr `plusPtr` 24)
+                                <*> peek (ptr `plusPtr` 28)
+                                <*> peek (ptr `plusPtr` 32)
+                                <*> peek (ptr `plusPtr` 36)
+                                <*> peek (ptr `plusPtr` 40)
+                                <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 24) (oldLayout (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 28) (newLayout (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 32) (srcQueueFamilyIndex (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 36) (dstQueueFamilyIndex (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 40) (image (poked :: ImageMemoryBarrier))
+                *> poke (ptr `plusPtr` 48) (subresourceRange (poked :: ImageMemoryBarrier))
 
 
 
-data VkMemoryBarrier =
-  VkMemoryBarrier{ sType :: VkStructureType 
-                 , pNext :: Ptr Void 
-                 , srcAccessMask :: VkAccessFlags 
-                 , dstAccessMask :: VkAccessFlags 
-                 }
+data MemoryBarrier =
+  MemoryBarrier{ sType :: VkStructureType 
+               , pNext :: Ptr Void 
+               , srcAccessMask :: VkAccessFlags 
+               , dstAccessMask :: VkAccessFlags 
+               }
   deriving (Eq)
 
-instance Storable VkMemoryBarrier where
+instance Storable MemoryBarrier where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkMemoryBarrier <$> peek (ptr `plusPtr` 0)
-                             <*> peek (ptr `plusPtr` 8)
-                             <*> peek (ptr `plusPtr` 16)
-                             <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkMemoryBarrier))
-                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkMemoryBarrier))
+  peek ptr = MemoryBarrier <$> peek (ptr `plusPtr` 0)
+                           <*> peek (ptr `plusPtr` 8)
+                           <*> peek (ptr `plusPtr` 16)
+                           <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: MemoryBarrier))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: MemoryBarrier))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: MemoryBarrier))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: MemoryBarrier))
 
 
 
-data VkDrawIndirectCommand =
-  VkDrawIndirectCommand{ vertexCount :: Word32 
-                       , instanceCount :: Word32 
-                       , firstVertex :: Word32 
-                       , firstInstance :: Word32 
-                       }
+data DrawIndirectCommand =
+  DrawIndirectCommand{ vertexCount :: Word32 
+                     , instanceCount :: Word32 
+                     , firstVertex :: Word32 
+                     , firstInstance :: Word32 
+                     }
   deriving (Eq)
 
-instance Storable VkDrawIndirectCommand where
+instance Storable DrawIndirectCommand where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ptr = VkDrawIndirectCommand <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 4)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vertexCount (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (firstVertex (poked :: VkDrawIndirectCommand))
-                *> poke (ptr `plusPtr` 12) (firstInstance (poked :: VkDrawIndirectCommand))
+  peek ptr = DrawIndirectCommand <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 4)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vertexCount (poked :: DrawIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (instanceCount (poked :: DrawIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (firstVertex (poked :: DrawIndirectCommand))
+                *> poke (ptr `plusPtr` 12) (firstInstance (poked :: DrawIndirectCommand))
 
 
 
-data VkDispatchIndirectCommand =
-  VkDispatchIndirectCommand{ x :: Word32 
-                           , y :: Word32 
-                           , z :: Word32 
-                           }
+data DispatchIndirectCommand =
+  DispatchIndirectCommand{ x :: Word32 
+                         , y :: Word32 
+                         , z :: Word32 
+                         }
   deriving (Eq)
 
-instance Storable VkDispatchIndirectCommand where
+instance Storable DispatchIndirectCommand where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkDispatchIndirectCommand <$> peek (ptr `plusPtr` 0)
-                                       <*> peek (ptr `plusPtr` 4)
-                                       <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: VkDispatchIndirectCommand))
-                *> poke (ptr `plusPtr` 4) (y (poked :: VkDispatchIndirectCommand))
-                *> poke (ptr `plusPtr` 8) (z (poked :: VkDispatchIndirectCommand))
+  peek ptr = DispatchIndirectCommand <$> peek (ptr `plusPtr` 0)
+                                     <*> peek (ptr `plusPtr` 4)
+                                     <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (x (poked :: DispatchIndirectCommand))
+                *> poke (ptr `plusPtr` 4) (y (poked :: DispatchIndirectCommand))
+                *> poke (ptr `plusPtr` 8) (z (poked :: DispatchIndirectCommand))
 
 

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -4,17 +4,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pass where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits(..)
-                               , VkPipelineStageFlags(..)
-                               , VkPipelineBindPoint(..)
-                               )
 import Data.Word( Word64
                 , Word32
                 )
@@ -30,15 +24,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -46,20 +31,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
-                              )
-import Graphics.Vulkan.Image( VkImageLayout(..)
-                            )
-import Graphics.Vulkan.ImageView( ImageView(..)
-                                )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 
 data VkSubpassDependency =

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pass where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -50,7 +50,7 @@ import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
                               )
 import Graphics.Vulkan.Image( VkImageLayout(..)
                             )
-import Graphics.Vulkan.ImageView( VkImageView(..)
+import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkExtent2D(..)
@@ -63,13 +63,13 @@ import Foreign.C.Types( CSize(..)
 
 
 data VkSubpassDependency =
-  VkSubpassDependency{ vkSrcSubpass :: Word32 
-                     , vkDstSubpass :: Word32 
-                     , vkSrcStageMask :: VkPipelineStageFlags 
-                     , vkDstStageMask :: VkPipelineStageFlags 
-                     , vkSrcAccessMask :: VkAccessFlags 
-                     , vkDstAccessMask :: VkAccessFlags 
-                     , vkDependencyFlags :: VkDependencyFlags 
+  VkSubpassDependency{ srcSubpass :: Word32 
+                     , dstSubpass :: Word32 
+                     , srcStageMask :: VkPipelineStageFlags 
+                     , dstStageMask :: VkPipelineStageFlags 
+                     , srcAccessMask :: VkAccessFlags 
+                     , dstAccessMask :: VkAccessFlags 
+                     , dependencyFlags :: VkDependencyFlags 
                      }
   deriving (Eq)
 
@@ -83,13 +83,13 @@ instance Storable VkSubpassDependency where
                                  <*> peek (ptr `plusPtr` 16)
                                  <*> peek (ptr `plusPtr` 20)
                                  <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSrcSubpass (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 4) (vkDstSubpass (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 8) (vkSrcStageMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 12) (vkDstStageMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 16) (vkSrcAccessMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 20) (vkDstAccessMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 24) (vkDependencyFlags (poked :: VkSubpassDependency))
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubpass (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 4) (dstSubpass (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 8) (srcStageMask (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 12) (dstStageMask (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkSubpassDependency))
+                *> poke (ptr `plusPtr` 24) (dependencyFlags (poked :: VkSubpassDependency))
 
 
 -- ** VkSubpassDescriptionFlags
@@ -97,7 +97,7 @@ instance Storable VkSubpassDependency where
 newtype VkSubpassDescriptionFlags = VkSubpassDescriptionFlags VkFlags
   deriving (Eq, Storable)
 
-newtype VkFramebuffer = VkFramebuffer Word64
+newtype Framebuffer = Framebuffer Word64
   deriving (Eq, Storable)
 
 -- ** VkAttachmentDescriptionFlags
@@ -156,25 +156,25 @@ pattern VK_DEPENDENCY_BY_REGION_BIT = VkDependencyFlagBits 0x1
 
 -- ** vkDestroyRenderPass
 foreign import ccall "vkDestroyRenderPass" vkDestroyRenderPass ::
-  VkDevice -> VkRenderPass -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> RenderPass -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** vkCreateFramebuffer
 foreign import ccall "vkCreateFramebuffer" vkCreateFramebuffer ::
-  VkDevice ->
+  Device ->
   Ptr VkFramebufferCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkFramebuffer -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Framebuffer -> IO VkResult
 
 
 data VkFramebufferCreateInfo =
-  VkFramebufferCreateInfo{ vkSType :: VkStructureType 
-                         , vkPNext :: Ptr Void 
-                         , vkFlags :: VkFramebufferCreateFlags 
-                         , vkRenderPass :: VkRenderPass 
-                         , vkAttachmentCount :: Word32 
-                         , vkPAttachments :: Ptr VkImageView 
-                         , vkWidth :: Word32 
-                         , vkHeight :: Word32 
-                         , vkLayers :: Word32 
+  VkFramebufferCreateInfo{ sType :: VkStructureType 
+                         , pNext :: Ptr Void 
+                         , flags :: VkFramebufferCreateFlags 
+                         , renderPass :: RenderPass 
+                         , attachmentCount :: Word32 
+                         , pAttachments :: Ptr ImageView 
+                         , width :: Word32 
+                         , height :: Word32 
+                         , layers :: Word32 
                          }
   deriving (Eq)
 
@@ -190,20 +190,20 @@ instance Storable VkFramebufferCreateInfo where
                                      <*> peek (ptr `plusPtr` 48)
                                      <*> peek (ptr `plusPtr` 52)
                                      <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkRenderPass (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkAttachmentCount (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPAttachments (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkWidth (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 52) (vkHeight (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkLayers (poked :: VkFramebufferCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 24) (renderPass (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 32) (attachmentCount (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pAttachments (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 48) (width (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 52) (height (poked :: VkFramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 56) (layers (poked :: VkFramebufferCreateInfo))
 
 
 -- ** vkGetRenderAreaGranularity
 foreign import ccall "vkGetRenderAreaGranularity" vkGetRenderAreaGranularity ::
-  VkDevice -> VkRenderPass -> Ptr VkExtent2D -> IO ()
+  Device -> RenderPass -> Ptr VkExtent2D -> IO ()
 
 -- ** VkAttachmentLoadOp
 
@@ -352,17 +352,17 @@ pattern VK_ACCESS_MEMORY_READ_BIT = VkAccessFlagBits 0x8000
 pattern VK_ACCESS_MEMORY_WRITE_BIT = VkAccessFlagBits 0x10000
 
 
-newtype VkRenderPass = VkRenderPass Word64
+newtype RenderPass = RenderPass Word64
   deriving (Eq, Storable)
 
 -- ** vkDestroyFramebuffer
 foreign import ccall "vkDestroyFramebuffer" vkDestroyFramebuffer ::
-  VkDevice -> VkFramebuffer -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Framebuffer -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkAttachmentReference =
-  VkAttachmentReference{ vkAttachment :: Word32 
-                       , vkLayout :: VkImageLayout 
+  VkAttachmentReference{ attachment :: Word32 
+                       , layout :: VkImageLayout 
                        }
   deriving (Eq)
 
@@ -371,8 +371,8 @@ instance Storable VkAttachmentReference where
   alignment ~_ = 4
   peek ptr = VkAttachmentReference <$> peek (ptr `plusPtr` 0)
                                    <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAttachment (poked :: VkAttachmentReference))
-                *> poke (ptr `plusPtr` 4) (vkLayout (poked :: VkAttachmentReference))
+  poke ptr poked = poke (ptr `plusPtr` 0) (attachment (poked :: VkAttachmentReference))
+                *> poke (ptr `plusPtr` 4) (layout (poked :: VkAttachmentReference))
 
 
 -- ** VkRenderPassCreateFlags
@@ -382,15 +382,15 @@ newtype VkRenderPassCreateFlags = VkRenderPassCreateFlags VkFlags
 
 
 data VkAttachmentDescription =
-  VkAttachmentDescription{ vkFlags :: VkAttachmentDescriptionFlags 
-                         , vkFormat :: VkFormat 
-                         , vkSamples :: VkSampleCountFlagBits 
-                         , vkLoadOp :: VkAttachmentLoadOp 
-                         , vkStoreOp :: VkAttachmentStoreOp 
-                         , vkStencilLoadOp :: VkAttachmentLoadOp 
-                         , vkStencilStoreOp :: VkAttachmentStoreOp 
-                         , vkInitialLayout :: VkImageLayout 
-                         , vkFinalLayout :: VkImageLayout 
+  VkAttachmentDescription{ flags :: VkAttachmentDescriptionFlags 
+                         , format :: VkFormat 
+                         , samples :: VkSampleCountFlagBits 
+                         , loadOp :: VkAttachmentLoadOp 
+                         , storeOp :: VkAttachmentStoreOp 
+                         , stencilLoadOp :: VkAttachmentLoadOp 
+                         , stencilStoreOp :: VkAttachmentStoreOp 
+                         , initialLayout :: VkImageLayout 
+                         , finalLayout :: VkImageLayout 
                          }
   deriving (Eq)
 
@@ -406,29 +406,29 @@ instance Storable VkAttachmentDescription where
                                      <*> peek (ptr `plusPtr` 24)
                                      <*> peek (ptr `plusPtr` 28)
                                      <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkFlags (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 4) (vkFormat (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 8) (vkSamples (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 12) (vkLoadOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 16) (vkStoreOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 20) (vkStencilLoadOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 24) (vkStencilStoreOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 28) (vkInitialLayout (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 32) (vkFinalLayout (poked :: VkAttachmentDescription))
+  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 4) (format (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 8) (samples (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 12) (loadOp (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 16) (storeOp (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 20) (stencilLoadOp (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 24) (stencilStoreOp (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 28) (initialLayout (poked :: VkAttachmentDescription))
+                *> poke (ptr `plusPtr` 32) (finalLayout (poked :: VkAttachmentDescription))
 
 
 
 data VkSubpassDescription =
-  VkSubpassDescription{ vkFlags :: VkSubpassDescriptionFlags 
-                      , vkPipelineBindPoint :: VkPipelineBindPoint 
-                      , vkInputAttachmentCount :: Word32 
-                      , vkPInputAttachments :: Ptr VkAttachmentReference 
-                      , vkColorAttachmentCount :: Word32 
-                      , vkPColorAttachments :: Ptr VkAttachmentReference 
-                      , vkPResolveAttachments :: Ptr VkAttachmentReference 
-                      , vkPDepthStencilAttachment :: Ptr VkAttachmentReference 
-                      , vkPreserveAttachmentCount :: Word32 
-                      , vkPPreserveAttachments :: Ptr Word32 
+  VkSubpassDescription{ flags :: VkSubpassDescriptionFlags 
+                      , pipelineBindPoint :: VkPipelineBindPoint 
+                      , inputAttachmentCount :: Word32 
+                      , pInputAttachments :: Ptr VkAttachmentReference 
+                      , colorAttachmentCount :: Word32 
+                      , pColorAttachments :: Ptr VkAttachmentReference 
+                      , pResolveAttachments :: Ptr VkAttachmentReference 
+                      , pDepthStencilAttachment :: Ptr VkAttachmentReference 
+                      , preserveAttachmentCount :: Word32 
+                      , pPreserveAttachments :: Ptr Word32 
                       }
   deriving (Eq)
 
@@ -445,35 +445,35 @@ instance Storable VkSubpassDescription where
                                   <*> peek (ptr `plusPtr` 48)
                                   <*> peek (ptr `plusPtr` 56)
                                   <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkFlags (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 4) (vkPipelineBindPoint (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 8) (vkInputAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 16) (vkPInputAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 24) (vkColorAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 32) (vkPColorAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 40) (vkPResolveAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 48) (vkPDepthStencilAttachment (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 56) (vkPreserveAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 64) (vkPPreserveAttachments (poked :: VkSubpassDescription))
+  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 4) (pipelineBindPoint (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 8) (inputAttachmentCount (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 16) (pInputAttachments (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 24) (colorAttachmentCount (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 32) (pColorAttachments (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 40) (pResolveAttachments (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 48) (pDepthStencilAttachment (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 56) (preserveAttachmentCount (poked :: VkSubpassDescription))
+                *> poke (ptr `plusPtr` 64) (pPreserveAttachments (poked :: VkSubpassDescription))
 
 
 -- ** vkCreateRenderPass
 foreign import ccall "vkCreateRenderPass" vkCreateRenderPass ::
-  VkDevice ->
+  Device ->
   Ptr VkRenderPassCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkRenderPass -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr RenderPass -> IO VkResult
 
 
 data VkRenderPassCreateInfo =
-  VkRenderPassCreateInfo{ vkSType :: VkStructureType 
-                        , vkPNext :: Ptr Void 
-                        , vkFlags :: VkRenderPassCreateFlags 
-                        , vkAttachmentCount :: Word32 
-                        , vkPAttachments :: Ptr VkAttachmentDescription 
-                        , vkSubpassCount :: Word32 
-                        , vkPSubpasses :: Ptr VkSubpassDescription 
-                        , vkDependencyCount :: Word32 
-                        , vkPDependencies :: Ptr VkSubpassDependency 
+  VkRenderPassCreateInfo{ sType :: VkStructureType 
+                        , pNext :: Ptr Void 
+                        , flags :: VkRenderPassCreateFlags 
+                        , attachmentCount :: Word32 
+                        , pAttachments :: Ptr VkAttachmentDescription 
+                        , subpassCount :: Word32 
+                        , pSubpasses :: Ptr VkSubpassDescription 
+                        , dependencyCount :: Word32 
+                        , pDependencies :: Ptr VkSubpassDependency 
                         }
   deriving (Eq)
 
@@ -489,15 +489,15 @@ instance Storable VkRenderPassCreateInfo where
                                     <*> peek (ptr `plusPtr` 40)
                                     <*> peek (ptr `plusPtr` 48)
                                     <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkAttachmentCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPAttachments (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkSubpassCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPSubpasses (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkDependencyCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkPDependencies (poked :: VkRenderPassCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 20) (attachmentCount (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pAttachments (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 32) (subpassCount (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pSubpasses (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 48) (dependencyCount (poked :: VkRenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 56) (pDependencies (poked :: VkRenderPassCreateInfo))
 
 
 -- ** VkFramebufferCreateFlags

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -138,12 +138,12 @@ instance Read DependencyFlags where
 pattern VK_DEPENDENCY_BY_REGION_BIT = DependencyFlags 0x1
 
 
--- ** vkDestroyRenderPass
-foreign import ccall "vkDestroyRenderPass" vkDestroyRenderPass ::
+-- ** destroyRenderPass
+foreign import ccall "vkDestroyRenderPass" destroyRenderPass ::
   Device -> RenderPass -> Ptr AllocationCallbacks -> IO ()
 
--- ** vkCreateFramebuffer
-foreign import ccall "vkCreateFramebuffer" vkCreateFramebuffer ::
+-- ** createFramebuffer
+foreign import ccall "vkCreateFramebuffer" createFramebuffer ::
   Device ->
   Ptr FramebufferCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Framebuffer -> IO Result
@@ -185,8 +185,8 @@ instance Storable FramebufferCreateInfo where
                 *> poke (ptr `plusPtr` 56) (layers (poked :: FramebufferCreateInfo))
 
 
--- ** vkGetRenderAreaGranularity
-foreign import ccall "vkGetRenderAreaGranularity" vkGetRenderAreaGranularity ::
+-- ** getRenderAreaGranularity
+foreign import ccall "vkGetRenderAreaGranularity" getRenderAreaGranularity ::
   Device -> RenderPass -> Ptr Extent2D -> IO ()
 
 -- ** AttachmentLoadOp
@@ -336,8 +336,8 @@ pattern VK_ACCESS_MEMORY_WRITE_BIT = AccessFlags 0x10000
 newtype RenderPass = RenderPass Word64
   deriving (Eq, Storable)
 
--- ** vkDestroyFramebuffer
-foreign import ccall "vkDestroyFramebuffer" vkDestroyFramebuffer ::
+-- ** destroyFramebuffer
+foreign import ccall "vkDestroyFramebuffer" destroyFramebuffer ::
   Device -> Framebuffer -> Ptr AllocationCallbacks -> IO ()
 
 
@@ -438,8 +438,8 @@ instance Storable SubpassDescription where
                 *> poke (ptr `plusPtr` 64) (pPreserveAttachments (poked :: SubpassDescription))
 
 
--- ** vkCreateRenderPass
-foreign import ccall "vkCreateRenderPass" vkCreateRenderPass ::
+-- ** createRenderPass
+foreign import ccall "vkCreateRenderPass" createRenderPass ::
   Device ->
   Ptr RenderPassCreateInfo ->
     Ptr AllocationCallbacks -> Ptr RenderPass -> IO Result

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -29,7 +29,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -48,38 +48,38 @@ import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
                            , VkFlags(..)
                            , VkResult(..)
-                           , VkExtent2D(..)
+                           , Extent2D(..)
                            )
 
 
-data VkSubpassDependency =
-  VkSubpassDependency{ srcSubpass :: Word32 
-                     , dstSubpass :: Word32 
-                     , srcStageMask :: VkPipelineStageFlags 
-                     , dstStageMask :: VkPipelineStageFlags 
-                     , srcAccessMask :: VkAccessFlags 
-                     , dstAccessMask :: VkAccessFlags 
-                     , dependencyFlags :: VkDependencyFlags 
-                     }
+data SubpassDependency =
+  SubpassDependency{ srcSubpass :: Word32 
+                   , dstSubpass :: Word32 
+                   , srcStageMask :: VkPipelineStageFlags 
+                   , dstStageMask :: VkPipelineStageFlags 
+                   , srcAccessMask :: VkAccessFlags 
+                   , dstAccessMask :: VkAccessFlags 
+                   , dependencyFlags :: VkDependencyFlags 
+                   }
   deriving (Eq)
 
-instance Storable VkSubpassDependency where
+instance Storable SubpassDependency where
   sizeOf ~_ = 28
   alignment ~_ = 4
-  peek ptr = VkSubpassDependency <$> peek (ptr `plusPtr` 0)
-                                 <*> peek (ptr `plusPtr` 4)
-                                 <*> peek (ptr `plusPtr` 8)
-                                 <*> peek (ptr `plusPtr` 12)
-                                 <*> peek (ptr `plusPtr` 16)
-                                 <*> peek (ptr `plusPtr` 20)
-                                 <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubpass (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 4) (dstSubpass (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 8) (srcStageMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 12) (dstStageMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: VkSubpassDependency))
-                *> poke (ptr `plusPtr` 24) (dependencyFlags (poked :: VkSubpassDependency))
+  peek ptr = SubpassDependency <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 4)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 12)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 20)
+                               <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (srcSubpass (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 4) (dstSubpass (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 8) (srcStageMask (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 12) (dstStageMask (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 16) (srcAccessMask (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 20) (dstAccessMask (poked :: SubpassDependency))
+                *> poke (ptr `plusPtr` 24) (dependencyFlags (poked :: SubpassDependency))
 
 
 -- ** VkSubpassDescriptionFlags
@@ -140,54 +140,54 @@ pattern VK_DEPENDENCY_BY_REGION_BIT = VkDependencyFlags 0x1
 
 -- ** vkDestroyRenderPass
 foreign import ccall "vkDestroyRenderPass" vkDestroyRenderPass ::
-  Device -> RenderPass -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> RenderPass -> Ptr AllocationCallbacks -> IO ()
 
 -- ** vkCreateFramebuffer
 foreign import ccall "vkCreateFramebuffer" vkCreateFramebuffer ::
   Device ->
-  Ptr VkFramebufferCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Framebuffer -> IO VkResult
+  Ptr FramebufferCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Framebuffer -> IO VkResult
 
 
-data VkFramebufferCreateInfo =
-  VkFramebufferCreateInfo{ sType :: VkStructureType 
-                         , pNext :: Ptr Void 
-                         , flags :: VkFramebufferCreateFlags 
-                         , renderPass :: RenderPass 
-                         , attachmentCount :: Word32 
-                         , pAttachments :: Ptr ImageView 
-                         , width :: Word32 
-                         , height :: Word32 
-                         , layers :: Word32 
-                         }
+data FramebufferCreateInfo =
+  FramebufferCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkFramebufferCreateFlags 
+                       , renderPass :: RenderPass 
+                       , attachmentCount :: Word32 
+                       , pAttachments :: Ptr ImageView 
+                       , width :: Word32 
+                       , height :: Word32 
+                       , layers :: Word32 
+                       }
   deriving (Eq)
 
-instance Storable VkFramebufferCreateInfo where
+instance Storable FramebufferCreateInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkFramebufferCreateInfo <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 24)
-                                     <*> peek (ptr `plusPtr` 32)
-                                     <*> peek (ptr `plusPtr` 40)
-                                     <*> peek (ptr `plusPtr` 48)
-                                     <*> peek (ptr `plusPtr` 52)
-                                     <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 24) (renderPass (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 32) (attachmentCount (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pAttachments (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 48) (width (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 52) (height (poked :: VkFramebufferCreateInfo))
-                *> poke (ptr `plusPtr` 56) (layers (poked :: VkFramebufferCreateInfo))
+  peek ptr = FramebufferCreateInfo <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 24)
+                                   <*> peek (ptr `plusPtr` 32)
+                                   <*> peek (ptr `plusPtr` 40)
+                                   <*> peek (ptr `plusPtr` 48)
+                                   <*> peek (ptr `plusPtr` 52)
+                                   <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 24) (renderPass (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 32) (attachmentCount (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pAttachments (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 48) (width (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 52) (height (poked :: FramebufferCreateInfo))
+                *> poke (ptr `plusPtr` 56) (layers (poked :: FramebufferCreateInfo))
 
 
 -- ** vkGetRenderAreaGranularity
 foreign import ccall "vkGetRenderAreaGranularity" vkGetRenderAreaGranularity ::
-  Device -> RenderPass -> Ptr VkExtent2D -> IO ()
+  Device -> RenderPass -> Ptr Extent2D -> IO ()
 
 -- ** VkAttachmentLoadOp
 
@@ -338,22 +338,22 @@ newtype RenderPass = RenderPass Word64
 
 -- ** vkDestroyFramebuffer
 foreign import ccall "vkDestroyFramebuffer" vkDestroyFramebuffer ::
-  Device -> Framebuffer -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Framebuffer -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkAttachmentReference =
-  VkAttachmentReference{ attachment :: Word32 
-                       , layout :: VkImageLayout 
-                       }
+data AttachmentReference =
+  AttachmentReference{ attachment :: Word32 
+                     , layout :: VkImageLayout 
+                     }
   deriving (Eq)
 
-instance Storable VkAttachmentReference where
+instance Storable AttachmentReference where
   sizeOf ~_ = 8
   alignment ~_ = 4
-  peek ptr = VkAttachmentReference <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 4)
-  poke ptr poked = poke (ptr `plusPtr` 0) (attachment (poked :: VkAttachmentReference))
-                *> poke (ptr `plusPtr` 4) (layout (poked :: VkAttachmentReference))
+  peek ptr = AttachmentReference <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 4)
+  poke ptr poked = poke (ptr `plusPtr` 0) (attachment (poked :: AttachmentReference))
+                *> poke (ptr `plusPtr` 4) (layout (poked :: AttachmentReference))
 
 
 -- ** VkRenderPassCreateFlags
@@ -362,123 +362,123 @@ newtype VkRenderPassCreateFlags = VkRenderPassCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
-data VkAttachmentDescription =
-  VkAttachmentDescription{ flags :: VkAttachmentDescriptionFlags 
-                         , format :: VkFormat 
-                         , samples :: VkSampleCountFlags 
-                         , loadOp :: VkAttachmentLoadOp 
-                         , storeOp :: VkAttachmentStoreOp 
-                         , stencilLoadOp :: VkAttachmentLoadOp 
-                         , stencilStoreOp :: VkAttachmentStoreOp 
-                         , initialLayout :: VkImageLayout 
-                         , finalLayout :: VkImageLayout 
-                         }
+data AttachmentDescription =
+  AttachmentDescription{ flags :: VkAttachmentDescriptionFlags 
+                       , format :: VkFormat 
+                       , samples :: VkSampleCountFlags 
+                       , loadOp :: VkAttachmentLoadOp 
+                       , storeOp :: VkAttachmentStoreOp 
+                       , stencilLoadOp :: VkAttachmentLoadOp 
+                       , stencilStoreOp :: VkAttachmentStoreOp 
+                       , initialLayout :: VkImageLayout 
+                       , finalLayout :: VkImageLayout 
+                       }
   deriving (Eq)
 
-instance Storable VkAttachmentDescription where
+instance Storable AttachmentDescription where
   sizeOf ~_ = 36
   alignment ~_ = 4
-  peek ptr = VkAttachmentDescription <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 4)
-                                     <*> peek (ptr `plusPtr` 8)
-                                     <*> peek (ptr `plusPtr` 12)
-                                     <*> peek (ptr `plusPtr` 16)
-                                     <*> peek (ptr `plusPtr` 20)
-                                     <*> peek (ptr `plusPtr` 24)
-                                     <*> peek (ptr `plusPtr` 28)
-                                     <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 4) (format (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 8) (samples (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 12) (loadOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 16) (storeOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 20) (stencilLoadOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 24) (stencilStoreOp (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 28) (initialLayout (poked :: VkAttachmentDescription))
-                *> poke (ptr `plusPtr` 32) (finalLayout (poked :: VkAttachmentDescription))
+  peek ptr = AttachmentDescription <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 4)
+                                   <*> peek (ptr `plusPtr` 8)
+                                   <*> peek (ptr `plusPtr` 12)
+                                   <*> peek (ptr `plusPtr` 16)
+                                   <*> peek (ptr `plusPtr` 20)
+                                   <*> peek (ptr `plusPtr` 24)
+                                   <*> peek (ptr `plusPtr` 28)
+                                   <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 4) (format (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 8) (samples (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 12) (loadOp (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 16) (storeOp (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 20) (stencilLoadOp (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 24) (stencilStoreOp (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 28) (initialLayout (poked :: AttachmentDescription))
+                *> poke (ptr `plusPtr` 32) (finalLayout (poked :: AttachmentDescription))
 
 
 
-data VkSubpassDescription =
-  VkSubpassDescription{ flags :: VkSubpassDescriptionFlags 
-                      , pipelineBindPoint :: VkPipelineBindPoint 
-                      , inputAttachmentCount :: Word32 
-                      , pInputAttachments :: Ptr VkAttachmentReference 
-                      , colorAttachmentCount :: Word32 
-                      , pColorAttachments :: Ptr VkAttachmentReference 
-                      , pResolveAttachments :: Ptr VkAttachmentReference 
-                      , pDepthStencilAttachment :: Ptr VkAttachmentReference 
-                      , preserveAttachmentCount :: Word32 
-                      , pPreserveAttachments :: Ptr Word32 
-                      }
+data SubpassDescription =
+  SubpassDescription{ flags :: VkSubpassDescriptionFlags 
+                    , pipelineBindPoint :: VkPipelineBindPoint 
+                    , inputAttachmentCount :: Word32 
+                    , pInputAttachments :: Ptr AttachmentReference 
+                    , colorAttachmentCount :: Word32 
+                    , pColorAttachments :: Ptr AttachmentReference 
+                    , pResolveAttachments :: Ptr AttachmentReference 
+                    , pDepthStencilAttachment :: Ptr AttachmentReference 
+                    , preserveAttachmentCount :: Word32 
+                    , pPreserveAttachments :: Ptr Word32 
+                    }
   deriving (Eq)
 
-instance Storable VkSubpassDescription where
+instance Storable SubpassDescription where
   sizeOf ~_ = 72
   alignment ~_ = 8
-  peek ptr = VkSubpassDescription <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 4)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-                                  <*> peek (ptr `plusPtr` 32)
-                                  <*> peek (ptr `plusPtr` 40)
-                                  <*> peek (ptr `plusPtr` 48)
-                                  <*> peek (ptr `plusPtr` 56)
-                                  <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 4) (pipelineBindPoint (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 8) (inputAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 16) (pInputAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 24) (colorAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 32) (pColorAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 40) (pResolveAttachments (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 48) (pDepthStencilAttachment (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 56) (preserveAttachmentCount (poked :: VkSubpassDescription))
-                *> poke (ptr `plusPtr` 64) (pPreserveAttachments (poked :: VkSubpassDescription))
+  peek ptr = SubpassDescription <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 4)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 24)
+                                <*> peek (ptr `plusPtr` 32)
+                                <*> peek (ptr `plusPtr` 40)
+                                <*> peek (ptr `plusPtr` 48)
+                                <*> peek (ptr `plusPtr` 56)
+                                <*> peek (ptr `plusPtr` 64)
+  poke ptr poked = poke (ptr `plusPtr` 0) (flags (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 4) (pipelineBindPoint (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 8) (inputAttachmentCount (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 16) (pInputAttachments (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 24) (colorAttachmentCount (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 32) (pColorAttachments (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 40) (pResolveAttachments (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 48) (pDepthStencilAttachment (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 56) (preserveAttachmentCount (poked :: SubpassDescription))
+                *> poke (ptr `plusPtr` 64) (pPreserveAttachments (poked :: SubpassDescription))
 
 
 -- ** vkCreateRenderPass
 foreign import ccall "vkCreateRenderPass" vkCreateRenderPass ::
   Device ->
-  Ptr VkRenderPassCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr RenderPass -> IO VkResult
+  Ptr RenderPassCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr RenderPass -> IO VkResult
 
 
-data VkRenderPassCreateInfo =
-  VkRenderPassCreateInfo{ sType :: VkStructureType 
-                        , pNext :: Ptr Void 
-                        , flags :: VkRenderPassCreateFlags 
-                        , attachmentCount :: Word32 
-                        , pAttachments :: Ptr VkAttachmentDescription 
-                        , subpassCount :: Word32 
-                        , pSubpasses :: Ptr VkSubpassDescription 
-                        , dependencyCount :: Word32 
-                        , pDependencies :: Ptr VkSubpassDependency 
-                        }
+data RenderPassCreateInfo =
+  RenderPassCreateInfo{ sType :: VkStructureType 
+                      , pNext :: Ptr Void 
+                      , flags :: VkRenderPassCreateFlags 
+                      , attachmentCount :: Word32 
+                      , pAttachments :: Ptr AttachmentDescription 
+                      , subpassCount :: Word32 
+                      , pSubpasses :: Ptr SubpassDescription 
+                      , dependencyCount :: Word32 
+                      , pDependencies :: Ptr SubpassDependency 
+                      }
   deriving (Eq)
 
-instance Storable VkRenderPassCreateInfo where
+instance Storable RenderPassCreateInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkRenderPassCreateInfo <$> peek (ptr `plusPtr` 0)
-                                    <*> peek (ptr `plusPtr` 8)
-                                    <*> peek (ptr `plusPtr` 16)
-                                    <*> peek (ptr `plusPtr` 20)
-                                    <*> peek (ptr `plusPtr` 24)
-                                    <*> peek (ptr `plusPtr` 32)
-                                    <*> peek (ptr `plusPtr` 40)
-                                    <*> peek (ptr `plusPtr` 48)
-                                    <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 20) (attachmentCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pAttachments (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 32) (subpassCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pSubpasses (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 48) (dependencyCount (poked :: VkRenderPassCreateInfo))
-                *> poke (ptr `plusPtr` 56) (pDependencies (poked :: VkRenderPassCreateInfo))
+  peek ptr = RenderPassCreateInfo <$> peek (ptr `plusPtr` 0)
+                                  <*> peek (ptr `plusPtr` 8)
+                                  <*> peek (ptr `plusPtr` 16)
+                                  <*> peek (ptr `plusPtr` 20)
+                                  <*> peek (ptr `plusPtr` 24)
+                                  <*> peek (ptr `plusPtr` 32)
+                                  <*> peek (ptr `plusPtr` 40)
+                                  <*> peek (ptr `plusPtr` 48)
+                                  <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 20) (attachmentCount (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pAttachments (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 32) (subpassCount (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pSubpasses (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 48) (dependencyCount (poked :: RenderPassCreateInfo))
+                *> poke (ptr `plusPtr` 56) (pDependencies (poked :: RenderPassCreateInfo))
 
 
 -- ** VkFramebufferCreateFlags

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -4,11 +4,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pass where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Pass( VkSubpassDescription
+                           , VkFramebufferCreateFlags
+                           , VkAttachmentStoreOp
+                           , VkFramebufferCreateInfo
+                           , VkAccessFlags
+                           , VkRenderPassCreateInfo
+                           , VkRenderPassCreateFlags
+                           , VkSubpassDescriptionFlags
+                           , VkAttachmentReference
+                           , VkAttachmentDescription
+                           , Framebuffer
+                           , VkSubpassDependency
+                           , VkAttachmentDescriptionFlags
+                           , VkDependencyFlags
+                           , RenderPass
+                           , VkAttachmentLoadOp
+                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
+import Graphics.Vulkan.Pipeline( VkPipelineStageFlags
+                               , VkPipelineBindPoint
+                               )
 import Data.Word( Word64
                 , Word32
                 )
@@ -24,6 +46,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -31,6 +55,18 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+                              )
+import Graphics.Vulkan.Image( VkImageLayout
+                            )
+import Graphics.Vulkan.ImageView( ImageView
+                                )
+import Graphics.Vulkan.Core( VkResult
+                           , VkExtent2D
+                           , VkFlags
+                           , VkFormat
+                           , VkStructureType
+                           )
 
 
 data VkSubpassDependency =

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -195,15 +195,15 @@ newtype AttachmentLoadOp = AttachmentLoadOp Int32
   deriving (Eq, Storable)
 
 instance Show AttachmentLoadOp where
-  showsPrec _ VK_ATTACHMENT_LOAD_OP_LOAD = showString "VK_ATTACHMENT_LOAD_OP_LOAD"
-  showsPrec _ VK_ATTACHMENT_LOAD_OP_CLEAR = showString "VK_ATTACHMENT_LOAD_OP_CLEAR"
-  showsPrec _ VK_ATTACHMENT_LOAD_OP_DONT_CARE = showString "VK_ATTACHMENT_LOAD_OP_DONT_CARE"
+  showsPrec _ AttachmentLoadOpLoad = showString "AttachmentLoadOpLoad"
+  showsPrec _ AttachmentLoadOpClear = showString "AttachmentLoadOpClear"
+  showsPrec _ AttachmentLoadOpDontCare = showString "AttachmentLoadOpDontCare"
   showsPrec p (AttachmentLoadOp x) = showParen (p >= 11) (showString "AttachmentLoadOp " . showsPrec 11 x)
 
 instance Read AttachmentLoadOp where
-  readPrec = parens ( choose [ ("VK_ATTACHMENT_LOAD_OP_LOAD", pure VK_ATTACHMENT_LOAD_OP_LOAD)
-                             , ("VK_ATTACHMENT_LOAD_OP_CLEAR", pure VK_ATTACHMENT_LOAD_OP_CLEAR)
-                             , ("VK_ATTACHMENT_LOAD_OP_DONT_CARE", pure VK_ATTACHMENT_LOAD_OP_DONT_CARE)
+  readPrec = parens ( choose [ ("AttachmentLoadOpLoad", pure AttachmentLoadOpLoad)
+                             , ("AttachmentLoadOpClear", pure AttachmentLoadOpClear)
+                             , ("AttachmentLoadOpDontCare", pure AttachmentLoadOpDontCare)
                              ] +++
                       prec 10 (do
                         expectP (Ident "AttachmentLoadOp")
@@ -213,11 +213,11 @@ instance Read AttachmentLoadOp where
                     )
 
 
-pattern VK_ATTACHMENT_LOAD_OP_LOAD = AttachmentLoadOp 0
+pattern AttachmentLoadOpLoad = AttachmentLoadOp 0
 
-pattern VK_ATTACHMENT_LOAD_OP_CLEAR = AttachmentLoadOp 1
+pattern AttachmentLoadOpClear = AttachmentLoadOp 1
 
-pattern VK_ATTACHMENT_LOAD_OP_DONT_CARE = AttachmentLoadOp 2
+pattern AttachmentLoadOpDontCare = AttachmentLoadOp 2
 
 -- ** AttachmentStoreOp
 
@@ -225,13 +225,13 @@ newtype AttachmentStoreOp = AttachmentStoreOp Int32
   deriving (Eq, Storable)
 
 instance Show AttachmentStoreOp where
-  showsPrec _ VK_ATTACHMENT_STORE_OP_STORE = showString "VK_ATTACHMENT_STORE_OP_STORE"
-  showsPrec _ VK_ATTACHMENT_STORE_OP_DONT_CARE = showString "VK_ATTACHMENT_STORE_OP_DONT_CARE"
+  showsPrec _ AttachmentStoreOpStore = showString "AttachmentStoreOpStore"
+  showsPrec _ AttachmentStoreOpDontCare = showString "AttachmentStoreOpDontCare"
   showsPrec p (AttachmentStoreOp x) = showParen (p >= 11) (showString "AttachmentStoreOp " . showsPrec 11 x)
 
 instance Read AttachmentStoreOp where
-  readPrec = parens ( choose [ ("VK_ATTACHMENT_STORE_OP_STORE", pure VK_ATTACHMENT_STORE_OP_STORE)
-                             , ("VK_ATTACHMENT_STORE_OP_DONT_CARE", pure VK_ATTACHMENT_STORE_OP_DONT_CARE)
+  readPrec = parens ( choose [ ("AttachmentStoreOpStore", pure AttachmentStoreOpStore)
+                             , ("AttachmentStoreOpDontCare", pure AttachmentStoreOpDontCare)
                              ] +++
                       prec 10 (do
                         expectP (Ident "AttachmentStoreOp")
@@ -241,9 +241,9 @@ instance Read AttachmentStoreOp where
                     )
 
 
-pattern VK_ATTACHMENT_STORE_OP_STORE = AttachmentStoreOp 0
+pattern AttachmentStoreOpStore = AttachmentStoreOp 0
 
-pattern VK_ATTACHMENT_STORE_OP_DONT_CARE = AttachmentStoreOp 1
+pattern AttachmentStoreOpDontCare = AttachmentStoreOp 1
 
 -- ** AccessFlags
 

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -44,10 +44,10 @@ import Graphics.Vulkan.Image( ImageLayout(..)
                             )
 import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Format(..)
                            , Result(..)
+                           , Flags(..)
                            , Extent2D(..)
                            )
 
@@ -84,7 +84,7 @@ instance Storable SubpassDependency where
 
 -- ** SubpassDescriptionFlags
 -- | Opaque flag
-newtype SubpassDescriptionFlags = SubpassDescriptionFlags VkFlags
+newtype SubpassDescriptionFlags = SubpassDescriptionFlags Flags
   deriving (Eq, Storable)
 
 newtype Framebuffer = Framebuffer Word64
@@ -92,7 +92,7 @@ newtype Framebuffer = Framebuffer Word64
 
 -- ** VkAttachmentDescriptionFlags
 
-newtype AttachmentDescriptionFlags = AttachmentDescriptionFlags VkFlags
+newtype AttachmentDescriptionFlags = AttachmentDescriptionFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show AttachmentDescriptionFlags where
@@ -116,7 +116,7 @@ pattern VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = AttachmentDescriptionFlags 0x1
 
 -- ** VkDependencyFlags
 
-newtype DependencyFlags = DependencyFlags VkFlags
+newtype DependencyFlags = DependencyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DependencyFlags where
@@ -247,7 +247,7 @@ pattern VK_ATTACHMENT_STORE_OP_DONT_CARE = AttachmentStoreOp 1
 
 -- ** VkAccessFlags
 
-newtype AccessFlags = AccessFlags VkFlags
+newtype AccessFlags = AccessFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show AccessFlags where
@@ -358,7 +358,7 @@ instance Storable AttachmentReference where
 
 -- ** RenderPassCreateFlags
 -- | Opaque flag
-newtype RenderPassCreateFlags = RenderPassCreateFlags VkFlags
+newtype RenderPassCreateFlags = RenderPassCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -483,6 +483,6 @@ instance Storable RenderPassCreateInfo where
 
 -- ** FramebufferCreateFlags
 -- | Opaque flag
-newtype FramebufferCreateFlags = FramebufferCreateFlags VkFlags
+newtype FramebufferCreateFlags = FramebufferCreateFlags Flags
   deriving (Eq, Storable)
 

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -90,7 +90,7 @@ newtype SubpassDescriptionFlags = SubpassDescriptionFlags Flags
 newtype Framebuffer = Framebuffer Word64
   deriving (Eq, Storable)
 
--- ** VkAttachmentDescriptionFlags
+-- ** AttachmentDescriptionFlags
 
 newtype AttachmentDescriptionFlags = AttachmentDescriptionFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -114,7 +114,7 @@ instance Read AttachmentDescriptionFlags where
 pattern VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = AttachmentDescriptionFlags 0x1
 
 
--- ** VkDependencyFlags
+-- ** DependencyFlags
 
 newtype DependencyFlags = DependencyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -245,7 +245,7 @@ pattern VK_ATTACHMENT_STORE_OP_STORE = AttachmentStoreOp 0
 
 pattern VK_ATTACHMENT_STORE_OP_DONT_CARE = AttachmentStoreOp 1
 
--- ** VkAccessFlags
+-- ** AccessFlags
 
 newtype AccessFlags = AccessFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -96,12 +96,12 @@ newtype AttachmentDescriptionFlags = AttachmentDescriptionFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show AttachmentDescriptionFlags where
-  showsPrec _ VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = showString "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT"
+  showsPrec _ AttachmentDescriptionMayAliasBit = showString "AttachmentDescriptionMayAliasBit"
   
   showsPrec p (AttachmentDescriptionFlags x) = showParen (p >= 11) (showString "AttachmentDescriptionFlags " . showsPrec 11 x)
 
 instance Read AttachmentDescriptionFlags where
-  readPrec = parens ( choose [ ("VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT", pure VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT)
+  readPrec = parens ( choose [ ("AttachmentDescriptionMayAliasBit", pure AttachmentDescriptionMayAliasBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "AttachmentDescriptionFlags")
@@ -111,7 +111,7 @@ instance Read AttachmentDescriptionFlags where
                     )
 
 -- | The attachment may alias physical memory of another attachment in the same render pass
-pattern VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = AttachmentDescriptionFlags 0x1
+pattern AttachmentDescriptionMayAliasBit = AttachmentDescriptionFlags 0x1
 
 
 -- ** DependencyFlags
@@ -120,12 +120,12 @@ newtype DependencyFlags = DependencyFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show DependencyFlags where
-  showsPrec _ VK_DEPENDENCY_BY_REGION_BIT = showString "VK_DEPENDENCY_BY_REGION_BIT"
+  showsPrec _ DependencyByRegionBit = showString "DependencyByRegionBit"
   
   showsPrec p (DependencyFlags x) = showParen (p >= 11) (showString "DependencyFlags " . showsPrec 11 x)
 
 instance Read DependencyFlags where
-  readPrec = parens ( choose [ ("VK_DEPENDENCY_BY_REGION_BIT", pure VK_DEPENDENCY_BY_REGION_BIT)
+  readPrec = parens ( choose [ ("DependencyByRegionBit", pure DependencyByRegionBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DependencyFlags")
@@ -135,7 +135,7 @@ instance Read DependencyFlags where
                     )
 
 -- | Dependency is per pixel region 
-pattern VK_DEPENDENCY_BY_REGION_BIT = DependencyFlags 0x1
+pattern DependencyByRegionBit = DependencyFlags 0x1
 
 
 -- ** destroyRenderPass
@@ -251,44 +251,44 @@ newtype AccessFlags = AccessFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show AccessFlags where
-  showsPrec _ VK_ACCESS_INDIRECT_COMMAND_READ_BIT = showString "VK_ACCESS_INDIRECT_COMMAND_READ_BIT"
-  showsPrec _ VK_ACCESS_INDEX_READ_BIT = showString "VK_ACCESS_INDEX_READ_BIT"
-  showsPrec _ VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT = showString "VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT"
-  showsPrec _ VK_ACCESS_UNIFORM_READ_BIT = showString "VK_ACCESS_UNIFORM_READ_BIT"
-  showsPrec _ VK_ACCESS_INPUT_ATTACHMENT_READ_BIT = showString "VK_ACCESS_INPUT_ATTACHMENT_READ_BIT"
-  showsPrec _ VK_ACCESS_SHADER_READ_BIT = showString "VK_ACCESS_SHADER_READ_BIT"
-  showsPrec _ VK_ACCESS_SHADER_WRITE_BIT = showString "VK_ACCESS_SHADER_WRITE_BIT"
-  showsPrec _ VK_ACCESS_COLOR_ATTACHMENT_READ_BIT = showString "VK_ACCESS_COLOR_ATTACHMENT_READ_BIT"
-  showsPrec _ VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT = showString "VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT"
-  showsPrec _ VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT = showString "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT"
-  showsPrec _ VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = showString "VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT"
-  showsPrec _ VK_ACCESS_TRANSFER_READ_BIT = showString "VK_ACCESS_TRANSFER_READ_BIT"
-  showsPrec _ VK_ACCESS_TRANSFER_WRITE_BIT = showString "VK_ACCESS_TRANSFER_WRITE_BIT"
-  showsPrec _ VK_ACCESS_HOST_READ_BIT = showString "VK_ACCESS_HOST_READ_BIT"
-  showsPrec _ VK_ACCESS_HOST_WRITE_BIT = showString "VK_ACCESS_HOST_WRITE_BIT"
-  showsPrec _ VK_ACCESS_MEMORY_READ_BIT = showString "VK_ACCESS_MEMORY_READ_BIT"
-  showsPrec _ VK_ACCESS_MEMORY_WRITE_BIT = showString "VK_ACCESS_MEMORY_WRITE_BIT"
+  showsPrec _ AccessIndirectCommandReadBit = showString "AccessIndirectCommandReadBit"
+  showsPrec _ AccessIndexReadBit = showString "AccessIndexReadBit"
+  showsPrec _ AccessVertexAttributeReadBit = showString "AccessVertexAttributeReadBit"
+  showsPrec _ AccessUniformReadBit = showString "AccessUniformReadBit"
+  showsPrec _ AccessInputAttachmentReadBit = showString "AccessInputAttachmentReadBit"
+  showsPrec _ AccessShaderReadBit = showString "AccessShaderReadBit"
+  showsPrec _ AccessShaderWriteBit = showString "AccessShaderWriteBit"
+  showsPrec _ AccessColorAttachmentReadBit = showString "AccessColorAttachmentReadBit"
+  showsPrec _ AccessColorAttachmentWriteBit = showString "AccessColorAttachmentWriteBit"
+  showsPrec _ AccessDepthStencilAttachmentReadBit = showString "AccessDepthStencilAttachmentReadBit"
+  showsPrec _ AccessDepthStencilAttachmentWriteBit = showString "AccessDepthStencilAttachmentWriteBit"
+  showsPrec _ AccessTransferReadBit = showString "AccessTransferReadBit"
+  showsPrec _ AccessTransferWriteBit = showString "AccessTransferWriteBit"
+  showsPrec _ AccessHostReadBit = showString "AccessHostReadBit"
+  showsPrec _ AccessHostWriteBit = showString "AccessHostWriteBit"
+  showsPrec _ AccessMemoryReadBit = showString "AccessMemoryReadBit"
+  showsPrec _ AccessMemoryWriteBit = showString "AccessMemoryWriteBit"
   
   showsPrec p (AccessFlags x) = showParen (p >= 11) (showString "AccessFlags " . showsPrec 11 x)
 
 instance Read AccessFlags where
-  readPrec = parens ( choose [ ("VK_ACCESS_INDIRECT_COMMAND_READ_BIT", pure VK_ACCESS_INDIRECT_COMMAND_READ_BIT)
-                             , ("VK_ACCESS_INDEX_READ_BIT", pure VK_ACCESS_INDEX_READ_BIT)
-                             , ("VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT", pure VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT)
-                             , ("VK_ACCESS_UNIFORM_READ_BIT", pure VK_ACCESS_UNIFORM_READ_BIT)
-                             , ("VK_ACCESS_INPUT_ATTACHMENT_READ_BIT", pure VK_ACCESS_INPUT_ATTACHMENT_READ_BIT)
-                             , ("VK_ACCESS_SHADER_READ_BIT", pure VK_ACCESS_SHADER_READ_BIT)
-                             , ("VK_ACCESS_SHADER_WRITE_BIT", pure VK_ACCESS_SHADER_WRITE_BIT)
-                             , ("VK_ACCESS_COLOR_ATTACHMENT_READ_BIT", pure VK_ACCESS_COLOR_ATTACHMENT_READ_BIT)
-                             , ("VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT", pure VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT)
-                             , ("VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT", pure VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT)
-                             , ("VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT", pure VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT)
-                             , ("VK_ACCESS_TRANSFER_READ_BIT", pure VK_ACCESS_TRANSFER_READ_BIT)
-                             , ("VK_ACCESS_TRANSFER_WRITE_BIT", pure VK_ACCESS_TRANSFER_WRITE_BIT)
-                             , ("VK_ACCESS_HOST_READ_BIT", pure VK_ACCESS_HOST_READ_BIT)
-                             , ("VK_ACCESS_HOST_WRITE_BIT", pure VK_ACCESS_HOST_WRITE_BIT)
-                             , ("VK_ACCESS_MEMORY_READ_BIT", pure VK_ACCESS_MEMORY_READ_BIT)
-                             , ("VK_ACCESS_MEMORY_WRITE_BIT", pure VK_ACCESS_MEMORY_WRITE_BIT)
+  readPrec = parens ( choose [ ("AccessIndirectCommandReadBit", pure AccessIndirectCommandReadBit)
+                             , ("AccessIndexReadBit", pure AccessIndexReadBit)
+                             , ("AccessVertexAttributeReadBit", pure AccessVertexAttributeReadBit)
+                             , ("AccessUniformReadBit", pure AccessUniformReadBit)
+                             , ("AccessInputAttachmentReadBit", pure AccessInputAttachmentReadBit)
+                             , ("AccessShaderReadBit", pure AccessShaderReadBit)
+                             , ("AccessShaderWriteBit", pure AccessShaderWriteBit)
+                             , ("AccessColorAttachmentReadBit", pure AccessColorAttachmentReadBit)
+                             , ("AccessColorAttachmentWriteBit", pure AccessColorAttachmentWriteBit)
+                             , ("AccessDepthStencilAttachmentReadBit", pure AccessDepthStencilAttachmentReadBit)
+                             , ("AccessDepthStencilAttachmentWriteBit", pure AccessDepthStencilAttachmentWriteBit)
+                             , ("AccessTransferReadBit", pure AccessTransferReadBit)
+                             , ("AccessTransferWriteBit", pure AccessTransferWriteBit)
+                             , ("AccessHostReadBit", pure AccessHostReadBit)
+                             , ("AccessHostWriteBit", pure AccessHostWriteBit)
+                             , ("AccessMemoryReadBit", pure AccessMemoryReadBit)
+                             , ("AccessMemoryWriteBit", pure AccessMemoryWriteBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "AccessFlags")
@@ -298,39 +298,39 @@ instance Read AccessFlags where
                     )
 
 -- | Controls coherency of indirect command reads
-pattern VK_ACCESS_INDIRECT_COMMAND_READ_BIT = AccessFlags 0x1
+pattern AccessIndirectCommandReadBit = AccessFlags 0x1
 -- | Controls coherency of index reads
-pattern VK_ACCESS_INDEX_READ_BIT = AccessFlags 0x2
+pattern AccessIndexReadBit = AccessFlags 0x2
 -- | Controls coherency of vertex attribute reads
-pattern VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT = AccessFlags 0x4
+pattern AccessVertexAttributeReadBit = AccessFlags 0x4
 -- | Controls coherency of uniform buffer reads
-pattern VK_ACCESS_UNIFORM_READ_BIT = AccessFlags 0x8
+pattern AccessUniformReadBit = AccessFlags 0x8
 -- | Controls coherency of input attachment reads
-pattern VK_ACCESS_INPUT_ATTACHMENT_READ_BIT = AccessFlags 0x10
+pattern AccessInputAttachmentReadBit = AccessFlags 0x10
 -- | Controls coherency of shader reads
-pattern VK_ACCESS_SHADER_READ_BIT = AccessFlags 0x20
+pattern AccessShaderReadBit = AccessFlags 0x20
 -- | Controls coherency of shader writes
-pattern VK_ACCESS_SHADER_WRITE_BIT = AccessFlags 0x40
+pattern AccessShaderWriteBit = AccessFlags 0x40
 -- | Controls coherency of color attachment reads
-pattern VK_ACCESS_COLOR_ATTACHMENT_READ_BIT = AccessFlags 0x80
+pattern AccessColorAttachmentReadBit = AccessFlags 0x80
 -- | Controls coherency of color attachment writes
-pattern VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT = AccessFlags 0x100
+pattern AccessColorAttachmentWriteBit = AccessFlags 0x100
 -- | Controls coherency of depth/stencil attachment reads
-pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT = AccessFlags 0x200
+pattern AccessDepthStencilAttachmentReadBit = AccessFlags 0x200
 -- | Controls coherency of depth/stencil attachment writes
-pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = AccessFlags 0x400
+pattern AccessDepthStencilAttachmentWriteBit = AccessFlags 0x400
 -- | Controls coherency of transfer reads
-pattern VK_ACCESS_TRANSFER_READ_BIT = AccessFlags 0x800
+pattern AccessTransferReadBit = AccessFlags 0x800
 -- | Controls coherency of transfer writes
-pattern VK_ACCESS_TRANSFER_WRITE_BIT = AccessFlags 0x1000
+pattern AccessTransferWriteBit = AccessFlags 0x1000
 -- | Controls coherency of host reads
-pattern VK_ACCESS_HOST_READ_BIT = AccessFlags 0x2000
+pattern AccessHostReadBit = AccessFlags 0x2000
 -- | Controls coherency of host writes
-pattern VK_ACCESS_HOST_WRITE_BIT = AccessFlags 0x4000
+pattern AccessHostWriteBit = AccessFlags 0x4000
 -- | Controls coherency of memory reads
-pattern VK_ACCESS_MEMORY_READ_BIT = AccessFlags 0x8000
+pattern AccessMemoryReadBit = AccessFlags 0x8000
 -- | Controls coherency of memory writes
-pattern VK_ACCESS_MEMORY_WRITE_BIT = AccessFlags 0x10000
+pattern AccessMemoryWriteBit = AccessFlags 0x10000
 
 
 newtype RenderPass = RenderPass Word64

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -4,37 +4,20 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pass where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Pass( VkSubpassDescription
-                           , VkFramebufferCreateFlags
-                           , VkAttachmentStoreOp
-                           , VkFramebufferCreateInfo
-                           , VkAccessFlags
-                           , VkRenderPassCreateInfo
-                           , VkRenderPassCreateFlags
-                           , VkSubpassDescriptionFlags
-                           , VkAttachmentReference
-                           , VkAttachmentDescription
-                           , Framebuffer
-                           , VkSubpassDependency
-                           , VkAttachmentDescriptionFlags
-                           , VkDependencyFlags
-                           , RenderPass
-                           , VkAttachmentLoadOp
-                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlags
-                               , VkPipelineBindPoint
+import Graphics.Vulkan.Pipeline( VkPipelineBindPoint(..)
+                               , VkPipelineStageFlags(..)
                                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
@@ -44,9 +27,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -55,17 +38,17 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( VkImageLayout
+import Graphics.Vulkan.Image( VkImageLayout(..)
                             )
-import Graphics.Vulkan.ImageView( ImageView
+import Graphics.Vulkan.ImageView( ImageView(..)
                                 )
-import Graphics.Vulkan.Core( VkResult
-                           , VkExtent2D
-                           , VkFlags
-                           , VkFormat
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkExtent2D(..)
                            )
 
 
@@ -109,56 +92,50 @@ newtype Framebuffer = Framebuffer Word64
 
 -- ** VkAttachmentDescriptionFlags
 
-newtype VkAttachmentDescriptionFlagBits = VkAttachmentDescriptionFlagBits VkFlags
+newtype VkAttachmentDescriptionFlags = VkAttachmentDescriptionFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkAttachmentDescriptionFlagBits
-type VkAttachmentDescriptionFlags = VkAttachmentDescriptionFlagBits
-
-instance Show VkAttachmentDescriptionFlagBits where
+instance Show VkAttachmentDescriptionFlags where
   showsPrec _ VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = showString "VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT"
   
-  showsPrec p (VkAttachmentDescriptionFlagBits x) = showParen (p >= 11) (showString "VkAttachmentDescriptionFlagBits " . showsPrec 11 x)
+  showsPrec p (VkAttachmentDescriptionFlags x) = showParen (p >= 11) (showString "VkAttachmentDescriptionFlags " . showsPrec 11 x)
 
-instance Read VkAttachmentDescriptionFlagBits where
+instance Read VkAttachmentDescriptionFlags where
   readPrec = parens ( choose [ ("VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT", pure VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkAttachmentDescriptionFlagBits")
+                        expectP (Ident "VkAttachmentDescriptionFlags")
                         v <- step readPrec
-                        pure (VkAttachmentDescriptionFlagBits v)
+                        pure (VkAttachmentDescriptionFlags v)
                         )
                     )
 
 -- | The attachment may alias physical memory of another attachment in the same render pass
-pattern VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = VkAttachmentDescriptionFlagBits 0x1
+pattern VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT = VkAttachmentDescriptionFlags 0x1
 
 
 -- ** VkDependencyFlags
 
-newtype VkDependencyFlagBits = VkDependencyFlagBits VkFlags
+newtype VkDependencyFlags = VkDependencyFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkDependencyFlagBits
-type VkDependencyFlags = VkDependencyFlagBits
-
-instance Show VkDependencyFlagBits where
+instance Show VkDependencyFlags where
   showsPrec _ VK_DEPENDENCY_BY_REGION_BIT = showString "VK_DEPENDENCY_BY_REGION_BIT"
   
-  showsPrec p (VkDependencyFlagBits x) = showParen (p >= 11) (showString "VkDependencyFlagBits " . showsPrec 11 x)
+  showsPrec p (VkDependencyFlags x) = showParen (p >= 11) (showString "VkDependencyFlags " . showsPrec 11 x)
 
-instance Read VkDependencyFlagBits where
+instance Read VkDependencyFlags where
   readPrec = parens ( choose [ ("VK_DEPENDENCY_BY_REGION_BIT", pure VK_DEPENDENCY_BY_REGION_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDependencyFlagBits")
+                        expectP (Ident "VkDependencyFlags")
                         v <- step readPrec
-                        pure (VkDependencyFlagBits v)
+                        pure (VkDependencyFlags v)
                         )
                     )
 
 -- | Dependency is per pixel region 
-pattern VK_DEPENDENCY_BY_REGION_BIT = VkDependencyFlagBits 0x1
+pattern VK_DEPENDENCY_BY_REGION_BIT = VkDependencyFlags 0x1
 
 
 -- ** vkDestroyRenderPass
@@ -270,13 +247,10 @@ pattern VK_ATTACHMENT_STORE_OP_DONT_CARE = VkAttachmentStoreOp 1
 
 -- ** VkAccessFlags
 
-newtype VkAccessFlagBits = VkAccessFlagBits VkFlags
+newtype VkAccessFlags = VkAccessFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkAccessFlagBits
-type VkAccessFlags = VkAccessFlagBits
-
-instance Show VkAccessFlagBits where
+instance Show VkAccessFlags where
   showsPrec _ VK_ACCESS_INDIRECT_COMMAND_READ_BIT = showString "VK_ACCESS_INDIRECT_COMMAND_READ_BIT"
   showsPrec _ VK_ACCESS_INDEX_READ_BIT = showString "VK_ACCESS_INDEX_READ_BIT"
   showsPrec _ VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT = showString "VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT"
@@ -295,9 +269,9 @@ instance Show VkAccessFlagBits where
   showsPrec _ VK_ACCESS_MEMORY_READ_BIT = showString "VK_ACCESS_MEMORY_READ_BIT"
   showsPrec _ VK_ACCESS_MEMORY_WRITE_BIT = showString "VK_ACCESS_MEMORY_WRITE_BIT"
   
-  showsPrec p (VkAccessFlagBits x) = showParen (p >= 11) (showString "VkAccessFlagBits " . showsPrec 11 x)
+  showsPrec p (VkAccessFlags x) = showParen (p >= 11) (showString "VkAccessFlags " . showsPrec 11 x)
 
-instance Read VkAccessFlagBits where
+instance Read VkAccessFlags where
   readPrec = parens ( choose [ ("VK_ACCESS_INDIRECT_COMMAND_READ_BIT", pure VK_ACCESS_INDIRECT_COMMAND_READ_BIT)
                              , ("VK_ACCESS_INDEX_READ_BIT", pure VK_ACCESS_INDEX_READ_BIT)
                              , ("VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT", pure VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT)
@@ -317,46 +291,46 @@ instance Read VkAccessFlagBits where
                              , ("VK_ACCESS_MEMORY_WRITE_BIT", pure VK_ACCESS_MEMORY_WRITE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkAccessFlagBits")
+                        expectP (Ident "VkAccessFlags")
                         v <- step readPrec
-                        pure (VkAccessFlagBits v)
+                        pure (VkAccessFlags v)
                         )
                     )
 
 -- | Controls coherency of indirect command reads
-pattern VK_ACCESS_INDIRECT_COMMAND_READ_BIT = VkAccessFlagBits 0x1
+pattern VK_ACCESS_INDIRECT_COMMAND_READ_BIT = VkAccessFlags 0x1
 -- | Controls coherency of index reads
-pattern VK_ACCESS_INDEX_READ_BIT = VkAccessFlagBits 0x2
+pattern VK_ACCESS_INDEX_READ_BIT = VkAccessFlags 0x2
 -- | Controls coherency of vertex attribute reads
-pattern VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT = VkAccessFlagBits 0x4
+pattern VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT = VkAccessFlags 0x4
 -- | Controls coherency of uniform buffer reads
-pattern VK_ACCESS_UNIFORM_READ_BIT = VkAccessFlagBits 0x8
+pattern VK_ACCESS_UNIFORM_READ_BIT = VkAccessFlags 0x8
 -- | Controls coherency of input attachment reads
-pattern VK_ACCESS_INPUT_ATTACHMENT_READ_BIT = VkAccessFlagBits 0x10
+pattern VK_ACCESS_INPUT_ATTACHMENT_READ_BIT = VkAccessFlags 0x10
 -- | Controls coherency of shader reads
-pattern VK_ACCESS_SHADER_READ_BIT = VkAccessFlagBits 0x20
+pattern VK_ACCESS_SHADER_READ_BIT = VkAccessFlags 0x20
 -- | Controls coherency of shader writes
-pattern VK_ACCESS_SHADER_WRITE_BIT = VkAccessFlagBits 0x40
+pattern VK_ACCESS_SHADER_WRITE_BIT = VkAccessFlags 0x40
 -- | Controls coherency of color attachment reads
-pattern VK_ACCESS_COLOR_ATTACHMENT_READ_BIT = VkAccessFlagBits 0x80
+pattern VK_ACCESS_COLOR_ATTACHMENT_READ_BIT = VkAccessFlags 0x80
 -- | Controls coherency of color attachment writes
-pattern VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT = VkAccessFlagBits 0x100
+pattern VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT = VkAccessFlags 0x100
 -- | Controls coherency of depth/stencil attachment reads
-pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT = VkAccessFlagBits 0x200
+pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT = VkAccessFlags 0x200
 -- | Controls coherency of depth/stencil attachment writes
-pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = VkAccessFlagBits 0x400
+pattern VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT = VkAccessFlags 0x400
 -- | Controls coherency of transfer reads
-pattern VK_ACCESS_TRANSFER_READ_BIT = VkAccessFlagBits 0x800
+pattern VK_ACCESS_TRANSFER_READ_BIT = VkAccessFlags 0x800
 -- | Controls coherency of transfer writes
-pattern VK_ACCESS_TRANSFER_WRITE_BIT = VkAccessFlagBits 0x1000
+pattern VK_ACCESS_TRANSFER_WRITE_BIT = VkAccessFlags 0x1000
 -- | Controls coherency of host reads
-pattern VK_ACCESS_HOST_READ_BIT = VkAccessFlagBits 0x2000
+pattern VK_ACCESS_HOST_READ_BIT = VkAccessFlags 0x2000
 -- | Controls coherency of host writes
-pattern VK_ACCESS_HOST_WRITE_BIT = VkAccessFlagBits 0x4000
+pattern VK_ACCESS_HOST_WRITE_BIT = VkAccessFlags 0x4000
 -- | Controls coherency of memory reads
-pattern VK_ACCESS_MEMORY_READ_BIT = VkAccessFlagBits 0x8000
+pattern VK_ACCESS_MEMORY_READ_BIT = VkAccessFlags 0x8000
 -- | Controls coherency of memory writes
-pattern VK_ACCESS_MEMORY_WRITE_BIT = VkAccessFlagBits 0x10000
+pattern VK_ACCESS_MEMORY_WRITE_BIT = VkAccessFlags 0x10000
 
 
 newtype RenderPass = RenderPass Word64
@@ -391,7 +365,7 @@ newtype VkRenderPassCreateFlags = VkRenderPassCreateFlags VkFlags
 data VkAttachmentDescription =
   VkAttachmentDescription{ flags :: VkAttachmentDescriptionFlags 
                          , format :: VkFormat 
-                         , samples :: VkSampleCountFlagBits 
+                         , samples :: VkSampleCountFlags 
                          , loadOp :: VkAttachmentLoadOp 
                          , storeOp :: VkAttachmentStoreOp 
                          , stencilLoadOp :: VkAttachmentLoadOp 

--- a/src/Graphics/Vulkan/Pass.hs
+++ b/src/Graphics/Vulkan/Pass.hs
@@ -61,7 +61,7 @@ data SubpassDependency =
                    , dstAccessMask :: AccessFlags 
                    , dependencyFlags :: DependencyFlags 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SubpassDependency where
   sizeOf ~_ = 28
@@ -85,15 +85,15 @@ instance Storable SubpassDependency where
 -- ** SubpassDescriptionFlags
 -- | Opaque flag
 newtype SubpassDescriptionFlags = SubpassDescriptionFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 newtype Framebuffer = Framebuffer Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** AttachmentDescriptionFlags
 
 newtype AttachmentDescriptionFlags = AttachmentDescriptionFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show AttachmentDescriptionFlags where
   showsPrec _ AttachmentDescriptionMayAliasBit = showString "AttachmentDescriptionMayAliasBit"
@@ -117,7 +117,7 @@ pattern AttachmentDescriptionMayAliasBit = AttachmentDescriptionFlags 0x1
 -- ** DependencyFlags
 
 newtype DependencyFlags = DependencyFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show DependencyFlags where
   showsPrec _ DependencyByRegionBit = showString "DependencyByRegionBit"
@@ -160,7 +160,7 @@ data FramebufferCreateInfo =
                        , height :: Word32 
                        , layers :: Word32 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable FramebufferCreateInfo where
   sizeOf ~_ = 64
@@ -192,7 +192,7 @@ foreign import ccall "vkGetRenderAreaGranularity" getRenderAreaGranularity ::
 -- ** AttachmentLoadOp
 
 newtype AttachmentLoadOp = AttachmentLoadOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show AttachmentLoadOp where
   showsPrec _ AttachmentLoadOpLoad = showString "AttachmentLoadOpLoad"
@@ -222,7 +222,7 @@ pattern AttachmentLoadOpDontCare = AttachmentLoadOp 2
 -- ** AttachmentStoreOp
 
 newtype AttachmentStoreOp = AttachmentStoreOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show AttachmentStoreOp where
   showsPrec _ AttachmentStoreOpStore = showString "AttachmentStoreOpStore"
@@ -248,7 +248,7 @@ pattern AttachmentStoreOpDontCare = AttachmentStoreOp 1
 -- ** AccessFlags
 
 newtype AccessFlags = AccessFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show AccessFlags where
   showsPrec _ AccessIndirectCommandReadBit = showString "AccessIndirectCommandReadBit"
@@ -334,7 +334,7 @@ pattern AccessMemoryWriteBit = AccessFlags 0x10000
 
 
 newtype RenderPass = RenderPass Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroyFramebuffer
 foreign import ccall "vkDestroyFramebuffer" destroyFramebuffer ::
@@ -345,7 +345,7 @@ data AttachmentReference =
   AttachmentReference{ attachment :: Word32 
                      , layout :: ImageLayout 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable AttachmentReference where
   sizeOf ~_ = 8
@@ -359,7 +359,7 @@ instance Storable AttachmentReference where
 -- ** RenderPassCreateFlags
 -- | Opaque flag
 newtype RenderPassCreateFlags = RenderPassCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data AttachmentDescription =
@@ -373,7 +373,7 @@ data AttachmentDescription =
                        , initialLayout :: ImageLayout 
                        , finalLayout :: ImageLayout 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable AttachmentDescription where
   sizeOf ~_ = 36
@@ -411,7 +411,7 @@ data SubpassDescription =
                     , preserveAttachmentCount :: Word32 
                     , pPreserveAttachments :: Ptr Word32 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SubpassDescription where
   sizeOf ~_ = 72
@@ -456,7 +456,7 @@ data RenderPassCreateInfo =
                       , dependencyCount :: Word32 
                       , pDependencies :: Ptr SubpassDependency 
                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable RenderPassCreateInfo where
   sizeOf ~_ = 64
@@ -484,5 +484,5 @@ instance Storable RenderPassCreateInfo where
 -- ** FramebufferCreateFlags
 -- | Opaque flag
 newtype FramebufferCreateFlags = FramebufferCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 

--- a/src/Graphics/Vulkan/Pass.hs-boot
+++ b/src/Graphics/Vulkan/Pass.hs-boot
@@ -1,7 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pass where
 
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
 import Foreign.Storable( Storable(..)
                        )

--- a/src/Graphics/Vulkan/Pass.hs-boot
+++ b/src/Graphics/Vulkan/Pass.hs-boot
@@ -6,8 +6,8 @@ import Data.Word( Word64
 import Foreign.Storable( Storable(..)
                        )
 
-newtype VkRenderPass = VkRenderPass Word64
+newtype RenderPass = RenderPass Word64
   
-instance Eq VkRenderPass
-instance Storable VkRenderPass
+instance Eq RenderPass
+instance Storable RenderPass
 

--- a/src/Graphics/Vulkan/Pass.hs-boot
+++ b/src/Graphics/Vulkan/Pass.hs-boot
@@ -9,5 +9,6 @@ import Foreign.Storable( Storable(..)
 newtype RenderPass = RenderPass Word64
   
 instance Eq RenderPass
+instance Ord RenderPass
 instance Storable RenderPass
 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -7,10 +7,6 @@ module Graphics.Vulkan.Pipeline where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import {-# SOURCE #-} Graphics.Vulkan.Pass( RenderPass(..)
-                                          )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -22,8 +18,6 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.PipelineCache( PipelineCache(..)
-                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -33,17 +27,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
-                                     )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -51,27 +34,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
-                             , ShaderModule(..)
-                             )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
-                              , VkCompareOp(..)
-                              )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkExtent2D(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkOffset2D(..)
-                           , VkRect2D(..)
-                           , VkViewport(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
                       , CFloat
-                      , CFloat(..)
                       , CChar
-                      , CSize(..)
                       )
 
 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -7,9 +7,9 @@ module Graphics.Vulkan.Pipeline where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
-import {-# SOURCE #-} Graphics.Vulkan.Pass( VkRenderPass(..)
+import {-# SOURCE #-} Graphics.Vulkan.Pass( RenderPass(..)
                                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -22,7 +22,7 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.PipelineCache( VkPipelineCache(..)
+import Graphics.Vulkan.PipelineCache( PipelineCache(..)
                                     )
 import Data.Int( Int32
                )
@@ -42,7 +42,7 @@ import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
                              , PFN_vkFreeFunction
                              , PFN_vkInternalFreeNotification
                              )
-import Graphics.Vulkan.PipelineLayout( VkPipelineLayout(..)
+import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
                                      )
 import Text.Read( Read(..)
                 , parens
@@ -52,7 +52,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , step
                                       )
 import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
-                             , VkShaderModule(..)
+                             , ShaderModule(..)
                              )
 import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
                               , VkCompareOp(..)
@@ -76,10 +76,10 @@ import Foreign.C.Types( CSize
 
 
 data VkPipelineTessellationStateCreateInfo =
-  VkPipelineTessellationStateCreateInfo{ vkSType :: VkStructureType 
-                                       , vkPNext :: Ptr Void 
-                                       , vkFlags :: VkPipelineTessellationStateCreateFlags 
-                                       , vkPatchControlPoints :: Word32 
+  VkPipelineTessellationStateCreateInfo{ sType :: VkStructureType 
+                                       , pNext :: Ptr Void 
+                                       , flags :: VkPipelineTessellationStateCreateFlags 
+                                       , patchControlPoints :: Word32 
                                        }
   deriving (Eq)
 
@@ -90,18 +90,18 @@ instance Storable VkPipelineTessellationStateCreateInfo where
                                                    <*> peek (ptr `plusPtr` 8)
                                                    <*> peek (ptr `plusPtr` 16)
                                                    <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkPatchControlPoints (poked :: VkPipelineTessellationStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (patchControlPoints (poked :: VkPipelineTessellationStateCreateInfo))
 
 
 
 data VkVertexInputAttributeDescription =
-  VkVertexInputAttributeDescription{ vkLocation :: Word32 
-                                   , vkBinding :: Word32 
-                                   , vkFormat :: VkFormat 
-                                   , vkOffset :: Word32 
+  VkVertexInputAttributeDescription{ location :: Word32 
+                                   , binding :: Word32 
+                                   , format :: VkFormat 
+                                   , offset :: Word32 
                                    }
   deriving (Eq)
 
@@ -112,33 +112,33 @@ instance Storable VkVertexInputAttributeDescription where
                                                <*> peek (ptr `plusPtr` 4)
                                                <*> peek (ptr `plusPtr` 8)
                                                <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkLocation (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 4) (vkBinding (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 8) (vkFormat (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 12) (vkOffset (poked :: VkVertexInputAttributeDescription))
+  poke ptr poked = poke (ptr `plusPtr` 0) (location (poked :: VkVertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 4) (binding (poked :: VkVertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 8) (format (poked :: VkVertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 12) (offset (poked :: VkVertexInputAttributeDescription))
 
 
 
 data VkGraphicsPipelineCreateInfo =
-  VkGraphicsPipelineCreateInfo{ vkSType :: VkStructureType 
-                              , vkPNext :: Ptr Void 
-                              , vkFlags :: VkPipelineCreateFlags 
-                              , vkStageCount :: Word32 
-                              , vkPStages :: Ptr VkPipelineShaderStageCreateInfo 
-                              , vkPVertexInputState :: Ptr VkPipelineVertexInputStateCreateInfo 
-                              , vkPInputAssemblyState :: Ptr VkPipelineInputAssemblyStateCreateInfo 
-                              , vkPTessellationState :: Ptr VkPipelineTessellationStateCreateInfo 
-                              , vkPViewportState :: Ptr VkPipelineViewportStateCreateInfo 
-                              , vkPRasterizationState :: Ptr VkPipelineRasterizationStateCreateInfo 
-                              , vkPMultisampleState :: Ptr VkPipelineMultisampleStateCreateInfo 
-                              , vkPDepthStencilState :: Ptr VkPipelineDepthStencilStateCreateInfo 
-                              , vkPColorBlendState :: Ptr VkPipelineColorBlendStateCreateInfo 
-                              , vkPDynamicState :: Ptr VkPipelineDynamicStateCreateInfo 
-                              , vkLayout :: VkPipelineLayout 
-                              , vkRenderPass :: VkRenderPass 
-                              , vkSubpass :: Word32 
-                              , vkBasePipelineHandle :: VkPipeline 
-                              , vkBasePipelineIndex :: Int32 
+  VkGraphicsPipelineCreateInfo{ sType :: VkStructureType 
+                              , pNext :: Ptr Void 
+                              , flags :: VkPipelineCreateFlags 
+                              , stageCount :: Word32 
+                              , pStages :: Ptr VkPipelineShaderStageCreateInfo 
+                              , pVertexInputState :: Ptr VkPipelineVertexInputStateCreateInfo 
+                              , pInputAssemblyState :: Ptr VkPipelineInputAssemblyStateCreateInfo 
+                              , pTessellationState :: Ptr VkPipelineTessellationStateCreateInfo 
+                              , pViewportState :: Ptr VkPipelineViewportStateCreateInfo 
+                              , pRasterizationState :: Ptr VkPipelineRasterizationStateCreateInfo 
+                              , pMultisampleState :: Ptr VkPipelineMultisampleStateCreateInfo 
+                              , pDepthStencilState :: Ptr VkPipelineDepthStencilStateCreateInfo 
+                              , pColorBlendState :: Ptr VkPipelineColorBlendStateCreateInfo 
+                              , pDynamicState :: Ptr VkPipelineDynamicStateCreateInfo 
+                              , layout :: PipelineLayout 
+                              , renderPass :: RenderPass 
+                              , subpass :: Word32 
+                              , basePipelineHandle :: Pipeline 
+                              , basePipelineIndex :: Int32 
                               }
   deriving (Eq)
 
@@ -164,25 +164,25 @@ instance Storable VkGraphicsPipelineCreateInfo where
                                           <*> peek (ptr `plusPtr` 120)
                                           <*> peek (ptr `plusPtr` 128)
                                           <*> peek (ptr `plusPtr` 136)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkStageCount (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPStages (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPVertexInputState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPInputAssemblyState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkPTessellationState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkPViewportState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 64) (vkPRasterizationState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 72) (vkPMultisampleState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 80) (vkPDepthStencilState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 88) (vkPColorBlendState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 96) (vkPDynamicState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 104) (vkLayout (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 112) (vkRenderPass (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 120) (vkSubpass (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 128) (vkBasePipelineHandle (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 136) (vkBasePipelineIndex (poked :: VkGraphicsPipelineCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 20) (stageCount (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pStages (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pVertexInputState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pInputAssemblyState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 48) (pTessellationState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 56) (pViewportState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 64) (pRasterizationState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 72) (pMultisampleState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 80) (pDepthStencilState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 88) (pColorBlendState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 96) (pDynamicState (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 104) (layout (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 112) (renderPass (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 120) (subpass (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 128) (basePipelineHandle (poked :: VkGraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 136) (basePipelineIndex (poked :: VkGraphicsPipelineCreateInfo))
 
 
 -- ** VkCullModeFlags
@@ -229,13 +229,13 @@ newtype VkPipelineDepthStencilStateCreateFlags = VkPipelineDepthStencilStateCrea
 
 
 data VkPipelineShaderStageCreateInfo =
-  VkPipelineShaderStageCreateInfo{ vkSType :: VkStructureType 
-                                 , vkPNext :: Ptr Void 
-                                 , vkFlags :: VkPipelineShaderStageCreateFlags 
-                                 , vkStage :: VkShaderStageFlagBits 
-                                 , vkModule :: VkShaderModule 
-                                 , vkPName :: Ptr CChar 
-                                 , vkPSpecializationInfo :: Ptr VkSpecializationInfo 
+  VkPipelineShaderStageCreateInfo{ sType :: VkStructureType 
+                                 , pNext :: Ptr Void 
+                                 , flags :: VkPipelineShaderStageCreateFlags 
+                                 , stage :: VkShaderStageFlagBits 
+                                 , _module :: ShaderModule 
+                                 , pName :: Ptr CChar 
+                                 , pSpecializationInfo :: Ptr VkSpecializationInfo 
                                  }
   deriving (Eq)
 
@@ -249,13 +249,13 @@ instance Storable VkPipelineShaderStageCreateInfo where
                                              <*> peek (ptr `plusPtr` 24)
                                              <*> peek (ptr `plusPtr` 32)
                                              <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkStage (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkModule (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPName (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPSpecializationInfo (poked :: VkPipelineShaderStageCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 20) (stage (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 24) (_module (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pName (poked :: VkPipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pSpecializationInfo (poked :: VkPipelineShaderStageCreateInfo))
 
 
 -- ** VkColorComponentFlags
@@ -299,13 +299,13 @@ pattern VK_COLOR_COMPONENT_A_BIT = VkColorComponentFlagBits 0x8
 
 
 data VkComputePipelineCreateInfo =
-  VkComputePipelineCreateInfo{ vkSType :: VkStructureType 
-                             , vkPNext :: Ptr Void 
-                             , vkFlags :: VkPipelineCreateFlags 
-                             , vkStage :: VkPipelineShaderStageCreateInfo 
-                             , vkLayout :: VkPipelineLayout 
-                             , vkBasePipelineHandle :: VkPipeline 
-                             , vkBasePipelineIndex :: Int32 
+  VkComputePipelineCreateInfo{ sType :: VkStructureType 
+                             , pNext :: Ptr Void 
+                             , flags :: VkPipelineCreateFlags 
+                             , stage :: VkPipelineShaderStageCreateInfo 
+                             , layout :: PipelineLayout 
+                             , basePipelineHandle :: Pipeline 
+                             , basePipelineIndex :: Int32 
                              }
   deriving (Eq)
 
@@ -319,13 +319,13 @@ instance Storable VkComputePipelineCreateInfo where
                                          <*> peek (ptr `plusPtr` 72)
                                          <*> peek (ptr `plusPtr` 80)
                                          <*> peek (ptr `plusPtr` 88)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkStage (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 72) (vkLayout (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 80) (vkBasePipelineHandle (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 88) (vkBasePipelineIndex (poked :: VkComputePipelineCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 24) (stage (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 72) (layout (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 80) (basePipelineHandle (poked :: VkComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 88) (basePipelineIndex (poked :: VkComputePipelineCreateInfo))
 
 
 -- ** VkStencilOp
@@ -380,10 +380,10 @@ pattern VK_STENCIL_OP_DECREMENT_AND_WRAP = VkStencilOp 7
 
 
 data VkSpecializationInfo =
-  VkSpecializationInfo{ vkMapEntryCount :: Word32 
-                      , vkPMapEntries :: Ptr VkSpecializationMapEntry 
-                      , vkDataSize :: CSize 
-                      , vkPData :: Ptr Void 
+  VkSpecializationInfo{ mapEntryCount :: Word32 
+                      , pMapEntries :: Ptr VkSpecializationMapEntry 
+                      , dataSize :: CSize 
+                      , pData :: Ptr Void 
                       }
   deriving (Eq)
 
@@ -394,10 +394,10 @@ instance Storable VkSpecializationInfo where
                                   <*> peek (ptr `plusPtr` 8)
                                   <*> peek (ptr `plusPtr` 16)
                                   <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkMapEntryCount (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 8) (vkPMapEntries (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 16) (vkDataSize (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 24) (vkPData (poked :: VkSpecializationInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (mapEntryCount (poked :: VkSpecializationInfo))
+                *> poke (ptr `plusPtr` 8) (pMapEntries (poked :: VkSpecializationInfo))
+                *> poke (ptr `plusPtr` 16) (dataSize (poked :: VkSpecializationInfo))
+                *> poke (ptr `plusPtr` 24) (pData (poked :: VkSpecializationInfo))
 
 
 -- ** VkPipelineColorBlendStateCreateFlags
@@ -405,7 +405,7 @@ instance Storable VkSpecializationInfo where
 newtype VkPipelineColorBlendStateCreateFlags = VkPipelineColorBlendStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
-newtype VkPipeline = VkPipeline Word64
+newtype Pipeline = Pipeline Word64
   deriving (Eq, Storable)
 
 -- ** VkPipelineInputAssemblyStateCreateFlags
@@ -415,11 +415,11 @@ newtype VkPipelineInputAssemblyStateCreateFlags = VkPipelineInputAssemblyStateCr
 
 -- ** vkCreateGraphicsPipelines
 foreign import ccall "vkCreateGraphicsPipelines" vkCreateGraphicsPipelines ::
-  VkDevice ->
-  VkPipelineCache ->
+  Device ->
+  PipelineCache ->
     Word32 ->
       Ptr VkGraphicsPipelineCreateInfo ->
-        Ptr VkAllocationCallbacks -> Ptr VkPipeline -> IO VkResult
+        Ptr VkAllocationCallbacks -> Ptr Pipeline -> IO VkResult
 
 -- ** VkFrontFace
 
@@ -691,19 +691,19 @@ newtype VkPipelineDynamicStateCreateFlags = VkPipelineDynamicStateCreateFlags Vk
 
 
 data VkPipelineRasterizationStateCreateInfo =
-  VkPipelineRasterizationStateCreateInfo{ vkSType :: VkStructureType 
-                                        , vkPNext :: Ptr Void 
-                                        , vkFlags :: VkPipelineRasterizationStateCreateFlags 
-                                        , vkDepthClampEnable :: VkBool32 
-                                        , vkRasterizerDiscardEnable :: VkBool32 
-                                        , vkPolygonMode :: VkPolygonMode 
-                                        , vkCullMode :: VkCullModeFlags 
-                                        , vkFrontFace :: VkFrontFace 
-                                        , vkDepthBiasEnable :: VkBool32 
-                                        , vkDepthBiasConstantFactor :: CFloat 
-                                        , vkDepthBiasClamp :: CFloat 
-                                        , vkDepthBiasSlopeFactor :: CFloat 
-                                        , vkLineWidth :: CFloat 
+  VkPipelineRasterizationStateCreateInfo{ sType :: VkStructureType 
+                                        , pNext :: Ptr Void 
+                                        , flags :: VkPipelineRasterizationStateCreateFlags 
+                                        , depthClampEnable :: VkBool32 
+                                        , rasterizerDiscardEnable :: VkBool32 
+                                        , polygonMode :: VkPolygonMode 
+                                        , cullMode :: VkCullModeFlags 
+                                        , frontFace :: VkFrontFace 
+                                        , depthBiasEnable :: VkBool32 
+                                        , depthBiasConstantFactor :: CFloat 
+                                        , depthBiasClamp :: CFloat 
+                                        , depthBiasSlopeFactor :: CFloat 
+                                        , lineWidth :: CFloat 
                                         }
   deriving (Eq)
 
@@ -723,19 +723,19 @@ instance Storable VkPipelineRasterizationStateCreateInfo where
                                                     <*> peek (ptr `plusPtr` 48)
                                                     <*> peek (ptr `plusPtr` 52)
                                                     <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkDepthClampEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkRasterizerDiscardEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkPolygonMode (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkCullMode (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 36) (vkFrontFace (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkDepthBiasEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 44) (vkDepthBiasConstantFactor (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkDepthBiasClamp (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 52) (vkDepthBiasSlopeFactor (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkLineWidth (poked :: VkPipelineRasterizationStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (depthClampEnable (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (rasterizerDiscardEnable (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (polygonMode (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (cullMode (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 36) (frontFace (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (depthBiasEnable (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 44) (depthBiasConstantFactor (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 52) (depthBiasSlopeFactor (poked :: VkPipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 56) (lineWidth (poked :: VkPipelineRasterizationStateCreateInfo))
 
 
 -- ** VkBlendOp
@@ -778,7 +778,7 @@ pattern VK_BLEND_OP_MAX = VkBlendOp 4
 
 -- ** vkDestroyPipeline
 foreign import ccall "vkDestroyPipeline" vkDestroyPipeline ::
-  VkDevice -> VkPipeline -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Pipeline -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkPipelineShaderStageCreateFlags
 -- | Opaque flag
@@ -787,13 +787,13 @@ newtype VkPipelineShaderStageCreateFlags = VkPipelineShaderStageCreateFlags VkFl
 
 
 data VkPipelineViewportStateCreateInfo =
-  VkPipelineViewportStateCreateInfo{ vkSType :: VkStructureType 
-                                   , vkPNext :: Ptr Void 
-                                   , vkFlags :: VkPipelineViewportStateCreateFlags 
-                                   , vkViewportCount :: Word32 
-                                   , vkPViewports :: Ptr VkViewport 
-                                   , vkScissorCount :: Word32 
-                                   , vkPScissors :: Ptr VkRect2D 
+  VkPipelineViewportStateCreateInfo{ sType :: VkStructureType 
+                                   , pNext :: Ptr Void 
+                                   , flags :: VkPipelineViewportStateCreateFlags 
+                                   , viewportCount :: Word32 
+                                   , pViewports :: Ptr VkViewport 
+                                   , scissorCount :: Word32 
+                                   , pScissors :: Ptr VkRect2D 
                                    }
   deriving (Eq)
 
@@ -807,13 +807,13 @@ instance Storable VkPipelineViewportStateCreateInfo where
                                                <*> peek (ptr `plusPtr` 24)
                                                <*> peek (ptr `plusPtr` 32)
                                                <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkViewportCount (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPViewports (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkScissorCount (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPScissors (poked :: VkPipelineViewportStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (viewportCount (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pViewports (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (scissorCount (poked :: VkPipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pScissors (poked :: VkPipelineViewportStateCreateInfo))
 
 
 -- ** VkPipelineTessellationStateCreateFlags
@@ -823,13 +823,13 @@ newtype VkPipelineTessellationStateCreateFlags = VkPipelineTessellationStateCrea
 
 
 data VkPipelineVertexInputStateCreateInfo =
-  VkPipelineVertexInputStateCreateInfo{ vkSType :: VkStructureType 
-                                      , vkPNext :: Ptr Void 
-                                      , vkFlags :: VkPipelineVertexInputStateCreateFlags 
-                                      , vkVertexBindingDescriptionCount :: Word32 
-                                      , vkPVertexBindingDescriptions :: Ptr VkVertexInputBindingDescription 
-                                      , vkVertexAttributeDescriptionCount :: Word32 
-                                      , vkPVertexAttributeDescriptions :: Ptr VkVertexInputAttributeDescription 
+  VkPipelineVertexInputStateCreateInfo{ sType :: VkStructureType 
+                                      , pNext :: Ptr Void 
+                                      , flags :: VkPipelineVertexInputStateCreateFlags 
+                                      , vertexBindingDescriptionCount :: Word32 
+                                      , pVertexBindingDescriptions :: Ptr VkVertexInputBindingDescription 
+                                      , vertexAttributeDescriptionCount :: Word32 
+                                      , pVertexAttributeDescriptions :: Ptr VkVertexInputAttributeDescription 
                                       }
   deriving (Eq)
 
@@ -843,13 +843,13 @@ instance Storable VkPipelineVertexInputStateCreateInfo where
                                                   <*> peek (ptr `plusPtr` 24)
                                                   <*> peek (ptr `plusPtr` 32)
                                                   <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkVertexBindingDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPVertexBindingDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkVertexAttributeDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPVertexAttributeDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (vertexBindingDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pVertexBindingDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (vertexAttributeDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pVertexAttributeDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
 
 
 -- ** VkPrimitiveTopology
@@ -916,11 +916,11 @@ pattern VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = VkPrimitiveTopology 10
 
 
 data VkPipelineInputAssemblyStateCreateInfo =
-  VkPipelineInputAssemblyStateCreateInfo{ vkSType :: VkStructureType 
-                                        , vkPNext :: Ptr Void 
-                                        , vkFlags :: VkPipelineInputAssemblyStateCreateFlags 
-                                        , vkTopology :: VkPrimitiveTopology 
-                                        , vkPrimitiveRestartEnable :: VkBool32 
+  VkPipelineInputAssemblyStateCreateInfo{ sType :: VkStructureType 
+                                        , pNext :: Ptr Void 
+                                        , flags :: VkPipelineInputAssemblyStateCreateFlags 
+                                        , topology :: VkPrimitiveTopology 
+                                        , primitiveRestartEnable :: VkBool32 
                                         }
   deriving (Eq)
 
@@ -932,23 +932,23 @@ instance Storable VkPipelineInputAssemblyStateCreateInfo where
                                                     <*> peek (ptr `plusPtr` 16)
                                                     <*> peek (ptr `plusPtr` 20)
                                                     <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkTopology (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPrimitiveRestartEnable (poked :: VkPipelineInputAssemblyStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (topology (poked :: VkPipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (primitiveRestartEnable (poked :: VkPipelineInputAssemblyStateCreateInfo))
 
 
 
 data VkPipelineColorBlendStateCreateInfo =
-  VkPipelineColorBlendStateCreateInfo{ vkSType :: VkStructureType 
-                                     , vkPNext :: Ptr Void 
-                                     , vkFlags :: VkPipelineColorBlendStateCreateFlags 
-                                     , vkLogicOpEnable :: VkBool32 
-                                     , vkLogicOp :: VkLogicOp 
-                                     , vkAttachmentCount :: Word32 
-                                     , vkPAttachments :: Ptr VkPipelineColorBlendAttachmentState 
-                                     , vkBlendConstants :: Vector 4 CFloat 
+  VkPipelineColorBlendStateCreateInfo{ sType :: VkStructureType 
+                                     , pNext :: Ptr Void 
+                                     , flags :: VkPipelineColorBlendStateCreateFlags 
+                                     , logicOpEnable :: VkBool32 
+                                     , logicOp :: VkLogicOp 
+                                     , attachmentCount :: Word32 
+                                     , pAttachments :: Ptr VkPipelineColorBlendAttachmentState 
+                                     , blendConstants :: Vector 4 CFloat 
                                      }
   deriving (Eq)
 
@@ -963,23 +963,23 @@ instance Storable VkPipelineColorBlendStateCreateInfo where
                                                  <*> peek (ptr `plusPtr` 28)
                                                  <*> peek (ptr `plusPtr` 32)
                                                  <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkLogicOpEnable (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkLogicOp (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkAttachmentCount (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPAttachments (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkBlendConstants (poked :: VkPipelineColorBlendStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (logicOpEnable (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (logicOp (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (attachmentCount (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pAttachments (poked :: VkPipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (blendConstants (poked :: VkPipelineColorBlendStateCreateInfo))
 
 
 
 data VkPipelineDynamicStateCreateInfo =
-  VkPipelineDynamicStateCreateInfo{ vkSType :: VkStructureType 
-                                  , vkPNext :: Ptr Void 
-                                  , vkFlags :: VkPipelineDynamicStateCreateFlags 
-                                  , vkDynamicStateCount :: Word32 
-                                  , vkPDynamicStates :: Ptr VkDynamicState 
+  VkPipelineDynamicStateCreateInfo{ sType :: VkStructureType 
+                                  , pNext :: Ptr Void 
+                                  , flags :: VkPipelineDynamicStateCreateFlags 
+                                  , dynamicStateCount :: Word32 
+                                  , pDynamicStates :: Ptr VkDynamicState 
                                   }
   deriving (Eq)
 
@@ -991,18 +991,18 @@ instance Storable VkPipelineDynamicStateCreateInfo where
                                               <*> peek (ptr `plusPtr` 16)
                                               <*> peek (ptr `plusPtr` 20)
                                               <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkDynamicStateCount (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPDynamicStates (poked :: VkPipelineDynamicStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (dynamicStateCount (poked :: VkPipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pDynamicStates (poked :: VkPipelineDynamicStateCreateInfo))
 
 
 
 data VkSpecializationMapEntry =
-  VkSpecializationMapEntry{ vkConstantID :: Word32 
-                          , vkOffset :: Word32 
-                          , vkSize :: CSize 
+  VkSpecializationMapEntry{ constantID :: Word32 
+                          , offset :: Word32 
+                          , size :: CSize 
                           }
   deriving (Eq)
 
@@ -1012,9 +1012,9 @@ instance Storable VkSpecializationMapEntry where
   peek ptr = VkSpecializationMapEntry <$> peek (ptr `plusPtr` 0)
                                       <*> peek (ptr `plusPtr` 4)
                                       <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkConstantID (poked :: VkSpecializationMapEntry))
-                *> poke (ptr `plusPtr` 4) (vkOffset (poked :: VkSpecializationMapEntry))
-                *> poke (ptr `plusPtr` 8) (vkSize (poked :: VkSpecializationMapEntry))
+  poke ptr poked = poke (ptr `plusPtr` 0) (constantID (poked :: VkSpecializationMapEntry))
+                *> poke (ptr `plusPtr` 4) (offset (poked :: VkSpecializationMapEntry))
+                *> poke (ptr `plusPtr` 8) (size (poked :: VkSpecializationMapEntry))
 
 
 -- ** VkPipelineVertexInputStateCreateFlags
@@ -1141,14 +1141,14 @@ pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = VkPipelineStageFlagBits 0x10000
 
 
 data VkPipelineColorBlendAttachmentState =
-  VkPipelineColorBlendAttachmentState{ vkBlendEnable :: VkBool32 
-                                     , vkSrcColorBlendFactor :: VkBlendFactor 
-                                     , vkDstColorBlendFactor :: VkBlendFactor 
-                                     , vkColorBlendOp :: VkBlendOp 
-                                     , vkSrcAlphaBlendFactor :: VkBlendFactor 
-                                     , vkDstAlphaBlendFactor :: VkBlendFactor 
-                                     , vkAlphaBlendOp :: VkBlendOp 
-                                     , vkColorWriteMask :: VkColorComponentFlags 
+  VkPipelineColorBlendAttachmentState{ blendEnable :: VkBool32 
+                                     , srcColorBlendFactor :: VkBlendFactor 
+                                     , dstColorBlendFactor :: VkBlendFactor 
+                                     , colorBlendOp :: VkBlendOp 
+                                     , srcAlphaBlendFactor :: VkBlendFactor 
+                                     , dstAlphaBlendFactor :: VkBlendFactor 
+                                     , alphaBlendOp :: VkBlendOp 
+                                     , colorWriteMask :: VkColorComponentFlags 
                                      }
   deriving (Eq)
 
@@ -1163,14 +1163,14 @@ instance Storable VkPipelineColorBlendAttachmentState where
                                                  <*> peek (ptr `plusPtr` 20)
                                                  <*> peek (ptr `plusPtr` 24)
                                                  <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBlendEnable (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 4) (vkSrcColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 8) (vkDstColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 12) (vkColorBlendOp (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 16) (vkSrcAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 20) (vkDstAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 24) (vkAlphaBlendOp (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 28) (vkColorWriteMask (poked :: VkPipelineColorBlendAttachmentState))
+  poke ptr poked = poke (ptr `plusPtr` 0) (blendEnable (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 4) (srcColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 8) (dstColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 12) (colorBlendOp (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 16) (srcAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 20) (dstAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 24) (alphaBlendOp (poked :: VkPipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 28) (colorWriteMask (poked :: VkPipelineColorBlendAttachmentState))
 
 
 -- ** VkBlendFactor
@@ -1277,15 +1277,15 @@ newtype VkPipelineMultisampleStateCreateFlags = VkPipelineMultisampleStateCreate
 
 
 data VkPipelineMultisampleStateCreateInfo =
-  VkPipelineMultisampleStateCreateInfo{ vkSType :: VkStructureType 
-                                      , vkPNext :: Ptr Void 
-                                      , vkFlags :: VkPipelineMultisampleStateCreateFlags 
-                                      , vkRasterizationSamples :: VkSampleCountFlagBits 
-                                      , vkSampleShadingEnable :: VkBool32 
-                                      , vkMinSampleShading :: CFloat 
-                                      , vkPSampleMask :: Ptr VkSampleMask 
-                                      , vkAlphaToCoverageEnable :: VkBool32 
-                                      , vkAlphaToOneEnable :: VkBool32 
+  VkPipelineMultisampleStateCreateInfo{ sType :: VkStructureType 
+                                      , pNext :: Ptr Void 
+                                      , flags :: VkPipelineMultisampleStateCreateFlags 
+                                      , rasterizationSamples :: VkSampleCountFlagBits 
+                                      , sampleShadingEnable :: VkBool32 
+                                      , minSampleShading :: CFloat 
+                                      , pSampleMask :: Ptr VkSampleMask 
+                                      , alphaToCoverageEnable :: VkBool32 
+                                      , alphaToOneEnable :: VkBool32 
                                       }
   deriving (Eq)
 
@@ -1301,22 +1301,22 @@ instance Storable VkPipelineMultisampleStateCreateInfo where
                                                   <*> peek (ptr `plusPtr` 32)
                                                   <*> peek (ptr `plusPtr` 40)
                                                   <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkRasterizationSamples (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkSampleShadingEnable (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkMinSampleShading (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPSampleMask (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkAlphaToCoverageEnable (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 44) (vkAlphaToOneEnable (poked :: VkPipelineMultisampleStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (rasterizationSamples (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (sampleShadingEnable (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (minSampleShading (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pSampleMask (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (alphaToCoverageEnable (poked :: VkPipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 44) (alphaToOneEnable (poked :: VkPipelineMultisampleStateCreateInfo))
 
 
 
 data VkVertexInputBindingDescription =
-  VkVertexInputBindingDescription{ vkBinding :: Word32 
-                                 , vkStride :: Word32 
-                                 , vkInputRate :: VkVertexInputRate 
+  VkVertexInputBindingDescription{ binding :: Word32 
+                                 , stride :: Word32 
+                                 , inputRate :: VkVertexInputRate 
                                  }
   deriving (Eq)
 
@@ -1326,25 +1326,25 @@ instance Storable VkVertexInputBindingDescription where
   peek ptr = VkVertexInputBindingDescription <$> peek (ptr `plusPtr` 0)
                                              <*> peek (ptr `plusPtr` 4)
                                              <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBinding (poked :: VkVertexInputBindingDescription))
-                *> poke (ptr `plusPtr` 4) (vkStride (poked :: VkVertexInputBindingDescription))
-                *> poke (ptr `plusPtr` 8) (vkInputRate (poked :: VkVertexInputBindingDescription))
+  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: VkVertexInputBindingDescription))
+                *> poke (ptr `plusPtr` 4) (stride (poked :: VkVertexInputBindingDescription))
+                *> poke (ptr `plusPtr` 8) (inputRate (poked :: VkVertexInputBindingDescription))
 
 
 
 data VkPipelineDepthStencilStateCreateInfo =
-  VkPipelineDepthStencilStateCreateInfo{ vkSType :: VkStructureType 
-                                       , vkPNext :: Ptr Void 
-                                       , vkFlags :: VkPipelineDepthStencilStateCreateFlags 
-                                       , vkDepthTestEnable :: VkBool32 
-                                       , vkDepthWriteEnable :: VkBool32 
-                                       , vkDepthCompareOp :: VkCompareOp 
-                                       , vkDepthBoundsTestEnable :: VkBool32 
-                                       , vkStencilTestEnable :: VkBool32 
-                                       , vkFront :: VkStencilOpState 
-                                       , vkBack :: VkStencilOpState 
-                                       , vkMinDepthBounds :: CFloat 
-                                       , vkMaxDepthBounds :: CFloat 
+  VkPipelineDepthStencilStateCreateInfo{ sType :: VkStructureType 
+                                       , pNext :: Ptr Void 
+                                       , flags :: VkPipelineDepthStencilStateCreateFlags 
+                                       , depthTestEnable :: VkBool32 
+                                       , depthWriteEnable :: VkBool32 
+                                       , depthCompareOp :: VkCompareOp 
+                                       , depthBoundsTestEnable :: VkBool32 
+                                       , stencilTestEnable :: VkBool32 
+                                       , front :: VkStencilOpState 
+                                       , back :: VkStencilOpState 
+                                       , minDepthBounds :: CFloat 
+                                       , maxDepthBounds :: CFloat 
                                        }
   deriving (Eq)
 
@@ -1363,37 +1363,37 @@ instance Storable VkPipelineDepthStencilStateCreateInfo where
                                                    <*> peek (ptr `plusPtr` 68)
                                                    <*> peek (ptr `plusPtr` 96)
                                                    <*> peek (ptr `plusPtr` 100)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkDepthTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkDepthWriteEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkDepthCompareOp (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkDepthBoundsTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 36) (vkStencilTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkFront (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 68) (vkBack (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 96) (vkMinDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 100) (vkMaxDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (depthTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (depthWriteEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (depthCompareOp (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (depthBoundsTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 36) (stencilTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (front (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 68) (back (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 96) (minDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 100) (maxDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
 
 
 -- ** vkCreateComputePipelines
 foreign import ccall "vkCreateComputePipelines" vkCreateComputePipelines ::
-  VkDevice ->
-  VkPipelineCache ->
+  Device ->
+  PipelineCache ->
     Word32 ->
       Ptr VkComputePipelineCreateInfo ->
-        Ptr VkAllocationCallbacks -> Ptr VkPipeline -> IO VkResult
+        Ptr VkAllocationCallbacks -> Ptr Pipeline -> IO VkResult
 
 
 data VkStencilOpState =
-  VkStencilOpState{ vkFailOp :: VkStencilOp 
-                  , vkPassOp :: VkStencilOp 
-                  , vkDepthFailOp :: VkStencilOp 
-                  , vkCompareOp :: VkCompareOp 
-                  , vkCompareMask :: Word32 
-                  , vkWriteMask :: Word32 
-                  , vkReference :: Word32 
+  VkStencilOpState{ failOp :: VkStencilOp 
+                  , passOp :: VkStencilOp 
+                  , depthFailOp :: VkStencilOp 
+                  , compareOp :: VkCompareOp 
+                  , compareMask :: Word32 
+                  , writeMask :: Word32 
+                  , reference :: Word32 
                   }
   deriving (Eq)
 
@@ -1407,12 +1407,12 @@ instance Storable VkStencilOpState where
                               <*> peek (ptr `plusPtr` 16)
                               <*> peek (ptr `plusPtr` 20)
                               <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkFailOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 4) (vkPassOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 8) (vkDepthFailOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 12) (vkCompareOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 16) (vkCompareMask (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 20) (vkWriteMask (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 24) (vkReference (poked :: VkStencilOpState))
+  poke ptr poked = poke (ptr `plusPtr` 0) (failOp (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 4) (passOp (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 8) (depthFailOp (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 12) (compareOp (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 16) (compareMask (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 20) (writeMask (poked :: VkStencilOpState))
+                *> poke (ptr `plusPtr` 24) (reference (poked :: VkStencilOpState))
 
 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -7,17 +7,66 @@ module Graphics.Vulkan.Pipeline where
 
 import Data.Vector.Storable.Sized( Vector
                                  )
+import Graphics.Vulkan.Device( Device
+                             )
+import {-# SOURCE #-} Graphics.Vulkan.Pass( RenderPass
+                                          )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
+import Graphics.Vulkan.Pipeline( VkVertexInputBindingDescription
+                               , VkColorComponentFlags
+                               , VkPolygonMode
+                               , VkPipelineTessellationStateCreateFlags
+                               , VkPipelineInputAssemblyStateCreateInfo
+                               , VkPipelineDepthStencilStateCreateInfo
+                               , VkPrimitiveTopology
+                               , VkPipelineShaderStageCreateFlags
+                               , VkPipelineCreateFlags
+                               , VkSampleMask
+                               , VkPipelineMultisampleStateCreateFlags
+                               , VkPipelineShaderStageCreateInfo
+                               , VkSpecializationMapEntry
+                               , VkPipelineVertexInputStateCreateFlags
+                               , VkPipelineInputAssemblyStateCreateFlags
+                               , VkPipelineRasterizationStateCreateInfo
+                               , VkDynamicState
+                               , VkPipelineColorBlendStateCreateFlags
+                               , VkPipelineDynamicStateCreateFlags
+                               , VkPipelineColorBlendStateCreateInfo
+                               , VkPipelineMultisampleStateCreateInfo
+                               , VkPipelineViewportStateCreateFlags
+                               , VkPipelineColorBlendAttachmentState
+                               , VkFrontFace
+                               , VkCullModeFlags
+                               , VkPipelineDepthStencilStateCreateFlags
+                               , VkVertexInputAttributeDescription
+                               , VkPipelineRasterizationStateCreateFlags
+                               , VkStencilOpState
+                               , VkPipelineVertexInputStateCreateInfo
+                               , VkSpecializationInfo
+                               , VkLogicOp
+                               , VkStencilOp
+                               , VkComputePipelineCreateInfo
+                               , VkPipelineViewportStateCreateInfo
+                               , VkPipelineTessellationStateCreateInfo
+                               , VkVertexInputRate
+                               , VkBlendFactor
+                               , VkGraphicsPipelineCreateInfo
+                               , VkBlendOp
+                               , VkPipelineDynamicStateCreateInfo
+                               , Pipeline
+                               )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.PipelineCache( PipelineCache
+                                    )
 import Data.Int( Int32
                )
 import Data.Bits( Bits
@@ -27,6 +76,10 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.PipelineLayout( PipelineLayout
+                                     )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -34,6 +87,20 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Shader( ShaderModule
+                             , VkShaderStageFlagBits
+                             )
+import Graphics.Vulkan.Sampler( VkCompareOp
+                              , VkSampleCountFlagBits
+                              )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkFormat
+                           , VkViewport
+                           , VkRect2D
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       , CFloat
                       , CChar

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -397,8 +397,8 @@ newtype Pipeline = Pipeline Word64
 newtype PipelineInputAssemblyStateCreateFlags = PipelineInputAssemblyStateCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkCreateGraphicsPipelines
-foreign import ccall "vkCreateGraphicsPipelines" vkCreateGraphicsPipelines ::
+-- ** createGraphicsPipelines
+foreign import ccall "vkCreateGraphicsPipelines" createGraphicsPipelines ::
   Device ->
   PipelineCache ->
     Word32 ->
@@ -757,8 +757,8 @@ pattern VK_BLEND_OP_MIN = BlendOp 3
 
 pattern VK_BLEND_OP_MAX = BlendOp 4
 
--- ** vkDestroyPipeline
-foreign import ccall "vkDestroyPipeline" vkDestroyPipeline ::
+-- ** destroyPipeline
+foreign import ccall "vkDestroyPipeline" destroyPipeline ::
   Device -> Pipeline -> Ptr AllocationCallbacks -> IO ()
 
 -- ** PipelineShaderStageCreateFlags
@@ -1355,8 +1355,8 @@ instance Storable PipelineDepthStencilStateCreateInfo where
                 *> poke (ptr `plusPtr` 100) (maxDepthBounds (poked :: PipelineDepthStencilStateCreateInfo))
 
 
--- ** vkCreateComputePipelines
-foreign import ccall "vkCreateComputePipelines" vkCreateComputePipelines ::
+-- ** createComputePipelines
+foreign import ccall "vkCreateComputePipelines" createComputePipelines ::
   Device ->
   PipelineCache ->
     Word32 ->

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -34,7 +34,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
                                      )
@@ -54,9 +54,9 @@ import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
                            , VkFlags(..)
-                           , VkRect2D(..)
+                           , Viewport(..)
                            , VkBool32(..)
-                           , VkViewport(..)
+                           , Rect2D(..)
                            , VkResult(..)
                            )
 import Foreign.C.Types( CFloat(..)
@@ -65,114 +65,114 @@ import Foreign.C.Types( CFloat(..)
                       )
 
 
-data VkPipelineTessellationStateCreateInfo =
-  VkPipelineTessellationStateCreateInfo{ sType :: VkStructureType 
-                                       , pNext :: Ptr Void 
-                                       , flags :: VkPipelineTessellationStateCreateFlags 
-                                       , patchControlPoints :: Word32 
-                                       }
+data PipelineTessellationStateCreateInfo =
+  PipelineTessellationStateCreateInfo{ sType :: VkStructureType 
+                                     , pNext :: Ptr Void 
+                                     , flags :: VkPipelineTessellationStateCreateFlags 
+                                     , patchControlPoints :: Word32 
+                                     }
   deriving (Eq)
 
-instance Storable VkPipelineTessellationStateCreateInfo where
+instance Storable PipelineTessellationStateCreateInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkPipelineTessellationStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                   <*> peek (ptr `plusPtr` 8)
-                                                   <*> peek (ptr `plusPtr` 16)
-                                                   <*> peek (ptr `plusPtr` 20)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineTessellationStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (patchControlPoints (poked :: VkPipelineTessellationStateCreateInfo))
+  peek ptr = PipelineTessellationStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                 <*> peek (ptr `plusPtr` 8)
+                                                 <*> peek (ptr `plusPtr` 16)
+                                                 <*> peek (ptr `plusPtr` 20)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineTessellationStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (patchControlPoints (poked :: PipelineTessellationStateCreateInfo))
 
 
 
-data VkVertexInputAttributeDescription =
-  VkVertexInputAttributeDescription{ location :: Word32 
-                                   , binding :: Word32 
-                                   , format :: VkFormat 
-                                   , offset :: Word32 
-                                   }
+data VertexInputAttributeDescription =
+  VertexInputAttributeDescription{ location :: Word32 
+                                 , binding :: Word32 
+                                 , format :: VkFormat 
+                                 , offset :: Word32 
+                                 }
   deriving (Eq)
 
-instance Storable VkVertexInputAttributeDescription where
+instance Storable VertexInputAttributeDescription where
   sizeOf ~_ = 16
   alignment ~_ = 4
-  peek ptr = VkVertexInputAttributeDescription <$> peek (ptr `plusPtr` 0)
-                                               <*> peek (ptr `plusPtr` 4)
-                                               <*> peek (ptr `plusPtr` 8)
-                                               <*> peek (ptr `plusPtr` 12)
-  poke ptr poked = poke (ptr `plusPtr` 0) (location (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 4) (binding (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 8) (format (poked :: VkVertexInputAttributeDescription))
-                *> poke (ptr `plusPtr` 12) (offset (poked :: VkVertexInputAttributeDescription))
+  peek ptr = VertexInputAttributeDescription <$> peek (ptr `plusPtr` 0)
+                                             <*> peek (ptr `plusPtr` 4)
+                                             <*> peek (ptr `plusPtr` 8)
+                                             <*> peek (ptr `plusPtr` 12)
+  poke ptr poked = poke (ptr `plusPtr` 0) (location (poked :: VertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 4) (binding (poked :: VertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 8) (format (poked :: VertexInputAttributeDescription))
+                *> poke (ptr `plusPtr` 12) (offset (poked :: VertexInputAttributeDescription))
 
 
 
-data VkGraphicsPipelineCreateInfo =
-  VkGraphicsPipelineCreateInfo{ sType :: VkStructureType 
-                              , pNext :: Ptr Void 
-                              , flags :: VkPipelineCreateFlags 
-                              , stageCount :: Word32 
-                              , pStages :: Ptr VkPipelineShaderStageCreateInfo 
-                              , pVertexInputState :: Ptr VkPipelineVertexInputStateCreateInfo 
-                              , pInputAssemblyState :: Ptr VkPipelineInputAssemblyStateCreateInfo 
-                              , pTessellationState :: Ptr VkPipelineTessellationStateCreateInfo 
-                              , pViewportState :: Ptr VkPipelineViewportStateCreateInfo 
-                              , pRasterizationState :: Ptr VkPipelineRasterizationStateCreateInfo 
-                              , pMultisampleState :: Ptr VkPipelineMultisampleStateCreateInfo 
-                              , pDepthStencilState :: Ptr VkPipelineDepthStencilStateCreateInfo 
-                              , pColorBlendState :: Ptr VkPipelineColorBlendStateCreateInfo 
-                              , pDynamicState :: Ptr VkPipelineDynamicStateCreateInfo 
-                              , layout :: PipelineLayout 
-                              , renderPass :: RenderPass 
-                              , subpass :: Word32 
-                              , basePipelineHandle :: Pipeline 
-                              , basePipelineIndex :: Int32 
-                              }
+data GraphicsPipelineCreateInfo =
+  GraphicsPipelineCreateInfo{ sType :: VkStructureType 
+                            , pNext :: Ptr Void 
+                            , flags :: VkPipelineCreateFlags 
+                            , stageCount :: Word32 
+                            , pStages :: Ptr PipelineShaderStageCreateInfo 
+                            , pVertexInputState :: Ptr PipelineVertexInputStateCreateInfo 
+                            , pInputAssemblyState :: Ptr PipelineInputAssemblyStateCreateInfo 
+                            , pTessellationState :: Ptr PipelineTessellationStateCreateInfo 
+                            , pViewportState :: Ptr PipelineViewportStateCreateInfo 
+                            , pRasterizationState :: Ptr PipelineRasterizationStateCreateInfo 
+                            , pMultisampleState :: Ptr PipelineMultisampleStateCreateInfo 
+                            , pDepthStencilState :: Ptr PipelineDepthStencilStateCreateInfo 
+                            , pColorBlendState :: Ptr PipelineColorBlendStateCreateInfo 
+                            , pDynamicState :: Ptr PipelineDynamicStateCreateInfo 
+                            , layout :: PipelineLayout 
+                            , renderPass :: RenderPass 
+                            , subpass :: Word32 
+                            , basePipelineHandle :: Pipeline 
+                            , basePipelineIndex :: Int32 
+                            }
   deriving (Eq)
 
-instance Storable VkGraphicsPipelineCreateInfo where
+instance Storable GraphicsPipelineCreateInfo where
   sizeOf ~_ = 144
   alignment ~_ = 8
-  peek ptr = VkGraphicsPipelineCreateInfo <$> peek (ptr `plusPtr` 0)
-                                          <*> peek (ptr `plusPtr` 8)
-                                          <*> peek (ptr `plusPtr` 16)
-                                          <*> peek (ptr `plusPtr` 20)
-                                          <*> peek (ptr `plusPtr` 24)
-                                          <*> peek (ptr `plusPtr` 32)
-                                          <*> peek (ptr `plusPtr` 40)
-                                          <*> peek (ptr `plusPtr` 48)
-                                          <*> peek (ptr `plusPtr` 56)
-                                          <*> peek (ptr `plusPtr` 64)
-                                          <*> peek (ptr `plusPtr` 72)
-                                          <*> peek (ptr `plusPtr` 80)
-                                          <*> peek (ptr `plusPtr` 88)
-                                          <*> peek (ptr `plusPtr` 96)
-                                          <*> peek (ptr `plusPtr` 104)
-                                          <*> peek (ptr `plusPtr` 112)
-                                          <*> peek (ptr `plusPtr` 120)
-                                          <*> peek (ptr `plusPtr` 128)
-                                          <*> peek (ptr `plusPtr` 136)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 20) (stageCount (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pStages (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pVertexInputState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pInputAssemblyState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 48) (pTessellationState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 56) (pViewportState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 64) (pRasterizationState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 72) (pMultisampleState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 80) (pDepthStencilState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 88) (pColorBlendState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 96) (pDynamicState (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 104) (layout (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 112) (renderPass (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 120) (subpass (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 128) (basePipelineHandle (poked :: VkGraphicsPipelineCreateInfo))
-                *> poke (ptr `plusPtr` 136) (basePipelineIndex (poked :: VkGraphicsPipelineCreateInfo))
+  peek ptr = GraphicsPipelineCreateInfo <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 16)
+                                        <*> peek (ptr `plusPtr` 20)
+                                        <*> peek (ptr `plusPtr` 24)
+                                        <*> peek (ptr `plusPtr` 32)
+                                        <*> peek (ptr `plusPtr` 40)
+                                        <*> peek (ptr `plusPtr` 48)
+                                        <*> peek (ptr `plusPtr` 56)
+                                        <*> peek (ptr `plusPtr` 64)
+                                        <*> peek (ptr `plusPtr` 72)
+                                        <*> peek (ptr `plusPtr` 80)
+                                        <*> peek (ptr `plusPtr` 88)
+                                        <*> peek (ptr `plusPtr` 96)
+                                        <*> peek (ptr `plusPtr` 104)
+                                        <*> peek (ptr `plusPtr` 112)
+                                        <*> peek (ptr `plusPtr` 120)
+                                        <*> peek (ptr `plusPtr` 128)
+                                        <*> peek (ptr `plusPtr` 136)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 20) (stageCount (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pStages (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pVertexInputState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pInputAssemblyState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 48) (pTessellationState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 56) (pViewportState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 64) (pRasterizationState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 72) (pMultisampleState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 80) (pDepthStencilState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 88) (pColorBlendState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 96) (pDynamicState (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 104) (layout (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 112) (renderPass (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 120) (subpass (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 128) (basePipelineHandle (poked :: GraphicsPipelineCreateInfo))
+                *> poke (ptr `plusPtr` 136) (basePipelineIndex (poked :: GraphicsPipelineCreateInfo))
 
 
 -- ** VkCullModeFlags
@@ -215,34 +215,34 @@ newtype VkPipelineDepthStencilStateCreateFlags = VkPipelineDepthStencilStateCrea
   deriving (Eq, Storable)
 
 
-data VkPipelineShaderStageCreateInfo =
-  VkPipelineShaderStageCreateInfo{ sType :: VkStructureType 
-                                 , pNext :: Ptr Void 
-                                 , flags :: VkPipelineShaderStageCreateFlags 
-                                 , stage :: VkShaderStageFlags 
-                                 , _module :: ShaderModule 
-                                 , pName :: Ptr CChar 
-                                 , pSpecializationInfo :: Ptr VkSpecializationInfo 
-                                 }
+data PipelineShaderStageCreateInfo =
+  PipelineShaderStageCreateInfo{ sType :: VkStructureType 
+                               , pNext :: Ptr Void 
+                               , flags :: VkPipelineShaderStageCreateFlags 
+                               , stage :: VkShaderStageFlags 
+                               , _module :: ShaderModule 
+                               , pName :: Ptr CChar 
+                               , pSpecializationInfo :: Ptr SpecializationInfo 
+                               }
   deriving (Eq)
 
-instance Storable VkPipelineShaderStageCreateInfo where
+instance Storable PipelineShaderStageCreateInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkPipelineShaderStageCreateInfo <$> peek (ptr `plusPtr` 0)
-                                             <*> peek (ptr `plusPtr` 8)
-                                             <*> peek (ptr `plusPtr` 16)
-                                             <*> peek (ptr `plusPtr` 20)
-                                             <*> peek (ptr `plusPtr` 24)
-                                             <*> peek (ptr `plusPtr` 32)
-                                             <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 20) (stage (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 24) (_module (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pName (poked :: VkPipelineShaderStageCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pSpecializationInfo (poked :: VkPipelineShaderStageCreateInfo))
+  peek ptr = PipelineShaderStageCreateInfo <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 8)
+                                           <*> peek (ptr `plusPtr` 16)
+                                           <*> peek (ptr `plusPtr` 20)
+                                           <*> peek (ptr `plusPtr` 24)
+                                           <*> peek (ptr `plusPtr` 32)
+                                           <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 20) (stage (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 24) (_module (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pName (poked :: PipelineShaderStageCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pSpecializationInfo (poked :: PipelineShaderStageCreateInfo))
 
 
 -- ** VkColorComponentFlags
@@ -282,34 +282,34 @@ pattern VK_COLOR_COMPONENT_A_BIT = VkColorComponentFlags 0x8
 
 
 
-data VkComputePipelineCreateInfo =
-  VkComputePipelineCreateInfo{ sType :: VkStructureType 
-                             , pNext :: Ptr Void 
-                             , flags :: VkPipelineCreateFlags 
-                             , stage :: VkPipelineShaderStageCreateInfo 
-                             , layout :: PipelineLayout 
-                             , basePipelineHandle :: Pipeline 
-                             , basePipelineIndex :: Int32 
-                             }
+data ComputePipelineCreateInfo =
+  ComputePipelineCreateInfo{ sType :: VkStructureType 
+                           , pNext :: Ptr Void 
+                           , flags :: VkPipelineCreateFlags 
+                           , stage :: PipelineShaderStageCreateInfo 
+                           , layout :: PipelineLayout 
+                           , basePipelineHandle :: Pipeline 
+                           , basePipelineIndex :: Int32 
+                           }
   deriving (Eq)
 
-instance Storable VkComputePipelineCreateInfo where
+instance Storable ComputePipelineCreateInfo where
   sizeOf ~_ = 96
   alignment ~_ = 8
-  peek ptr = VkComputePipelineCreateInfo <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-                                         <*> peek (ptr `plusPtr` 16)
-                                         <*> peek (ptr `plusPtr` 24)
-                                         <*> peek (ptr `plusPtr` 72)
-                                         <*> peek (ptr `plusPtr` 80)
-                                         <*> peek (ptr `plusPtr` 88)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 24) (stage (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 72) (layout (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 80) (basePipelineHandle (poked :: VkComputePipelineCreateInfo))
-                *> poke (ptr `plusPtr` 88) (basePipelineIndex (poked :: VkComputePipelineCreateInfo))
+  peek ptr = ComputePipelineCreateInfo <$> peek (ptr `plusPtr` 0)
+                                       <*> peek (ptr `plusPtr` 8)
+                                       <*> peek (ptr `plusPtr` 16)
+                                       <*> peek (ptr `plusPtr` 24)
+                                       <*> peek (ptr `plusPtr` 72)
+                                       <*> peek (ptr `plusPtr` 80)
+                                       <*> peek (ptr `plusPtr` 88)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 24) (stage (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 72) (layout (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 80) (basePipelineHandle (poked :: ComputePipelineCreateInfo))
+                *> poke (ptr `plusPtr` 88) (basePipelineIndex (poked :: ComputePipelineCreateInfo))
 
 
 -- ** VkStencilOp
@@ -363,25 +363,25 @@ pattern VK_STENCIL_OP_INCREMENT_AND_WRAP = VkStencilOp 6
 pattern VK_STENCIL_OP_DECREMENT_AND_WRAP = VkStencilOp 7
 
 
-data VkSpecializationInfo =
-  VkSpecializationInfo{ mapEntryCount :: Word32 
-                      , pMapEntries :: Ptr VkSpecializationMapEntry 
-                      , dataSize :: CSize 
-                      , pData :: Ptr Void 
-                      }
+data SpecializationInfo =
+  SpecializationInfo{ mapEntryCount :: Word32 
+                    , pMapEntries :: Ptr SpecializationMapEntry 
+                    , dataSize :: CSize 
+                    , pData :: Ptr Void 
+                    }
   deriving (Eq)
 
-instance Storable VkSpecializationInfo where
+instance Storable SpecializationInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkSpecializationInfo <$> peek (ptr `plusPtr` 0)
-                                  <*> peek (ptr `plusPtr` 8)
-                                  <*> peek (ptr `plusPtr` 16)
-                                  <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (mapEntryCount (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 8) (pMapEntries (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 16) (dataSize (poked :: VkSpecializationInfo))
-                *> poke (ptr `plusPtr` 24) (pData (poked :: VkSpecializationInfo))
+  peek ptr = SpecializationInfo <$> peek (ptr `plusPtr` 0)
+                                <*> peek (ptr `plusPtr` 8)
+                                <*> peek (ptr `plusPtr` 16)
+                                <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (mapEntryCount (poked :: SpecializationInfo))
+                *> poke (ptr `plusPtr` 8) (pMapEntries (poked :: SpecializationInfo))
+                *> poke (ptr `plusPtr` 16) (dataSize (poked :: SpecializationInfo))
+                *> poke (ptr `plusPtr` 24) (pData (poked :: SpecializationInfo))
 
 
 -- ** VkPipelineColorBlendStateCreateFlags
@@ -402,8 +402,8 @@ foreign import ccall "vkCreateGraphicsPipelines" vkCreateGraphicsPipelines ::
   Device ->
   PipelineCache ->
     Word32 ->
-      Ptr VkGraphicsPipelineCreateInfo ->
-        Ptr VkAllocationCallbacks -> Ptr Pipeline -> IO VkResult
+      Ptr GraphicsPipelineCreateInfo ->
+        Ptr AllocationCallbacks -> Ptr Pipeline -> IO VkResult
 
 -- ** VkFrontFace
 
@@ -671,52 +671,52 @@ newtype VkPipelineDynamicStateCreateFlags = VkPipelineDynamicStateCreateFlags Vk
   deriving (Eq, Storable)
 
 
-data VkPipelineRasterizationStateCreateInfo =
-  VkPipelineRasterizationStateCreateInfo{ sType :: VkStructureType 
-                                        , pNext :: Ptr Void 
-                                        , flags :: VkPipelineRasterizationStateCreateFlags 
-                                        , depthClampEnable :: VkBool32 
-                                        , rasterizerDiscardEnable :: VkBool32 
-                                        , polygonMode :: VkPolygonMode 
-                                        , cullMode :: VkCullModeFlags 
-                                        , frontFace :: VkFrontFace 
-                                        , depthBiasEnable :: VkBool32 
-                                        , depthBiasConstantFactor :: CFloat 
-                                        , depthBiasClamp :: CFloat 
-                                        , depthBiasSlopeFactor :: CFloat 
-                                        , lineWidth :: CFloat 
-                                        }
+data PipelineRasterizationStateCreateInfo =
+  PipelineRasterizationStateCreateInfo{ sType :: VkStructureType 
+                                      , pNext :: Ptr Void 
+                                      , flags :: VkPipelineRasterizationStateCreateFlags 
+                                      , depthClampEnable :: VkBool32 
+                                      , rasterizerDiscardEnable :: VkBool32 
+                                      , polygonMode :: VkPolygonMode 
+                                      , cullMode :: VkCullModeFlags 
+                                      , frontFace :: VkFrontFace 
+                                      , depthBiasEnable :: VkBool32 
+                                      , depthBiasConstantFactor :: CFloat 
+                                      , depthBiasClamp :: CFloat 
+                                      , depthBiasSlopeFactor :: CFloat 
+                                      , lineWidth :: CFloat 
+                                      }
   deriving (Eq)
 
-instance Storable VkPipelineRasterizationStateCreateInfo where
+instance Storable PipelineRasterizationStateCreateInfo where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkPipelineRasterizationStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                    <*> peek (ptr `plusPtr` 8)
-                                                    <*> peek (ptr `plusPtr` 16)
-                                                    <*> peek (ptr `plusPtr` 20)
-                                                    <*> peek (ptr `plusPtr` 24)
-                                                    <*> peek (ptr `plusPtr` 28)
-                                                    <*> peek (ptr `plusPtr` 32)
-                                                    <*> peek (ptr `plusPtr` 36)
-                                                    <*> peek (ptr `plusPtr` 40)
-                                                    <*> peek (ptr `plusPtr` 44)
-                                                    <*> peek (ptr `plusPtr` 48)
-                                                    <*> peek (ptr `plusPtr` 52)
-                                                    <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (depthClampEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (rasterizerDiscardEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (polygonMode (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (cullMode (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 36) (frontFace (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (depthBiasEnable (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 44) (depthBiasConstantFactor (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 52) (depthBiasSlopeFactor (poked :: VkPipelineRasterizationStateCreateInfo))
-                *> poke (ptr `plusPtr` 56) (lineWidth (poked :: VkPipelineRasterizationStateCreateInfo))
+  peek ptr = PipelineRasterizationStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                  <*> peek (ptr `plusPtr` 8)
+                                                  <*> peek (ptr `plusPtr` 16)
+                                                  <*> peek (ptr `plusPtr` 20)
+                                                  <*> peek (ptr `plusPtr` 24)
+                                                  <*> peek (ptr `plusPtr` 28)
+                                                  <*> peek (ptr `plusPtr` 32)
+                                                  <*> peek (ptr `plusPtr` 36)
+                                                  <*> peek (ptr `plusPtr` 40)
+                                                  <*> peek (ptr `plusPtr` 44)
+                                                  <*> peek (ptr `plusPtr` 48)
+                                                  <*> peek (ptr `plusPtr` 52)
+                                                  <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (depthClampEnable (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (rasterizerDiscardEnable (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (polygonMode (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (cullMode (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 36) (frontFace (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (depthBiasEnable (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 44) (depthBiasConstantFactor (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 48) (depthBiasClamp (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 52) (depthBiasSlopeFactor (poked :: PipelineRasterizationStateCreateInfo))
+                *> poke (ptr `plusPtr` 56) (lineWidth (poked :: PipelineRasterizationStateCreateInfo))
 
 
 -- ** VkBlendOp
@@ -759,7 +759,7 @@ pattern VK_BLEND_OP_MAX = VkBlendOp 4
 
 -- ** vkDestroyPipeline
 foreign import ccall "vkDestroyPipeline" vkDestroyPipeline ::
-  Device -> Pipeline -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Pipeline -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkPipelineShaderStageCreateFlags
 -- | Opaque flag
@@ -767,34 +767,34 @@ newtype VkPipelineShaderStageCreateFlags = VkPipelineShaderStageCreateFlags VkFl
   deriving (Eq, Storable)
 
 
-data VkPipelineViewportStateCreateInfo =
-  VkPipelineViewportStateCreateInfo{ sType :: VkStructureType 
-                                   , pNext :: Ptr Void 
-                                   , flags :: VkPipelineViewportStateCreateFlags 
-                                   , viewportCount :: Word32 
-                                   , pViewports :: Ptr VkViewport 
-                                   , scissorCount :: Word32 
-                                   , pScissors :: Ptr VkRect2D 
-                                   }
+data PipelineViewportStateCreateInfo =
+  PipelineViewportStateCreateInfo{ sType :: VkStructureType 
+                                 , pNext :: Ptr Void 
+                                 , flags :: VkPipelineViewportStateCreateFlags 
+                                 , viewportCount :: Word32 
+                                 , pViewports :: Ptr Viewport 
+                                 , scissorCount :: Word32 
+                                 , pScissors :: Ptr Rect2D 
+                                 }
   deriving (Eq)
 
-instance Storable VkPipelineViewportStateCreateInfo where
+instance Storable PipelineViewportStateCreateInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkPipelineViewportStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                               <*> peek (ptr `plusPtr` 8)
-                                               <*> peek (ptr `plusPtr` 16)
-                                               <*> peek (ptr `plusPtr` 20)
-                                               <*> peek (ptr `plusPtr` 24)
-                                               <*> peek (ptr `plusPtr` 32)
-                                               <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (viewportCount (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pViewports (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (scissorCount (poked :: VkPipelineViewportStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pScissors (poked :: VkPipelineViewportStateCreateInfo))
+  peek ptr = PipelineViewportStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                             <*> peek (ptr `plusPtr` 8)
+                                             <*> peek (ptr `plusPtr` 16)
+                                             <*> peek (ptr `plusPtr` 20)
+                                             <*> peek (ptr `plusPtr` 24)
+                                             <*> peek (ptr `plusPtr` 32)
+                                             <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (viewportCount (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pViewports (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (scissorCount (poked :: PipelineViewportStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pScissors (poked :: PipelineViewportStateCreateInfo))
 
 
 -- ** VkPipelineTessellationStateCreateFlags
@@ -803,34 +803,34 @@ newtype VkPipelineTessellationStateCreateFlags = VkPipelineTessellationStateCrea
   deriving (Eq, Storable)
 
 
-data VkPipelineVertexInputStateCreateInfo =
-  VkPipelineVertexInputStateCreateInfo{ sType :: VkStructureType 
-                                      , pNext :: Ptr Void 
-                                      , flags :: VkPipelineVertexInputStateCreateFlags 
-                                      , vertexBindingDescriptionCount :: Word32 
-                                      , pVertexBindingDescriptions :: Ptr VkVertexInputBindingDescription 
-                                      , vertexAttributeDescriptionCount :: Word32 
-                                      , pVertexAttributeDescriptions :: Ptr VkVertexInputAttributeDescription 
-                                      }
+data PipelineVertexInputStateCreateInfo =
+  PipelineVertexInputStateCreateInfo{ sType :: VkStructureType 
+                                    , pNext :: Ptr Void 
+                                    , flags :: VkPipelineVertexInputStateCreateFlags 
+                                    , vertexBindingDescriptionCount :: Word32 
+                                    , pVertexBindingDescriptions :: Ptr VertexInputBindingDescription 
+                                    , vertexAttributeDescriptionCount :: Word32 
+                                    , pVertexAttributeDescriptions :: Ptr VertexInputAttributeDescription 
+                                    }
   deriving (Eq)
 
-instance Storable VkPipelineVertexInputStateCreateInfo where
+instance Storable PipelineVertexInputStateCreateInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkPipelineVertexInputStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                  <*> peek (ptr `plusPtr` 8)
-                                                  <*> peek (ptr `plusPtr` 16)
-                                                  <*> peek (ptr `plusPtr` 20)
-                                                  <*> peek (ptr `plusPtr` 24)
-                                                  <*> peek (ptr `plusPtr` 32)
-                                                  <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vertexBindingDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pVertexBindingDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vertexAttributeDescriptionCount (poked :: VkPipelineVertexInputStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pVertexAttributeDescriptions (poked :: VkPipelineVertexInputStateCreateInfo))
+  peek ptr = PipelineVertexInputStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                <*> peek (ptr `plusPtr` 8)
+                                                <*> peek (ptr `plusPtr` 16)
+                                                <*> peek (ptr `plusPtr` 20)
+                                                <*> peek (ptr `plusPtr` 24)
+                                                <*> peek (ptr `plusPtr` 32)
+                                                <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (vertexBindingDescriptionCount (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pVertexBindingDescriptions (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (vertexAttributeDescriptionCount (poked :: PipelineVertexInputStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pVertexAttributeDescriptions (poked :: PipelineVertexInputStateCreateInfo))
 
 
 -- ** VkPrimitiveTopology
@@ -896,106 +896,106 @@ pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = VkPrimitiveTopolog
 pattern VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = VkPrimitiveTopology 10
 
 
-data VkPipelineInputAssemblyStateCreateInfo =
-  VkPipelineInputAssemblyStateCreateInfo{ sType :: VkStructureType 
-                                        , pNext :: Ptr Void 
-                                        , flags :: VkPipelineInputAssemblyStateCreateFlags 
-                                        , topology :: VkPrimitiveTopology 
-                                        , primitiveRestartEnable :: VkBool32 
-                                        }
+data PipelineInputAssemblyStateCreateInfo =
+  PipelineInputAssemblyStateCreateInfo{ sType :: VkStructureType 
+                                      , pNext :: Ptr Void 
+                                      , flags :: VkPipelineInputAssemblyStateCreateFlags 
+                                      , topology :: VkPrimitiveTopology 
+                                      , primitiveRestartEnable :: VkBool32 
+                                      }
   deriving (Eq)
 
-instance Storable VkPipelineInputAssemblyStateCreateInfo where
+instance Storable PipelineInputAssemblyStateCreateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkPipelineInputAssemblyStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                    <*> peek (ptr `plusPtr` 8)
-                                                    <*> peek (ptr `plusPtr` 16)
-                                                    <*> peek (ptr `plusPtr` 20)
-                                                    <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (topology (poked :: VkPipelineInputAssemblyStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (primitiveRestartEnable (poked :: VkPipelineInputAssemblyStateCreateInfo))
+  peek ptr = PipelineInputAssemblyStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                  <*> peek (ptr `plusPtr` 8)
+                                                  <*> peek (ptr `plusPtr` 16)
+                                                  <*> peek (ptr `plusPtr` 20)
+                                                  <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (topology (poked :: PipelineInputAssemblyStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (primitiveRestartEnable (poked :: PipelineInputAssemblyStateCreateInfo))
 
 
 
-data VkPipelineColorBlendStateCreateInfo =
-  VkPipelineColorBlendStateCreateInfo{ sType :: VkStructureType 
-                                     , pNext :: Ptr Void 
-                                     , flags :: VkPipelineColorBlendStateCreateFlags 
-                                     , logicOpEnable :: VkBool32 
-                                     , logicOp :: VkLogicOp 
-                                     , attachmentCount :: Word32 
-                                     , pAttachments :: Ptr VkPipelineColorBlendAttachmentState 
-                                     , blendConstants :: Vector 4 CFloat 
-                                     }
+data PipelineColorBlendStateCreateInfo =
+  PipelineColorBlendStateCreateInfo{ sType :: VkStructureType 
+                                   , pNext :: Ptr Void 
+                                   , flags :: VkPipelineColorBlendStateCreateFlags 
+                                   , logicOpEnable :: VkBool32 
+                                   , logicOp :: VkLogicOp 
+                                   , attachmentCount :: Word32 
+                                   , pAttachments :: Ptr PipelineColorBlendAttachmentState 
+                                   , blendConstants :: Vector 4 CFloat 
+                                   }
   deriving (Eq)
 
-instance Storable VkPipelineColorBlendStateCreateInfo where
+instance Storable PipelineColorBlendStateCreateInfo where
   sizeOf ~_ = 56
   alignment ~_ = 8
-  peek ptr = VkPipelineColorBlendStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                 <*> peek (ptr `plusPtr` 8)
-                                                 <*> peek (ptr `plusPtr` 16)
-                                                 <*> peek (ptr `plusPtr` 20)
-                                                 <*> peek (ptr `plusPtr` 24)
-                                                 <*> peek (ptr `plusPtr` 28)
-                                                 <*> peek (ptr `plusPtr` 32)
-                                                 <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (logicOpEnable (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (logicOp (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (attachmentCount (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pAttachments (poked :: VkPipelineColorBlendStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (blendConstants (poked :: VkPipelineColorBlendStateCreateInfo))
+  peek ptr = PipelineColorBlendStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                               <*> peek (ptr `plusPtr` 8)
+                                               <*> peek (ptr `plusPtr` 16)
+                                               <*> peek (ptr `plusPtr` 20)
+                                               <*> peek (ptr `plusPtr` 24)
+                                               <*> peek (ptr `plusPtr` 28)
+                                               <*> peek (ptr `plusPtr` 32)
+                                               <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (logicOpEnable (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (logicOp (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (attachmentCount (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pAttachments (poked :: PipelineColorBlendStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (blendConstants (poked :: PipelineColorBlendStateCreateInfo))
 
 
 
-data VkPipelineDynamicStateCreateInfo =
-  VkPipelineDynamicStateCreateInfo{ sType :: VkStructureType 
-                                  , pNext :: Ptr Void 
-                                  , flags :: VkPipelineDynamicStateCreateFlags 
-                                  , dynamicStateCount :: Word32 
-                                  , pDynamicStates :: Ptr VkDynamicState 
-                                  }
+data PipelineDynamicStateCreateInfo =
+  PipelineDynamicStateCreateInfo{ sType :: VkStructureType 
+                                , pNext :: Ptr Void 
+                                , flags :: VkPipelineDynamicStateCreateFlags 
+                                , dynamicStateCount :: Word32 
+                                , pDynamicStates :: Ptr VkDynamicState 
+                                }
   deriving (Eq)
 
-instance Storable VkPipelineDynamicStateCreateInfo where
+instance Storable PipelineDynamicStateCreateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkPipelineDynamicStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                              <*> peek (ptr `plusPtr` 8)
-                                              <*> peek (ptr `plusPtr` 16)
-                                              <*> peek (ptr `plusPtr` 20)
-                                              <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (dynamicStateCount (poked :: VkPipelineDynamicStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pDynamicStates (poked :: VkPipelineDynamicStateCreateInfo))
+  peek ptr = PipelineDynamicStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                            <*> peek (ptr `plusPtr` 8)
+                                            <*> peek (ptr `plusPtr` 16)
+                                            <*> peek (ptr `plusPtr` 20)
+                                            <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (dynamicStateCount (poked :: PipelineDynamicStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pDynamicStates (poked :: PipelineDynamicStateCreateInfo))
 
 
 
-data VkSpecializationMapEntry =
-  VkSpecializationMapEntry{ constantID :: Word32 
-                          , offset :: Word32 
-                          , size :: CSize 
-                          }
+data SpecializationMapEntry =
+  SpecializationMapEntry{ constantID :: Word32 
+                        , offset :: Word32 
+                        , size :: CSize 
+                        }
   deriving (Eq)
 
-instance Storable VkSpecializationMapEntry where
+instance Storable SpecializationMapEntry where
   sizeOf ~_ = 16
   alignment ~_ = 8
-  peek ptr = VkSpecializationMapEntry <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 4)
-                                      <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (constantID (poked :: VkSpecializationMapEntry))
-                *> poke (ptr `plusPtr` 4) (offset (poked :: VkSpecializationMapEntry))
-                *> poke (ptr `plusPtr` 8) (size (poked :: VkSpecializationMapEntry))
+  peek ptr = SpecializationMapEntry <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 4)
+                                    <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (constantID (poked :: SpecializationMapEntry))
+                *> poke (ptr `plusPtr` 4) (offset (poked :: SpecializationMapEntry))
+                *> poke (ptr `plusPtr` 8) (size (poked :: SpecializationMapEntry))
 
 
 -- ** VkPipelineVertexInputStateCreateFlags
@@ -1118,37 +1118,37 @@ pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = VkPipelineStageFlags 0x10000
 
 
 
-data VkPipelineColorBlendAttachmentState =
-  VkPipelineColorBlendAttachmentState{ blendEnable :: VkBool32 
-                                     , srcColorBlendFactor :: VkBlendFactor 
-                                     , dstColorBlendFactor :: VkBlendFactor 
-                                     , colorBlendOp :: VkBlendOp 
-                                     , srcAlphaBlendFactor :: VkBlendFactor 
-                                     , dstAlphaBlendFactor :: VkBlendFactor 
-                                     , alphaBlendOp :: VkBlendOp 
-                                     , colorWriteMask :: VkColorComponentFlags 
-                                     }
+data PipelineColorBlendAttachmentState =
+  PipelineColorBlendAttachmentState{ blendEnable :: VkBool32 
+                                   , srcColorBlendFactor :: VkBlendFactor 
+                                   , dstColorBlendFactor :: VkBlendFactor 
+                                   , colorBlendOp :: VkBlendOp 
+                                   , srcAlphaBlendFactor :: VkBlendFactor 
+                                   , dstAlphaBlendFactor :: VkBlendFactor 
+                                   , alphaBlendOp :: VkBlendOp 
+                                   , colorWriteMask :: VkColorComponentFlags 
+                                   }
   deriving (Eq)
 
-instance Storable VkPipelineColorBlendAttachmentState where
+instance Storable PipelineColorBlendAttachmentState where
   sizeOf ~_ = 32
   alignment ~_ = 4
-  peek ptr = VkPipelineColorBlendAttachmentState <$> peek (ptr `plusPtr` 0)
-                                                 <*> peek (ptr `plusPtr` 4)
-                                                 <*> peek (ptr `plusPtr` 8)
-                                                 <*> peek (ptr `plusPtr` 12)
-                                                 <*> peek (ptr `plusPtr` 16)
-                                                 <*> peek (ptr `plusPtr` 20)
-                                                 <*> peek (ptr `plusPtr` 24)
-                                                 <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (blendEnable (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 4) (srcColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 8) (dstColorBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 12) (colorBlendOp (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 16) (srcAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 20) (dstAlphaBlendFactor (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 24) (alphaBlendOp (poked :: VkPipelineColorBlendAttachmentState))
-                *> poke (ptr `plusPtr` 28) (colorWriteMask (poked :: VkPipelineColorBlendAttachmentState))
+  peek ptr = PipelineColorBlendAttachmentState <$> peek (ptr `plusPtr` 0)
+                                               <*> peek (ptr `plusPtr` 4)
+                                               <*> peek (ptr `plusPtr` 8)
+                                               <*> peek (ptr `plusPtr` 12)
+                                               <*> peek (ptr `plusPtr` 16)
+                                               <*> peek (ptr `plusPtr` 20)
+                                               <*> peek (ptr `plusPtr` 24)
+                                               <*> peek (ptr `plusPtr` 28)
+  poke ptr poked = poke (ptr `plusPtr` 0) (blendEnable (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 4) (srcColorBlendFactor (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 8) (dstColorBlendFactor (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 12) (colorBlendOp (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 16) (srcAlphaBlendFactor (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 20) (dstAlphaBlendFactor (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 24) (alphaBlendOp (poked :: PipelineColorBlendAttachmentState))
+                *> poke (ptr `plusPtr` 28) (colorWriteMask (poked :: PipelineColorBlendAttachmentState))
 
 
 -- ** VkBlendFactor
@@ -1254,105 +1254,105 @@ newtype VkPipelineMultisampleStateCreateFlags = VkPipelineMultisampleStateCreate
   deriving (Eq, Storable)
 
 
-data VkPipelineMultisampleStateCreateInfo =
-  VkPipelineMultisampleStateCreateInfo{ sType :: VkStructureType 
-                                      , pNext :: Ptr Void 
-                                      , flags :: VkPipelineMultisampleStateCreateFlags 
-                                      , rasterizationSamples :: VkSampleCountFlags 
-                                      , sampleShadingEnable :: VkBool32 
-                                      , minSampleShading :: CFloat 
-                                      , pSampleMask :: Ptr VkSampleMask 
-                                      , alphaToCoverageEnable :: VkBool32 
-                                      , alphaToOneEnable :: VkBool32 
-                                      }
+data PipelineMultisampleStateCreateInfo =
+  PipelineMultisampleStateCreateInfo{ sType :: VkStructureType 
+                                    , pNext :: Ptr Void 
+                                    , flags :: VkPipelineMultisampleStateCreateFlags 
+                                    , rasterizationSamples :: VkSampleCountFlags 
+                                    , sampleShadingEnable :: VkBool32 
+                                    , minSampleShading :: CFloat 
+                                    , pSampleMask :: Ptr VkSampleMask 
+                                    , alphaToCoverageEnable :: VkBool32 
+                                    , alphaToOneEnable :: VkBool32 
+                                    }
   deriving (Eq)
 
-instance Storable VkPipelineMultisampleStateCreateInfo where
+instance Storable PipelineMultisampleStateCreateInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkPipelineMultisampleStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                  <*> peek (ptr `plusPtr` 8)
-                                                  <*> peek (ptr `plusPtr` 16)
-                                                  <*> peek (ptr `plusPtr` 20)
-                                                  <*> peek (ptr `plusPtr` 24)
-                                                  <*> peek (ptr `plusPtr` 28)
-                                                  <*> peek (ptr `plusPtr` 32)
-                                                  <*> peek (ptr `plusPtr` 40)
-                                                  <*> peek (ptr `plusPtr` 44)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (rasterizationSamples (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (sampleShadingEnable (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (minSampleShading (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pSampleMask (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (alphaToCoverageEnable (poked :: VkPipelineMultisampleStateCreateInfo))
-                *> poke (ptr `plusPtr` 44) (alphaToOneEnable (poked :: VkPipelineMultisampleStateCreateInfo))
+  peek ptr = PipelineMultisampleStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                <*> peek (ptr `plusPtr` 8)
+                                                <*> peek (ptr `plusPtr` 16)
+                                                <*> peek (ptr `plusPtr` 20)
+                                                <*> peek (ptr `plusPtr` 24)
+                                                <*> peek (ptr `plusPtr` 28)
+                                                <*> peek (ptr `plusPtr` 32)
+                                                <*> peek (ptr `plusPtr` 40)
+                                                <*> peek (ptr `plusPtr` 44)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (rasterizationSamples (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (sampleShadingEnable (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (minSampleShading (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pSampleMask (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (alphaToCoverageEnable (poked :: PipelineMultisampleStateCreateInfo))
+                *> poke (ptr `plusPtr` 44) (alphaToOneEnable (poked :: PipelineMultisampleStateCreateInfo))
 
 
 
-data VkVertexInputBindingDescription =
-  VkVertexInputBindingDescription{ binding :: Word32 
-                                 , stride :: Word32 
-                                 , inputRate :: VkVertexInputRate 
-                                 }
+data VertexInputBindingDescription =
+  VertexInputBindingDescription{ binding :: Word32 
+                               , stride :: Word32 
+                               , inputRate :: VkVertexInputRate 
+                               }
   deriving (Eq)
 
-instance Storable VkVertexInputBindingDescription where
+instance Storable VertexInputBindingDescription where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkVertexInputBindingDescription <$> peek (ptr `plusPtr` 0)
-                                             <*> peek (ptr `plusPtr` 4)
-                                             <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: VkVertexInputBindingDescription))
-                *> poke (ptr `plusPtr` 4) (stride (poked :: VkVertexInputBindingDescription))
-                *> poke (ptr `plusPtr` 8) (inputRate (poked :: VkVertexInputBindingDescription))
+  peek ptr = VertexInputBindingDescription <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 4)
+                                           <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (binding (poked :: VertexInputBindingDescription))
+                *> poke (ptr `plusPtr` 4) (stride (poked :: VertexInputBindingDescription))
+                *> poke (ptr `plusPtr` 8) (inputRate (poked :: VertexInputBindingDescription))
 
 
 
-data VkPipelineDepthStencilStateCreateInfo =
-  VkPipelineDepthStencilStateCreateInfo{ sType :: VkStructureType 
-                                       , pNext :: Ptr Void 
-                                       , flags :: VkPipelineDepthStencilStateCreateFlags 
-                                       , depthTestEnable :: VkBool32 
-                                       , depthWriteEnable :: VkBool32 
-                                       , depthCompareOp :: VkCompareOp 
-                                       , depthBoundsTestEnable :: VkBool32 
-                                       , stencilTestEnable :: VkBool32 
-                                       , front :: VkStencilOpState 
-                                       , back :: VkStencilOpState 
-                                       , minDepthBounds :: CFloat 
-                                       , maxDepthBounds :: CFloat 
-                                       }
+data PipelineDepthStencilStateCreateInfo =
+  PipelineDepthStencilStateCreateInfo{ sType :: VkStructureType 
+                                     , pNext :: Ptr Void 
+                                     , flags :: VkPipelineDepthStencilStateCreateFlags 
+                                     , depthTestEnable :: VkBool32 
+                                     , depthWriteEnable :: VkBool32 
+                                     , depthCompareOp :: VkCompareOp 
+                                     , depthBoundsTestEnable :: VkBool32 
+                                     , stencilTestEnable :: VkBool32 
+                                     , front :: StencilOpState 
+                                     , back :: StencilOpState 
+                                     , minDepthBounds :: CFloat 
+                                     , maxDepthBounds :: CFloat 
+                                     }
   deriving (Eq)
 
-instance Storable VkPipelineDepthStencilStateCreateInfo where
+instance Storable PipelineDepthStencilStateCreateInfo where
   sizeOf ~_ = 104
   alignment ~_ = 8
-  peek ptr = VkPipelineDepthStencilStateCreateInfo <$> peek (ptr `plusPtr` 0)
-                                                   <*> peek (ptr `plusPtr` 8)
-                                                   <*> peek (ptr `plusPtr` 16)
-                                                   <*> peek (ptr `plusPtr` 20)
-                                                   <*> peek (ptr `plusPtr` 24)
-                                                   <*> peek (ptr `plusPtr` 28)
-                                                   <*> peek (ptr `plusPtr` 32)
-                                                   <*> peek (ptr `plusPtr` 36)
-                                                   <*> peek (ptr `plusPtr` 40)
-                                                   <*> peek (ptr `plusPtr` 68)
-                                                   <*> peek (ptr `plusPtr` 96)
-                                                   <*> peek (ptr `plusPtr` 100)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 20) (depthTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 24) (depthWriteEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 28) (depthCompareOp (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 32) (depthBoundsTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 36) (stencilTestEnable (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 40) (front (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 68) (back (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 96) (minDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
-                *> poke (ptr `plusPtr` 100) (maxDepthBounds (poked :: VkPipelineDepthStencilStateCreateInfo))
+  peek ptr = PipelineDepthStencilStateCreateInfo <$> peek (ptr `plusPtr` 0)
+                                                 <*> peek (ptr `plusPtr` 8)
+                                                 <*> peek (ptr `plusPtr` 16)
+                                                 <*> peek (ptr `plusPtr` 20)
+                                                 <*> peek (ptr `plusPtr` 24)
+                                                 <*> peek (ptr `plusPtr` 28)
+                                                 <*> peek (ptr `plusPtr` 32)
+                                                 <*> peek (ptr `plusPtr` 36)
+                                                 <*> peek (ptr `plusPtr` 40)
+                                                 <*> peek (ptr `plusPtr` 68)
+                                                 <*> peek (ptr `plusPtr` 96)
+                                                 <*> peek (ptr `plusPtr` 100)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 20) (depthTestEnable (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 24) (depthWriteEnable (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 28) (depthCompareOp (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 32) (depthBoundsTestEnable (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 36) (stencilTestEnable (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 40) (front (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 68) (back (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 96) (minDepthBounds (poked :: PipelineDepthStencilStateCreateInfo))
+                *> poke (ptr `plusPtr` 100) (maxDepthBounds (poked :: PipelineDepthStencilStateCreateInfo))
 
 
 -- ** vkCreateComputePipelines
@@ -1360,37 +1360,37 @@ foreign import ccall "vkCreateComputePipelines" vkCreateComputePipelines ::
   Device ->
   PipelineCache ->
     Word32 ->
-      Ptr VkComputePipelineCreateInfo ->
-        Ptr VkAllocationCallbacks -> Ptr Pipeline -> IO VkResult
+      Ptr ComputePipelineCreateInfo ->
+        Ptr AllocationCallbacks -> Ptr Pipeline -> IO VkResult
 
 
-data VkStencilOpState =
-  VkStencilOpState{ failOp :: VkStencilOp 
-                  , passOp :: VkStencilOp 
-                  , depthFailOp :: VkStencilOp 
-                  , compareOp :: VkCompareOp 
-                  , compareMask :: Word32 
-                  , writeMask :: Word32 
-                  , reference :: Word32 
-                  }
+data StencilOpState =
+  StencilOpState{ failOp :: VkStencilOp 
+                , passOp :: VkStencilOp 
+                , depthFailOp :: VkStencilOp 
+                , compareOp :: VkCompareOp 
+                , compareMask :: Word32 
+                , writeMask :: Word32 
+                , reference :: Word32 
+                }
   deriving (Eq)
 
-instance Storable VkStencilOpState where
+instance Storable StencilOpState where
   sizeOf ~_ = 28
   alignment ~_ = 4
-  peek ptr = VkStencilOpState <$> peek (ptr `plusPtr` 0)
-                              <*> peek (ptr `plusPtr` 4)
-                              <*> peek (ptr `plusPtr` 8)
-                              <*> peek (ptr `plusPtr` 12)
-                              <*> peek (ptr `plusPtr` 16)
-                              <*> peek (ptr `plusPtr` 20)
-                              <*> peek (ptr `plusPtr` 24)
-  poke ptr poked = poke (ptr `plusPtr` 0) (failOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 4) (passOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 8) (depthFailOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 12) (compareOp (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 16) (compareMask (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 20) (writeMask (poked :: VkStencilOpState))
-                *> poke (ptr `plusPtr` 24) (reference (poked :: VkStencilOpState))
+  peek ptr = StencilOpState <$> peek (ptr `plusPtr` 0)
+                            <*> peek (ptr `plusPtr` 4)
+                            <*> peek (ptr `plusPtr` 8)
+                            <*> peek (ptr `plusPtr` 12)
+                            <*> peek (ptr `plusPtr` 16)
+                            <*> peek (ptr `plusPtr` 20)
+                            <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (failOp (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 4) (passOp (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 8) (depthFailOp (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 12) (compareOp (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 16) (compareMask (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 20) (writeMask (poked :: StencilOpState))
+                *> poke (ptr `plusPtr` 24) (reference (poked :: StencilOpState))
 
 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -71,7 +71,7 @@ data PipelineTessellationStateCreateInfo =
                                      , flags :: PipelineTessellationStateCreateFlags 
                                      , patchControlPoints :: Word32 
                                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineTessellationStateCreateInfo where
   sizeOf ~_ = 24
@@ -93,7 +93,7 @@ data VertexInputAttributeDescription =
                                  , format :: Format 
                                  , offset :: Word32 
                                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable VertexInputAttributeDescription where
   sizeOf ~_ = 16
@@ -130,7 +130,7 @@ data GraphicsPipelineCreateInfo =
                             , basePipelineHandle :: Pipeline 
                             , basePipelineIndex :: Int32 
                             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable GraphicsPipelineCreateInfo where
   sizeOf ~_ = 144
@@ -178,7 +178,7 @@ instance Storable GraphicsPipelineCreateInfo where
 -- ** CullModeFlags
 
 newtype CullModeFlags = CullModeFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show CullModeFlags where
   showsPrec _ CullModeFrontBit = showString "CullModeFrontBit"
@@ -212,7 +212,7 @@ pattern CullModeFrontAndBack = CullModeFlags 0x3
 -- ** PipelineDepthStencilStateCreateFlags
 -- | Opaque flag
 newtype PipelineDepthStencilStateCreateFlags = PipelineDepthStencilStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineShaderStageCreateInfo =
@@ -224,7 +224,7 @@ data PipelineShaderStageCreateInfo =
                                , pName :: Ptr CChar 
                                , pSpecializationInfo :: Ptr SpecializationInfo 
                                }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineShaderStageCreateInfo where
   sizeOf ~_ = 48
@@ -248,7 +248,7 @@ instance Storable PipelineShaderStageCreateInfo where
 -- ** ColorComponentFlags
 
 newtype ColorComponentFlags = ColorComponentFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show ColorComponentFlags where
   showsPrec _ ColorComponentRBit = showString "ColorComponentRBit"
@@ -291,7 +291,7 @@ data ComputePipelineCreateInfo =
                            , basePipelineHandle :: Pipeline 
                            , basePipelineIndex :: Int32 
                            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ComputePipelineCreateInfo where
   sizeOf ~_ = 96
@@ -315,7 +315,7 @@ instance Storable ComputePipelineCreateInfo where
 -- ** StencilOp
 
 newtype StencilOp = StencilOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show StencilOp where
   showsPrec _ StencilOpKeep = showString "StencilOpKeep"
@@ -369,7 +369,7 @@ data SpecializationInfo =
                     , dataSize :: CSize 
                     , pData :: Ptr Void 
                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SpecializationInfo where
   sizeOf ~_ = 32
@@ -387,15 +387,15 @@ instance Storable SpecializationInfo where
 -- ** PipelineColorBlendStateCreateFlags
 -- | Opaque flag
 newtype PipelineColorBlendStateCreateFlags = PipelineColorBlendStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 newtype Pipeline = Pipeline Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** PipelineInputAssemblyStateCreateFlags
 -- | Opaque flag
 newtype PipelineInputAssemblyStateCreateFlags = PipelineInputAssemblyStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** createGraphicsPipelines
 foreign import ccall "vkCreateGraphicsPipelines" createGraphicsPipelines ::
@@ -408,7 +408,7 @@ foreign import ccall "vkCreateGraphicsPipelines" createGraphicsPipelines ::
 -- ** FrontFace
 
 newtype FrontFace = FrontFace Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show FrontFace where
   showsPrec _ FrontFaceCounterClockwise = showString "FrontFaceCounterClockwise"
@@ -434,7 +434,7 @@ pattern FrontFaceClockwise = FrontFace 1
 -- ** PolygonMode
 
 newtype PolygonMode = PolygonMode Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PolygonMode where
   showsPrec _ PolygonModeFill = showString "PolygonModeFill"
@@ -464,12 +464,12 @@ pattern PolygonModePoint = PolygonMode 2
 -- ** PipelineViewportStateCreateFlags
 -- | Opaque flag
 newtype PipelineViewportStateCreateFlags = PipelineViewportStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** LogicOp
 
 newtype LogicOp = LogicOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show LogicOp where
   showsPrec _ LogicOpClear = showString "LogicOpClear"
@@ -551,7 +551,7 @@ pattern LogicOpSet = LogicOp 15
 -- ** PipelineCreateFlags
 
 newtype PipelineCreateFlags = PipelineCreateFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show PipelineCreateFlags where
   showsPrec _ PipelineCreateDisableOptimizationBit = showString "PipelineCreateDisableOptimizationBit"
@@ -583,12 +583,12 @@ pattern PipelineCreateDerivativeBit = PipelineCreateFlags 0x4
 -- ** PipelineRasterizationStateCreateFlags
 -- | Opaque flag
 newtype PipelineRasterizationStateCreateFlags = PipelineRasterizationStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** DynamicState
 
 newtype DynamicState = DynamicState Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show DynamicState where
   showsPrec _ DynamicStateViewport = showString "DynamicStateViewport"
@@ -642,7 +642,7 @@ pattern DynamicStateStencilReference = DynamicState 8
 -- ** PipelineBindPoint
 
 newtype PipelineBindPoint = PipelineBindPoint Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PipelineBindPoint where
   showsPrec _ PipelineBindPointGraphics = showString "PipelineBindPointGraphics"
@@ -668,7 +668,7 @@ pattern PipelineBindPointCompute = PipelineBindPoint 1
 -- ** PipelineDynamicStateCreateFlags
 -- | Opaque flag
 newtype PipelineDynamicStateCreateFlags = PipelineDynamicStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineRasterizationStateCreateInfo =
@@ -686,7 +686,7 @@ data PipelineRasterizationStateCreateInfo =
                                       , depthBiasSlopeFactor :: CFloat 
                                       , lineWidth :: CFloat 
                                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineRasterizationStateCreateInfo where
   sizeOf ~_ = 64
@@ -722,7 +722,7 @@ instance Storable PipelineRasterizationStateCreateInfo where
 -- ** BlendOp
 
 newtype BlendOp = BlendOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show BlendOp where
   showsPrec _ BlendOpAdd = showString "BlendOpAdd"
@@ -764,7 +764,7 @@ foreign import ccall "vkDestroyPipeline" destroyPipeline ::
 -- ** PipelineShaderStageCreateFlags
 -- | Opaque flag
 newtype PipelineShaderStageCreateFlags = PipelineShaderStageCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineViewportStateCreateInfo =
@@ -776,7 +776,7 @@ data PipelineViewportStateCreateInfo =
                                  , scissorCount :: Word32 
                                  , pScissors :: Ptr Rect2D 
                                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineViewportStateCreateInfo where
   sizeOf ~_ = 48
@@ -800,7 +800,7 @@ instance Storable PipelineViewportStateCreateInfo where
 -- ** PipelineTessellationStateCreateFlags
 -- | Opaque flag
 newtype PipelineTessellationStateCreateFlags = PipelineTessellationStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineVertexInputStateCreateInfo =
@@ -812,7 +812,7 @@ data PipelineVertexInputStateCreateInfo =
                                     , vertexAttributeDescriptionCount :: Word32 
                                     , pVertexAttributeDescriptions :: Ptr VertexInputAttributeDescription 
                                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineVertexInputStateCreateInfo where
   sizeOf ~_ = 48
@@ -836,7 +836,7 @@ instance Storable PipelineVertexInputStateCreateInfo where
 -- ** PrimitiveTopology
 
 newtype PrimitiveTopology = PrimitiveTopology Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show PrimitiveTopology where
   showsPrec _ PrimitiveTopologyPointList = showString "PrimitiveTopologyPointList"
@@ -903,7 +903,7 @@ data PipelineInputAssemblyStateCreateInfo =
                                       , topology :: PrimitiveTopology 
                                       , primitiveRestartEnable :: Bool32 
                                       }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineInputAssemblyStateCreateInfo where
   sizeOf ~_ = 32
@@ -931,7 +931,7 @@ data PipelineColorBlendStateCreateInfo =
                                    , pAttachments :: Ptr PipelineColorBlendAttachmentState 
                                    , blendConstants :: Vector 4 CFloat 
                                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineColorBlendStateCreateInfo where
   sizeOf ~_ = 56
@@ -962,7 +962,7 @@ data PipelineDynamicStateCreateInfo =
                                 , dynamicStateCount :: Word32 
                                 , pDynamicStates :: Ptr DynamicState 
                                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineDynamicStateCreateInfo where
   sizeOf ~_ = 32
@@ -985,7 +985,7 @@ data SpecializationMapEntry =
                         , offset :: Word32 
                         , size :: CSize 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SpecializationMapEntry where
   sizeOf ~_ = 16
@@ -1001,12 +1001,12 @@ instance Storable SpecializationMapEntry where
 -- ** PipelineVertexInputStateCreateFlags
 -- | Opaque flag
 newtype PipelineVertexInputStateCreateFlags = PipelineVertexInputStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** VertexInputRate
 
 newtype VertexInputRate = VertexInputRate Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show VertexInputRate where
   showsPrec _ VertexInputRateVertex = showString "VertexInputRateVertex"
@@ -1032,7 +1032,7 @@ pattern VertexInputRateInstance = VertexInputRate 1
 -- ** PipelineStageFlags
 
 newtype PipelineStageFlags = PipelineStageFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show PipelineStageFlags where
   showsPrec _ PipelineStageTopOfPipeBit = showString "PipelineStageTopOfPipeBit"
@@ -1128,7 +1128,7 @@ data PipelineColorBlendAttachmentState =
                                    , alphaBlendOp :: BlendOp 
                                    , colorWriteMask :: ColorComponentFlags 
                                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineColorBlendAttachmentState where
   sizeOf ~_ = 32
@@ -1154,7 +1154,7 @@ instance Storable PipelineColorBlendAttachmentState where
 -- ** BlendFactor
 
 newtype BlendFactor = BlendFactor Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show BlendFactor where
   showsPrec _ BlendFactorZero = showString "BlendFactorZero"
@@ -1246,12 +1246,12 @@ pattern BlendFactorSrc1Alpha = BlendFactor 17
 pattern BlendFactorOneMinusSrc1Alpha = BlendFactor 18
 
 newtype SampleMask = SampleMask Word32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** PipelineMultisampleStateCreateFlags
 -- | Opaque flag
 newtype PipelineMultisampleStateCreateFlags = PipelineMultisampleStateCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineMultisampleStateCreateInfo =
@@ -1265,7 +1265,7 @@ data PipelineMultisampleStateCreateInfo =
                                     , alphaToCoverageEnable :: Bool32 
                                     , alphaToOneEnable :: Bool32 
                                     }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineMultisampleStateCreateInfo where
   sizeOf ~_ = 48
@@ -1296,7 +1296,7 @@ data VertexInputBindingDescription =
                                , stride :: Word32 
                                , inputRate :: VertexInputRate 
                                }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable VertexInputBindingDescription where
   sizeOf ~_ = 12
@@ -1324,7 +1324,7 @@ data PipelineDepthStencilStateCreateInfo =
                                      , minDepthBounds :: CFloat 
                                      , maxDepthBounds :: CFloat 
                                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineDepthStencilStateCreateInfo where
   sizeOf ~_ = 104
@@ -1373,7 +1373,7 @@ data StencilOpState =
                 , writeMask :: Word32 
                 , reference :: Word32 
                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable StencilOpState where
   sizeOf ~_ = 28

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -318,25 +318,25 @@ newtype StencilOp = StencilOp Int32
   deriving (Eq, Storable)
 
 instance Show StencilOp where
-  showsPrec _ VK_STENCIL_OP_KEEP = showString "VK_STENCIL_OP_KEEP"
-  showsPrec _ VK_STENCIL_OP_ZERO = showString "VK_STENCIL_OP_ZERO"
-  showsPrec _ VK_STENCIL_OP_REPLACE = showString "VK_STENCIL_OP_REPLACE"
-  showsPrec _ VK_STENCIL_OP_INCREMENT_AND_CLAMP = showString "VK_STENCIL_OP_INCREMENT_AND_CLAMP"
-  showsPrec _ VK_STENCIL_OP_DECREMENT_AND_CLAMP = showString "VK_STENCIL_OP_DECREMENT_AND_CLAMP"
-  showsPrec _ VK_STENCIL_OP_INVERT = showString "VK_STENCIL_OP_INVERT"
-  showsPrec _ VK_STENCIL_OP_INCREMENT_AND_WRAP = showString "VK_STENCIL_OP_INCREMENT_AND_WRAP"
-  showsPrec _ VK_STENCIL_OP_DECREMENT_AND_WRAP = showString "VK_STENCIL_OP_DECREMENT_AND_WRAP"
+  showsPrec _ StencilOpKeep = showString "StencilOpKeep"
+  showsPrec _ StencilOpZero = showString "StencilOpZero"
+  showsPrec _ StencilOpReplace = showString "StencilOpReplace"
+  showsPrec _ StencilOpIncrementAndClamp = showString "StencilOpIncrementAndClamp"
+  showsPrec _ StencilOpDecrementAndClamp = showString "StencilOpDecrementAndClamp"
+  showsPrec _ StencilOpInvert = showString "StencilOpInvert"
+  showsPrec _ StencilOpIncrementAndWrap = showString "StencilOpIncrementAndWrap"
+  showsPrec _ StencilOpDecrementAndWrap = showString "StencilOpDecrementAndWrap"
   showsPrec p (StencilOp x) = showParen (p >= 11) (showString "StencilOp " . showsPrec 11 x)
 
 instance Read StencilOp where
-  readPrec = parens ( choose [ ("VK_STENCIL_OP_KEEP", pure VK_STENCIL_OP_KEEP)
-                             , ("VK_STENCIL_OP_ZERO", pure VK_STENCIL_OP_ZERO)
-                             , ("VK_STENCIL_OP_REPLACE", pure VK_STENCIL_OP_REPLACE)
-                             , ("VK_STENCIL_OP_INCREMENT_AND_CLAMP", pure VK_STENCIL_OP_INCREMENT_AND_CLAMP)
-                             , ("VK_STENCIL_OP_DECREMENT_AND_CLAMP", pure VK_STENCIL_OP_DECREMENT_AND_CLAMP)
-                             , ("VK_STENCIL_OP_INVERT", pure VK_STENCIL_OP_INVERT)
-                             , ("VK_STENCIL_OP_INCREMENT_AND_WRAP", pure VK_STENCIL_OP_INCREMENT_AND_WRAP)
-                             , ("VK_STENCIL_OP_DECREMENT_AND_WRAP", pure VK_STENCIL_OP_DECREMENT_AND_WRAP)
+  readPrec = parens ( choose [ ("StencilOpKeep", pure StencilOpKeep)
+                             , ("StencilOpZero", pure StencilOpZero)
+                             , ("StencilOpReplace", pure StencilOpReplace)
+                             , ("StencilOpIncrementAndClamp", pure StencilOpIncrementAndClamp)
+                             , ("StencilOpDecrementAndClamp", pure StencilOpDecrementAndClamp)
+                             , ("StencilOpInvert", pure StencilOpInvert)
+                             , ("StencilOpIncrementAndWrap", pure StencilOpIncrementAndWrap)
+                             , ("StencilOpDecrementAndWrap", pure StencilOpDecrementAndWrap)
                              ] +++
                       prec 10 (do
                         expectP (Ident "StencilOp")
@@ -346,21 +346,21 @@ instance Read StencilOp where
                     )
 
 
-pattern VK_STENCIL_OP_KEEP = StencilOp 0
+pattern StencilOpKeep = StencilOp 0
 
-pattern VK_STENCIL_OP_ZERO = StencilOp 1
+pattern StencilOpZero = StencilOp 1
 
-pattern VK_STENCIL_OP_REPLACE = StencilOp 2
+pattern StencilOpReplace = StencilOp 2
 
-pattern VK_STENCIL_OP_INCREMENT_AND_CLAMP = StencilOp 3
+pattern StencilOpIncrementAndClamp = StencilOp 3
 
-pattern VK_STENCIL_OP_DECREMENT_AND_CLAMP = StencilOp 4
+pattern StencilOpDecrementAndClamp = StencilOp 4
 
-pattern VK_STENCIL_OP_INVERT = StencilOp 5
+pattern StencilOpInvert = StencilOp 5
 
-pattern VK_STENCIL_OP_INCREMENT_AND_WRAP = StencilOp 6
+pattern StencilOpIncrementAndWrap = StencilOp 6
 
-pattern VK_STENCIL_OP_DECREMENT_AND_WRAP = StencilOp 7
+pattern StencilOpDecrementAndWrap = StencilOp 7
 
 
 data SpecializationInfo =
@@ -411,13 +411,13 @@ newtype FrontFace = FrontFace Int32
   deriving (Eq, Storable)
 
 instance Show FrontFace where
-  showsPrec _ VK_FRONT_FACE_COUNTER_CLOCKWISE = showString "VK_FRONT_FACE_COUNTER_CLOCKWISE"
-  showsPrec _ VK_FRONT_FACE_CLOCKWISE = showString "VK_FRONT_FACE_CLOCKWISE"
+  showsPrec _ FrontFaceCounterClockwise = showString "FrontFaceCounterClockwise"
+  showsPrec _ FrontFaceClockwise = showString "FrontFaceClockwise"
   showsPrec p (FrontFace x) = showParen (p >= 11) (showString "FrontFace " . showsPrec 11 x)
 
 instance Read FrontFace where
-  readPrec = parens ( choose [ ("VK_FRONT_FACE_COUNTER_CLOCKWISE", pure VK_FRONT_FACE_COUNTER_CLOCKWISE)
-                             , ("VK_FRONT_FACE_CLOCKWISE", pure VK_FRONT_FACE_CLOCKWISE)
+  readPrec = parens ( choose [ ("FrontFaceCounterClockwise", pure FrontFaceCounterClockwise)
+                             , ("FrontFaceClockwise", pure FrontFaceClockwise)
                              ] +++
                       prec 10 (do
                         expectP (Ident "FrontFace")
@@ -427,9 +427,9 @@ instance Read FrontFace where
                     )
 
 
-pattern VK_FRONT_FACE_COUNTER_CLOCKWISE = FrontFace 0
+pattern FrontFaceCounterClockwise = FrontFace 0
 
-pattern VK_FRONT_FACE_CLOCKWISE = FrontFace 1
+pattern FrontFaceClockwise = FrontFace 1
 
 -- ** PolygonMode
 
@@ -437,15 +437,15 @@ newtype PolygonMode = PolygonMode Int32
   deriving (Eq, Storable)
 
 instance Show PolygonMode where
-  showsPrec _ VK_POLYGON_MODE_FILL = showString "VK_POLYGON_MODE_FILL"
-  showsPrec _ VK_POLYGON_MODE_LINE = showString "VK_POLYGON_MODE_LINE"
-  showsPrec _ VK_POLYGON_MODE_POINT = showString "VK_POLYGON_MODE_POINT"
+  showsPrec _ PolygonModeFill = showString "PolygonModeFill"
+  showsPrec _ PolygonModeLine = showString "PolygonModeLine"
+  showsPrec _ PolygonModePoint = showString "PolygonModePoint"
   showsPrec p (PolygonMode x) = showParen (p >= 11) (showString "PolygonMode " . showsPrec 11 x)
 
 instance Read PolygonMode where
-  readPrec = parens ( choose [ ("VK_POLYGON_MODE_FILL", pure VK_POLYGON_MODE_FILL)
-                             , ("VK_POLYGON_MODE_LINE", pure VK_POLYGON_MODE_LINE)
-                             , ("VK_POLYGON_MODE_POINT", pure VK_POLYGON_MODE_POINT)
+  readPrec = parens ( choose [ ("PolygonModeFill", pure PolygonModeFill)
+                             , ("PolygonModeLine", pure PolygonModeLine)
+                             , ("PolygonModePoint", pure PolygonModePoint)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PolygonMode")
@@ -455,11 +455,11 @@ instance Read PolygonMode where
                     )
 
 
-pattern VK_POLYGON_MODE_FILL = PolygonMode 0
+pattern PolygonModeFill = PolygonMode 0
 
-pattern VK_POLYGON_MODE_LINE = PolygonMode 1
+pattern PolygonModeLine = PolygonMode 1
 
-pattern VK_POLYGON_MODE_POINT = PolygonMode 2
+pattern PolygonModePoint = PolygonMode 2
 
 -- ** PipelineViewportStateCreateFlags
 -- | Opaque flag
@@ -472,41 +472,41 @@ newtype LogicOp = LogicOp Int32
   deriving (Eq, Storable)
 
 instance Show LogicOp where
-  showsPrec _ VK_LOGIC_OP_CLEAR = showString "VK_LOGIC_OP_CLEAR"
-  showsPrec _ VK_LOGIC_OP_AND = showString "VK_LOGIC_OP_AND"
-  showsPrec _ VK_LOGIC_OP_AND_REVERSE = showString "VK_LOGIC_OP_AND_REVERSE"
-  showsPrec _ VK_LOGIC_OP_COPY = showString "VK_LOGIC_OP_COPY"
-  showsPrec _ VK_LOGIC_OP_AND_INVERTED = showString "VK_LOGIC_OP_AND_INVERTED"
-  showsPrec _ VK_LOGIC_OP_NO_OP = showString "VK_LOGIC_OP_NO_OP"
-  showsPrec _ VK_LOGIC_OP_XOR = showString "VK_LOGIC_OP_XOR"
-  showsPrec _ VK_LOGIC_OP_OR = showString "VK_LOGIC_OP_OR"
-  showsPrec _ VK_LOGIC_OP_NOR = showString "VK_LOGIC_OP_NOR"
-  showsPrec _ VK_LOGIC_OP_EQUIVALENT = showString "VK_LOGIC_OP_EQUIVALENT"
-  showsPrec _ VK_LOGIC_OP_INVERT = showString "VK_LOGIC_OP_INVERT"
-  showsPrec _ VK_LOGIC_OP_OR_REVERSE = showString "VK_LOGIC_OP_OR_REVERSE"
-  showsPrec _ VK_LOGIC_OP_COPY_INVERTED = showString "VK_LOGIC_OP_COPY_INVERTED"
-  showsPrec _ VK_LOGIC_OP_OR_INVERTED = showString "VK_LOGIC_OP_OR_INVERTED"
-  showsPrec _ VK_LOGIC_OP_NAND = showString "VK_LOGIC_OP_NAND"
-  showsPrec _ VK_LOGIC_OP_SET = showString "VK_LOGIC_OP_SET"
+  showsPrec _ LogicOpClear = showString "LogicOpClear"
+  showsPrec _ LogicOpAnd = showString "LogicOpAnd"
+  showsPrec _ LogicOpAndReverse = showString "LogicOpAndReverse"
+  showsPrec _ LogicOpCopy = showString "LogicOpCopy"
+  showsPrec _ LogicOpAndInverted = showString "LogicOpAndInverted"
+  showsPrec _ LogicOpNoOp = showString "LogicOpNoOp"
+  showsPrec _ LogicOpXor = showString "LogicOpXor"
+  showsPrec _ LogicOpOr = showString "LogicOpOr"
+  showsPrec _ LogicOpNor = showString "LogicOpNor"
+  showsPrec _ LogicOpEquivalent = showString "LogicOpEquivalent"
+  showsPrec _ LogicOpInvert = showString "LogicOpInvert"
+  showsPrec _ LogicOpOrReverse = showString "LogicOpOrReverse"
+  showsPrec _ LogicOpCopyInverted = showString "LogicOpCopyInverted"
+  showsPrec _ LogicOpOrInverted = showString "LogicOpOrInverted"
+  showsPrec _ LogicOpNand = showString "LogicOpNand"
+  showsPrec _ LogicOpSet = showString "LogicOpSet"
   showsPrec p (LogicOp x) = showParen (p >= 11) (showString "LogicOp " . showsPrec 11 x)
 
 instance Read LogicOp where
-  readPrec = parens ( choose [ ("VK_LOGIC_OP_CLEAR", pure VK_LOGIC_OP_CLEAR)
-                             , ("VK_LOGIC_OP_AND", pure VK_LOGIC_OP_AND)
-                             , ("VK_LOGIC_OP_AND_REVERSE", pure VK_LOGIC_OP_AND_REVERSE)
-                             , ("VK_LOGIC_OP_COPY", pure VK_LOGIC_OP_COPY)
-                             , ("VK_LOGIC_OP_AND_INVERTED", pure VK_LOGIC_OP_AND_INVERTED)
-                             , ("VK_LOGIC_OP_NO_OP", pure VK_LOGIC_OP_NO_OP)
-                             , ("VK_LOGIC_OP_XOR", pure VK_LOGIC_OP_XOR)
-                             , ("VK_LOGIC_OP_OR", pure VK_LOGIC_OP_OR)
-                             , ("VK_LOGIC_OP_NOR", pure VK_LOGIC_OP_NOR)
-                             , ("VK_LOGIC_OP_EQUIVALENT", pure VK_LOGIC_OP_EQUIVALENT)
-                             , ("VK_LOGIC_OP_INVERT", pure VK_LOGIC_OP_INVERT)
-                             , ("VK_LOGIC_OP_OR_REVERSE", pure VK_LOGIC_OP_OR_REVERSE)
-                             , ("VK_LOGIC_OP_COPY_INVERTED", pure VK_LOGIC_OP_COPY_INVERTED)
-                             , ("VK_LOGIC_OP_OR_INVERTED", pure VK_LOGIC_OP_OR_INVERTED)
-                             , ("VK_LOGIC_OP_NAND", pure VK_LOGIC_OP_NAND)
-                             , ("VK_LOGIC_OP_SET", pure VK_LOGIC_OP_SET)
+  readPrec = parens ( choose [ ("LogicOpClear", pure LogicOpClear)
+                             , ("LogicOpAnd", pure LogicOpAnd)
+                             , ("LogicOpAndReverse", pure LogicOpAndReverse)
+                             , ("LogicOpCopy", pure LogicOpCopy)
+                             , ("LogicOpAndInverted", pure LogicOpAndInverted)
+                             , ("LogicOpNoOp", pure LogicOpNoOp)
+                             , ("LogicOpXor", pure LogicOpXor)
+                             , ("LogicOpOr", pure LogicOpOr)
+                             , ("LogicOpNor", pure LogicOpNor)
+                             , ("LogicOpEquivalent", pure LogicOpEquivalent)
+                             , ("LogicOpInvert", pure LogicOpInvert)
+                             , ("LogicOpOrReverse", pure LogicOpOrReverse)
+                             , ("LogicOpCopyInverted", pure LogicOpCopyInverted)
+                             , ("LogicOpOrInverted", pure LogicOpOrInverted)
+                             , ("LogicOpNand", pure LogicOpNand)
+                             , ("LogicOpSet", pure LogicOpSet)
                              ] +++
                       prec 10 (do
                         expectP (Ident "LogicOp")
@@ -516,37 +516,37 @@ instance Read LogicOp where
                     )
 
 
-pattern VK_LOGIC_OP_CLEAR = LogicOp 0
+pattern LogicOpClear = LogicOp 0
 
-pattern VK_LOGIC_OP_AND = LogicOp 1
+pattern LogicOpAnd = LogicOp 1
 
-pattern VK_LOGIC_OP_AND_REVERSE = LogicOp 2
+pattern LogicOpAndReverse = LogicOp 2
 
-pattern VK_LOGIC_OP_COPY = LogicOp 3
+pattern LogicOpCopy = LogicOp 3
 
-pattern VK_LOGIC_OP_AND_INVERTED = LogicOp 4
+pattern LogicOpAndInverted = LogicOp 4
 
-pattern VK_LOGIC_OP_NO_OP = LogicOp 5
+pattern LogicOpNoOp = LogicOp 5
 
-pattern VK_LOGIC_OP_XOR = LogicOp 6
+pattern LogicOpXor = LogicOp 6
 
-pattern VK_LOGIC_OP_OR = LogicOp 7
+pattern LogicOpOr = LogicOp 7
 
-pattern VK_LOGIC_OP_NOR = LogicOp 8
+pattern LogicOpNor = LogicOp 8
 
-pattern VK_LOGIC_OP_EQUIVALENT = LogicOp 9
+pattern LogicOpEquivalent = LogicOp 9
 
-pattern VK_LOGIC_OP_INVERT = LogicOp 10
+pattern LogicOpInvert = LogicOp 10
 
-pattern VK_LOGIC_OP_OR_REVERSE = LogicOp 11
+pattern LogicOpOrReverse = LogicOp 11
 
-pattern VK_LOGIC_OP_COPY_INVERTED = LogicOp 12
+pattern LogicOpCopyInverted = LogicOp 12
 
-pattern VK_LOGIC_OP_OR_INVERTED = LogicOp 13
+pattern LogicOpOrInverted = LogicOp 13
 
-pattern VK_LOGIC_OP_NAND = LogicOp 14
+pattern LogicOpNand = LogicOp 14
 
-pattern VK_LOGIC_OP_SET = LogicOp 15
+pattern LogicOpSet = LogicOp 15
 
 -- ** PipelineCreateFlags
 
@@ -591,27 +591,27 @@ newtype DynamicState = DynamicState Int32
   deriving (Eq, Storable)
 
 instance Show DynamicState where
-  showsPrec _ VK_DYNAMIC_STATE_VIEWPORT = showString "VK_DYNAMIC_STATE_VIEWPORT"
-  showsPrec _ VK_DYNAMIC_STATE_SCISSOR = showString "VK_DYNAMIC_STATE_SCISSOR"
-  showsPrec _ VK_DYNAMIC_STATE_LINE_WIDTH = showString "VK_DYNAMIC_STATE_LINE_WIDTH"
-  showsPrec _ VK_DYNAMIC_STATE_DEPTH_BIAS = showString "VK_DYNAMIC_STATE_DEPTH_BIAS"
-  showsPrec _ VK_DYNAMIC_STATE_BLEND_CONSTANTS = showString "VK_DYNAMIC_STATE_BLEND_CONSTANTS"
-  showsPrec _ VK_DYNAMIC_STATE_DEPTH_BOUNDS = showString "VK_DYNAMIC_STATE_DEPTH_BOUNDS"
-  showsPrec _ VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = showString "VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK"
-  showsPrec _ VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = showString "VK_DYNAMIC_STATE_STENCIL_WRITE_MASK"
-  showsPrec _ VK_DYNAMIC_STATE_STENCIL_REFERENCE = showString "VK_DYNAMIC_STATE_STENCIL_REFERENCE"
+  showsPrec _ DynamicStateViewport = showString "DynamicStateViewport"
+  showsPrec _ DynamicStateScissor = showString "DynamicStateScissor"
+  showsPrec _ DynamicStateLineWidth = showString "DynamicStateLineWidth"
+  showsPrec _ DynamicStateDepthBias = showString "DynamicStateDepthBias"
+  showsPrec _ DynamicStateBlendConstants = showString "DynamicStateBlendConstants"
+  showsPrec _ DynamicStateDepthBounds = showString "DynamicStateDepthBounds"
+  showsPrec _ DynamicStateStencilCompareMask = showString "DynamicStateStencilCompareMask"
+  showsPrec _ DynamicStateStencilWriteMask = showString "DynamicStateStencilWriteMask"
+  showsPrec _ DynamicStateStencilReference = showString "DynamicStateStencilReference"
   showsPrec p (DynamicState x) = showParen (p >= 11) (showString "DynamicState " . showsPrec 11 x)
 
 instance Read DynamicState where
-  readPrec = parens ( choose [ ("VK_DYNAMIC_STATE_VIEWPORT", pure VK_DYNAMIC_STATE_VIEWPORT)
-                             , ("VK_DYNAMIC_STATE_SCISSOR", pure VK_DYNAMIC_STATE_SCISSOR)
-                             , ("VK_DYNAMIC_STATE_LINE_WIDTH", pure VK_DYNAMIC_STATE_LINE_WIDTH)
-                             , ("VK_DYNAMIC_STATE_DEPTH_BIAS", pure VK_DYNAMIC_STATE_DEPTH_BIAS)
-                             , ("VK_DYNAMIC_STATE_BLEND_CONSTANTS", pure VK_DYNAMIC_STATE_BLEND_CONSTANTS)
-                             , ("VK_DYNAMIC_STATE_DEPTH_BOUNDS", pure VK_DYNAMIC_STATE_DEPTH_BOUNDS)
-                             , ("VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK", pure VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK)
-                             , ("VK_DYNAMIC_STATE_STENCIL_WRITE_MASK", pure VK_DYNAMIC_STATE_STENCIL_WRITE_MASK)
-                             , ("VK_DYNAMIC_STATE_STENCIL_REFERENCE", pure VK_DYNAMIC_STATE_STENCIL_REFERENCE)
+  readPrec = parens ( choose [ ("DynamicStateViewport", pure DynamicStateViewport)
+                             , ("DynamicStateScissor", pure DynamicStateScissor)
+                             , ("DynamicStateLineWidth", pure DynamicStateLineWidth)
+                             , ("DynamicStateDepthBias", pure DynamicStateDepthBias)
+                             , ("DynamicStateBlendConstants", pure DynamicStateBlendConstants)
+                             , ("DynamicStateDepthBounds", pure DynamicStateDepthBounds)
+                             , ("DynamicStateStencilCompareMask", pure DynamicStateStencilCompareMask)
+                             , ("DynamicStateStencilWriteMask", pure DynamicStateStencilWriteMask)
+                             , ("DynamicStateStencilReference", pure DynamicStateStencilReference)
                              ] +++
                       prec 10 (do
                         expectP (Ident "DynamicState")
@@ -621,23 +621,23 @@ instance Read DynamicState where
                     )
 
 
-pattern VK_DYNAMIC_STATE_VIEWPORT = DynamicState 0
+pattern DynamicStateViewport = DynamicState 0
 
-pattern VK_DYNAMIC_STATE_SCISSOR = DynamicState 1
+pattern DynamicStateScissor = DynamicState 1
 
-pattern VK_DYNAMIC_STATE_LINE_WIDTH = DynamicState 2
+pattern DynamicStateLineWidth = DynamicState 2
 
-pattern VK_DYNAMIC_STATE_DEPTH_BIAS = DynamicState 3
+pattern DynamicStateDepthBias = DynamicState 3
 
-pattern VK_DYNAMIC_STATE_BLEND_CONSTANTS = DynamicState 4
+pattern DynamicStateBlendConstants = DynamicState 4
 
-pattern VK_DYNAMIC_STATE_DEPTH_BOUNDS = DynamicState 5
+pattern DynamicStateDepthBounds = DynamicState 5
 
-pattern VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = DynamicState 6
+pattern DynamicStateStencilCompareMask = DynamicState 6
 
-pattern VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = DynamicState 7
+pattern DynamicStateStencilWriteMask = DynamicState 7
 
-pattern VK_DYNAMIC_STATE_STENCIL_REFERENCE = DynamicState 8
+pattern DynamicStateStencilReference = DynamicState 8
 
 -- ** PipelineBindPoint
 
@@ -645,13 +645,13 @@ newtype PipelineBindPoint = PipelineBindPoint Int32
   deriving (Eq, Storable)
 
 instance Show PipelineBindPoint where
-  showsPrec _ VK_PIPELINE_BIND_POINT_GRAPHICS = showString "VK_PIPELINE_BIND_POINT_GRAPHICS"
-  showsPrec _ VK_PIPELINE_BIND_POINT_COMPUTE = showString "VK_PIPELINE_BIND_POINT_COMPUTE"
+  showsPrec _ PipelineBindPointGraphics = showString "PipelineBindPointGraphics"
+  showsPrec _ PipelineBindPointCompute = showString "PipelineBindPointCompute"
   showsPrec p (PipelineBindPoint x) = showParen (p >= 11) (showString "PipelineBindPoint " . showsPrec 11 x)
 
 instance Read PipelineBindPoint where
-  readPrec = parens ( choose [ ("VK_PIPELINE_BIND_POINT_GRAPHICS", pure VK_PIPELINE_BIND_POINT_GRAPHICS)
-                             , ("VK_PIPELINE_BIND_POINT_COMPUTE", pure VK_PIPELINE_BIND_POINT_COMPUTE)
+  readPrec = parens ( choose [ ("PipelineBindPointGraphics", pure PipelineBindPointGraphics)
+                             , ("PipelineBindPointCompute", pure PipelineBindPointCompute)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PipelineBindPoint")
@@ -661,9 +661,9 @@ instance Read PipelineBindPoint where
                     )
 
 
-pattern VK_PIPELINE_BIND_POINT_GRAPHICS = PipelineBindPoint 0
+pattern PipelineBindPointGraphics = PipelineBindPoint 0
 
-pattern VK_PIPELINE_BIND_POINT_COMPUTE = PipelineBindPoint 1
+pattern PipelineBindPointCompute = PipelineBindPoint 1
 
 -- ** PipelineDynamicStateCreateFlags
 -- | Opaque flag
@@ -725,19 +725,19 @@ newtype BlendOp = BlendOp Int32
   deriving (Eq, Storable)
 
 instance Show BlendOp where
-  showsPrec _ VK_BLEND_OP_ADD = showString "VK_BLEND_OP_ADD"
-  showsPrec _ VK_BLEND_OP_SUBTRACT = showString "VK_BLEND_OP_SUBTRACT"
-  showsPrec _ VK_BLEND_OP_REVERSE_SUBTRACT = showString "VK_BLEND_OP_REVERSE_SUBTRACT"
-  showsPrec _ VK_BLEND_OP_MIN = showString "VK_BLEND_OP_MIN"
-  showsPrec _ VK_BLEND_OP_MAX = showString "VK_BLEND_OP_MAX"
+  showsPrec _ BlendOpAdd = showString "BlendOpAdd"
+  showsPrec _ BlendOpSubtract = showString "BlendOpSubtract"
+  showsPrec _ BlendOpReverseSubtract = showString "BlendOpReverseSubtract"
+  showsPrec _ BlendOpMin = showString "BlendOpMin"
+  showsPrec _ BlendOpMax = showString "BlendOpMax"
   showsPrec p (BlendOp x) = showParen (p >= 11) (showString "BlendOp " . showsPrec 11 x)
 
 instance Read BlendOp where
-  readPrec = parens ( choose [ ("VK_BLEND_OP_ADD", pure VK_BLEND_OP_ADD)
-                             , ("VK_BLEND_OP_SUBTRACT", pure VK_BLEND_OP_SUBTRACT)
-                             , ("VK_BLEND_OP_REVERSE_SUBTRACT", pure VK_BLEND_OP_REVERSE_SUBTRACT)
-                             , ("VK_BLEND_OP_MIN", pure VK_BLEND_OP_MIN)
-                             , ("VK_BLEND_OP_MAX", pure VK_BLEND_OP_MAX)
+  readPrec = parens ( choose [ ("BlendOpAdd", pure BlendOpAdd)
+                             , ("BlendOpSubtract", pure BlendOpSubtract)
+                             , ("BlendOpReverseSubtract", pure BlendOpReverseSubtract)
+                             , ("BlendOpMin", pure BlendOpMin)
+                             , ("BlendOpMax", pure BlendOpMax)
                              ] +++
                       prec 10 (do
                         expectP (Ident "BlendOp")
@@ -747,15 +747,15 @@ instance Read BlendOp where
                     )
 
 
-pattern VK_BLEND_OP_ADD = BlendOp 0
+pattern BlendOpAdd = BlendOp 0
 
-pattern VK_BLEND_OP_SUBTRACT = BlendOp 1
+pattern BlendOpSubtract = BlendOp 1
 
-pattern VK_BLEND_OP_REVERSE_SUBTRACT = BlendOp 2
+pattern BlendOpReverseSubtract = BlendOp 2
 
-pattern VK_BLEND_OP_MIN = BlendOp 3
+pattern BlendOpMin = BlendOp 3
 
-pattern VK_BLEND_OP_MAX = BlendOp 4
+pattern BlendOpMax = BlendOp 4
 
 -- ** destroyPipeline
 foreign import ccall "vkDestroyPipeline" destroyPipeline ::
@@ -839,31 +839,31 @@ newtype PrimitiveTopology = PrimitiveTopology Int32
   deriving (Eq, Storable)
 
 instance Show PrimitiveTopology where
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_POINT_LIST = showString "VK_PRIMITIVE_TOPOLOGY_POINT_LIST"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_LIST = showString "VK_PRIMITIVE_TOPOLOGY_LINE_LIST"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_STRIP = showString "VK_PRIMITIVE_TOPOLOGY_LINE_STRIP"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY"
-  showsPrec _ VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = showString "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST"
+  showsPrec _ PrimitiveTopologyPointList = showString "PrimitiveTopologyPointList"
+  showsPrec _ PrimitiveTopologyLineList = showString "PrimitiveTopologyLineList"
+  showsPrec _ PrimitiveTopologyLineStrip = showString "PrimitiveTopologyLineStrip"
+  showsPrec _ PrimitiveTopologyTriangleList = showString "PrimitiveTopologyTriangleList"
+  showsPrec _ PrimitiveTopologyTriangleStrip = showString "PrimitiveTopologyTriangleStrip"
+  showsPrec _ PrimitiveTopologyTriangleFan = showString "PrimitiveTopologyTriangleFan"
+  showsPrec _ PrimitiveTopologyLineListWithAdjacency = showString "PrimitiveTopologyLineListWithAdjacency"
+  showsPrec _ PrimitiveTopologyLineStripWithAdjacency = showString "PrimitiveTopologyLineStripWithAdjacency"
+  showsPrec _ PrimitiveTopologyTriangleListWithAdjacency = showString "PrimitiveTopologyTriangleListWithAdjacency"
+  showsPrec _ PrimitiveTopologyTriangleStripWithAdjacency = showString "PrimitiveTopologyTriangleStripWithAdjacency"
+  showsPrec _ PrimitiveTopologyPatchList = showString "PrimitiveTopologyPatchList"
   showsPrec p (PrimitiveTopology x) = showParen (p >= 11) (showString "PrimitiveTopology " . showsPrec 11 x)
 
 instance Read PrimitiveTopology where
-  readPrec = parens ( choose [ ("VK_PRIMITIVE_TOPOLOGY_POINT_LIST", pure VK_PRIMITIVE_TOPOLOGY_POINT_LIST)
-                             , ("VK_PRIMITIVE_TOPOLOGY_LINE_LIST", pure VK_PRIMITIVE_TOPOLOGY_LINE_LIST)
-                             , ("VK_PRIMITIVE_TOPOLOGY_LINE_STRIP", pure VK_PRIMITIVE_TOPOLOGY_LINE_STRIP)
-                             , ("VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST", pure VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST)
-                             , ("VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP", pure VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP)
-                             , ("VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN", pure VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN)
-                             , ("VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY", pure VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY)
-                             , ("VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY", pure VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY)
-                             , ("VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY", pure VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY)
-                             , ("VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY", pure VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY)
-                             , ("VK_PRIMITIVE_TOPOLOGY_PATCH_LIST", pure VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)
+  readPrec = parens ( choose [ ("PrimitiveTopologyPointList", pure PrimitiveTopologyPointList)
+                             , ("PrimitiveTopologyLineList", pure PrimitiveTopologyLineList)
+                             , ("PrimitiveTopologyLineStrip", pure PrimitiveTopologyLineStrip)
+                             , ("PrimitiveTopologyTriangleList", pure PrimitiveTopologyTriangleList)
+                             , ("PrimitiveTopologyTriangleStrip", pure PrimitiveTopologyTriangleStrip)
+                             , ("PrimitiveTopologyTriangleFan", pure PrimitiveTopologyTriangleFan)
+                             , ("PrimitiveTopologyLineListWithAdjacency", pure PrimitiveTopologyLineListWithAdjacency)
+                             , ("PrimitiveTopologyLineStripWithAdjacency", pure PrimitiveTopologyLineStripWithAdjacency)
+                             , ("PrimitiveTopologyTriangleListWithAdjacency", pure PrimitiveTopologyTriangleListWithAdjacency)
+                             , ("PrimitiveTopologyTriangleStripWithAdjacency", pure PrimitiveTopologyTriangleStripWithAdjacency)
+                             , ("PrimitiveTopologyPatchList", pure PrimitiveTopologyPatchList)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PrimitiveTopology")
@@ -873,27 +873,27 @@ instance Read PrimitiveTopology where
                     )
 
 
-pattern VK_PRIMITIVE_TOPOLOGY_POINT_LIST = PrimitiveTopology 0
+pattern PrimitiveTopologyPointList = PrimitiveTopology 0
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST = PrimitiveTopology 1
+pattern PrimitiveTopologyLineList = PrimitiveTopology 1
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP = PrimitiveTopology 2
+pattern PrimitiveTopologyLineStrip = PrimitiveTopology 2
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST = PrimitiveTopology 3
+pattern PrimitiveTopologyTriangleList = PrimitiveTopology 3
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP = PrimitiveTopology 4
+pattern PrimitiveTopologyTriangleStrip = PrimitiveTopology 4
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN = PrimitiveTopology 5
+pattern PrimitiveTopologyTriangleFan = PrimitiveTopology 5
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY = PrimitiveTopology 6
+pattern PrimitiveTopologyLineListWithAdjacency = PrimitiveTopology 6
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY = PrimitiveTopology 7
+pattern PrimitiveTopologyLineStripWithAdjacency = PrimitiveTopology 7
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY = PrimitiveTopology 8
+pattern PrimitiveTopologyTriangleListWithAdjacency = PrimitiveTopology 8
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = PrimitiveTopology 9
+pattern PrimitiveTopologyTriangleStripWithAdjacency = PrimitiveTopology 9
 
-pattern VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = PrimitiveTopology 10
+pattern PrimitiveTopologyPatchList = PrimitiveTopology 10
 
 
 data PipelineInputAssemblyStateCreateInfo =
@@ -1009,13 +1009,13 @@ newtype VertexInputRate = VertexInputRate Int32
   deriving (Eq, Storable)
 
 instance Show VertexInputRate where
-  showsPrec _ VK_VERTEX_INPUT_RATE_VERTEX = showString "VK_VERTEX_INPUT_RATE_VERTEX"
-  showsPrec _ VK_VERTEX_INPUT_RATE_INSTANCE = showString "VK_VERTEX_INPUT_RATE_INSTANCE"
+  showsPrec _ VertexInputRateVertex = showString "VertexInputRateVertex"
+  showsPrec _ VertexInputRateInstance = showString "VertexInputRateInstance"
   showsPrec p (VertexInputRate x) = showParen (p >= 11) (showString "VertexInputRate " . showsPrec 11 x)
 
 instance Read VertexInputRate where
-  readPrec = parens ( choose [ ("VK_VERTEX_INPUT_RATE_VERTEX", pure VK_VERTEX_INPUT_RATE_VERTEX)
-                             , ("VK_VERTEX_INPUT_RATE_INSTANCE", pure VK_VERTEX_INPUT_RATE_INSTANCE)
+  readPrec = parens ( choose [ ("VertexInputRateVertex", pure VertexInputRateVertex)
+                             , ("VertexInputRateInstance", pure VertexInputRateInstance)
                              ] +++
                       prec 10 (do
                         expectP (Ident "VertexInputRate")
@@ -1025,9 +1025,9 @@ instance Read VertexInputRate where
                     )
 
 
-pattern VK_VERTEX_INPUT_RATE_VERTEX = VertexInputRate 0
+pattern VertexInputRateVertex = VertexInputRate 0
 
-pattern VK_VERTEX_INPUT_RATE_INSTANCE = VertexInputRate 1
+pattern VertexInputRateInstance = VertexInputRate 1
 
 -- ** PipelineStageFlags
 
@@ -1157,47 +1157,47 @@ newtype BlendFactor = BlendFactor Int32
   deriving (Eq, Storable)
 
 instance Show BlendFactor where
-  showsPrec _ VK_BLEND_FACTOR_ZERO = showString "VK_BLEND_FACTOR_ZERO"
-  showsPrec _ VK_BLEND_FACTOR_ONE = showString "VK_BLEND_FACTOR_ONE"
-  showsPrec _ VK_BLEND_FACTOR_SRC_COLOR = showString "VK_BLEND_FACTOR_SRC_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_DST_COLOR = showString "VK_BLEND_FACTOR_DST_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR = showString "VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_SRC_ALPHA = showString "VK_BLEND_FACTOR_SRC_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_DST_ALPHA = showString "VK_BLEND_FACTOR_DST_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA = showString "VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_CONSTANT_COLOR = showString "VK_BLEND_FACTOR_CONSTANT_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR = showString "VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_CONSTANT_ALPHA = showString "VK_BLEND_FACTOR_CONSTANT_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = showString "VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_SRC_ALPHA_SATURATE = showString "VK_BLEND_FACTOR_SRC_ALPHA_SATURATE"
-  showsPrec _ VK_BLEND_FACTOR_SRC1_COLOR = showString "VK_BLEND_FACTOR_SRC1_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR"
-  showsPrec _ VK_BLEND_FACTOR_SRC1_ALPHA = showString "VK_BLEND_FACTOR_SRC1_ALPHA"
-  showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA"
+  showsPrec _ BlendFactorZero = showString "BlendFactorZero"
+  showsPrec _ BlendFactorOne = showString "BlendFactorOne"
+  showsPrec _ BlendFactorSrcColor = showString "BlendFactorSrcColor"
+  showsPrec _ BlendFactorOneMinusSrcColor = showString "BlendFactorOneMinusSrcColor"
+  showsPrec _ BlendFactorDstColor = showString "BlendFactorDstColor"
+  showsPrec _ BlendFactorOneMinusDstColor = showString "BlendFactorOneMinusDstColor"
+  showsPrec _ BlendFactorSrcAlpha = showString "BlendFactorSrcAlpha"
+  showsPrec _ BlendFactorOneMinusSrcAlpha = showString "BlendFactorOneMinusSrcAlpha"
+  showsPrec _ BlendFactorDstAlpha = showString "BlendFactorDstAlpha"
+  showsPrec _ BlendFactorOneMinusDstAlpha = showString "BlendFactorOneMinusDstAlpha"
+  showsPrec _ BlendFactorConstantColor = showString "BlendFactorConstantColor"
+  showsPrec _ BlendFactorOneMinusConstantColor = showString "BlendFactorOneMinusConstantColor"
+  showsPrec _ BlendFactorConstantAlpha = showString "BlendFactorConstantAlpha"
+  showsPrec _ BlendFactorOneMinusConstantAlpha = showString "BlendFactorOneMinusConstantAlpha"
+  showsPrec _ BlendFactorSrcAlphaSaturate = showString "BlendFactorSrcAlphaSaturate"
+  showsPrec _ BlendFactorSrc1Color = showString "BlendFactorSrc1Color"
+  showsPrec _ BlendFactorOneMinusSrc1Color = showString "BlendFactorOneMinusSrc1Color"
+  showsPrec _ BlendFactorSrc1Alpha = showString "BlendFactorSrc1Alpha"
+  showsPrec _ BlendFactorOneMinusSrc1Alpha = showString "BlendFactorOneMinusSrc1Alpha"
   showsPrec p (BlendFactor x) = showParen (p >= 11) (showString "BlendFactor " . showsPrec 11 x)
 
 instance Read BlendFactor where
-  readPrec = parens ( choose [ ("VK_BLEND_FACTOR_ZERO", pure VK_BLEND_FACTOR_ZERO)
-                             , ("VK_BLEND_FACTOR_ONE", pure VK_BLEND_FACTOR_ONE)
-                             , ("VK_BLEND_FACTOR_SRC_COLOR", pure VK_BLEND_FACTOR_SRC_COLOR)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR", pure VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR)
-                             , ("VK_BLEND_FACTOR_DST_COLOR", pure VK_BLEND_FACTOR_DST_COLOR)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR", pure VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR)
-                             , ("VK_BLEND_FACTOR_SRC_ALPHA", pure VK_BLEND_FACTOR_SRC_ALPHA)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA", pure VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA)
-                             , ("VK_BLEND_FACTOR_DST_ALPHA", pure VK_BLEND_FACTOR_DST_ALPHA)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA", pure VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA)
-                             , ("VK_BLEND_FACTOR_CONSTANT_COLOR", pure VK_BLEND_FACTOR_CONSTANT_COLOR)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR", pure VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR)
-                             , ("VK_BLEND_FACTOR_CONSTANT_ALPHA", pure VK_BLEND_FACTOR_CONSTANT_ALPHA)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA", pure VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA)
-                             , ("VK_BLEND_FACTOR_SRC_ALPHA_SATURATE", pure VK_BLEND_FACTOR_SRC_ALPHA_SATURATE)
-                             , ("VK_BLEND_FACTOR_SRC1_COLOR", pure VK_BLEND_FACTOR_SRC1_COLOR)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR", pure VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR)
-                             , ("VK_BLEND_FACTOR_SRC1_ALPHA", pure VK_BLEND_FACTOR_SRC1_ALPHA)
-                             , ("VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA", pure VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)
+  readPrec = parens ( choose [ ("BlendFactorZero", pure BlendFactorZero)
+                             , ("BlendFactorOne", pure BlendFactorOne)
+                             , ("BlendFactorSrcColor", pure BlendFactorSrcColor)
+                             , ("BlendFactorOneMinusSrcColor", pure BlendFactorOneMinusSrcColor)
+                             , ("BlendFactorDstColor", pure BlendFactorDstColor)
+                             , ("BlendFactorOneMinusDstColor", pure BlendFactorOneMinusDstColor)
+                             , ("BlendFactorSrcAlpha", pure BlendFactorSrcAlpha)
+                             , ("BlendFactorOneMinusSrcAlpha", pure BlendFactorOneMinusSrcAlpha)
+                             , ("BlendFactorDstAlpha", pure BlendFactorDstAlpha)
+                             , ("BlendFactorOneMinusDstAlpha", pure BlendFactorOneMinusDstAlpha)
+                             , ("BlendFactorConstantColor", pure BlendFactorConstantColor)
+                             , ("BlendFactorOneMinusConstantColor", pure BlendFactorOneMinusConstantColor)
+                             , ("BlendFactorConstantAlpha", pure BlendFactorConstantAlpha)
+                             , ("BlendFactorOneMinusConstantAlpha", pure BlendFactorOneMinusConstantAlpha)
+                             , ("BlendFactorSrcAlphaSaturate", pure BlendFactorSrcAlphaSaturate)
+                             , ("BlendFactorSrc1Color", pure BlendFactorSrc1Color)
+                             , ("BlendFactorOneMinusSrc1Color", pure BlendFactorOneMinusSrc1Color)
+                             , ("BlendFactorSrc1Alpha", pure BlendFactorSrc1Alpha)
+                             , ("BlendFactorOneMinusSrc1Alpha", pure BlendFactorOneMinusSrc1Alpha)
                              ] +++
                       prec 10 (do
                         expectP (Ident "BlendFactor")
@@ -1207,43 +1207,43 @@ instance Read BlendFactor where
                     )
 
 
-pattern VK_BLEND_FACTOR_ZERO = BlendFactor 0
+pattern BlendFactorZero = BlendFactor 0
 
-pattern VK_BLEND_FACTOR_ONE = BlendFactor 1
+pattern BlendFactorOne = BlendFactor 1
 
-pattern VK_BLEND_FACTOR_SRC_COLOR = BlendFactor 2
+pattern BlendFactorSrcColor = BlendFactor 2
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR = BlendFactor 3
+pattern BlendFactorOneMinusSrcColor = BlendFactor 3
 
-pattern VK_BLEND_FACTOR_DST_COLOR = BlendFactor 4
+pattern BlendFactorDstColor = BlendFactor 4
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR = BlendFactor 5
+pattern BlendFactorOneMinusDstColor = BlendFactor 5
 
-pattern VK_BLEND_FACTOR_SRC_ALPHA = BlendFactor 6
+pattern BlendFactorSrcAlpha = BlendFactor 6
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA = BlendFactor 7
+pattern BlendFactorOneMinusSrcAlpha = BlendFactor 7
 
-pattern VK_BLEND_FACTOR_DST_ALPHA = BlendFactor 8
+pattern BlendFactorDstAlpha = BlendFactor 8
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA = BlendFactor 9
+pattern BlendFactorOneMinusDstAlpha = BlendFactor 9
 
-pattern VK_BLEND_FACTOR_CONSTANT_COLOR = BlendFactor 10
+pattern BlendFactorConstantColor = BlendFactor 10
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR = BlendFactor 11
+pattern BlendFactorOneMinusConstantColor = BlendFactor 11
 
-pattern VK_BLEND_FACTOR_CONSTANT_ALPHA = BlendFactor 12
+pattern BlendFactorConstantAlpha = BlendFactor 12
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = BlendFactor 13
+pattern BlendFactorOneMinusConstantAlpha = BlendFactor 13
 
-pattern VK_BLEND_FACTOR_SRC_ALPHA_SATURATE = BlendFactor 14
+pattern BlendFactorSrcAlphaSaturate = BlendFactor 14
 
-pattern VK_BLEND_FACTOR_SRC1_COLOR = BlendFactor 15
+pattern BlendFactorSrc1Color = BlendFactor 15
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR = BlendFactor 16
+pattern BlendFactorOneMinusSrc1Color = BlendFactor 16
 
-pattern VK_BLEND_FACTOR_SRC1_ALPHA = BlendFactor 17
+pattern BlendFactorSrc1Alpha = BlendFactor 17
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = BlendFactor 18
+pattern BlendFactorOneMinusSrc1Alpha = BlendFactor 18
 
 newtype SampleMask = SampleMask Word32
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -45,19 +45,19 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
+import Graphics.Vulkan.Shader( ShaderStageFlags(..)
                              , ShaderModule(..)
                              )
-import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
-                              , VkCompareOp(..)
+import Graphics.Vulkan.Sampler( CompareOp(..)
+                              , SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , Viewport(..)
                            , VkBool32(..)
                            , Rect2D(..)
-                           , VkResult(..)
+                           , Format(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -66,9 +66,9 @@ import Foreign.C.Types( CFloat(..)
 
 
 data PipelineTessellationStateCreateInfo =
-  PipelineTessellationStateCreateInfo{ sType :: VkStructureType 
+  PipelineTessellationStateCreateInfo{ sType :: StructureType 
                                      , pNext :: Ptr Void 
-                                     , flags :: VkPipelineTessellationStateCreateFlags 
+                                     , flags :: PipelineTessellationStateCreateFlags 
                                      , patchControlPoints :: Word32 
                                      }
   deriving (Eq)
@@ -90,7 +90,7 @@ instance Storable PipelineTessellationStateCreateInfo where
 data VertexInputAttributeDescription =
   VertexInputAttributeDescription{ location :: Word32 
                                  , binding :: Word32 
-                                 , format :: VkFormat 
+                                 , format :: Format 
                                  , offset :: Word32 
                                  }
   deriving (Eq)
@@ -110,9 +110,9 @@ instance Storable VertexInputAttributeDescription where
 
 
 data GraphicsPipelineCreateInfo =
-  GraphicsPipelineCreateInfo{ sType :: VkStructureType 
+  GraphicsPipelineCreateInfo{ sType :: StructureType 
                             , pNext :: Ptr Void 
-                            , flags :: VkPipelineCreateFlags 
+                            , flags :: PipelineCreateFlags 
                             , stageCount :: Word32 
                             , pStages :: Ptr PipelineShaderStageCreateInfo 
                             , pVertexInputState :: Ptr PipelineVertexInputStateCreateInfo 
@@ -177,49 +177,49 @@ instance Storable GraphicsPipelineCreateInfo where
 
 -- ** VkCullModeFlags
 
-newtype VkCullModeFlags = VkCullModeFlags VkFlags
+newtype CullModeFlags = CullModeFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkCullModeFlags where
+instance Show CullModeFlags where
   showsPrec _ VK_CULL_MODE_FRONT_BIT = showString "VK_CULL_MODE_FRONT_BIT"
   showsPrec _ VK_CULL_MODE_BACK_BIT = showString "VK_CULL_MODE_BACK_BIT"
   showsPrec _ VK_CULL_MODE_NONE = showString "VK_CULL_MODE_NONE"
   showsPrec _ VK_CULL_MODE_FRONT_AND_BACK = showString "VK_CULL_MODE_FRONT_AND_BACK"
-  showsPrec p (VkCullModeFlags x) = showParen (p >= 11) (showString "VkCullModeFlags " . showsPrec 11 x)
+  showsPrec p (CullModeFlags x) = showParen (p >= 11) (showString "CullModeFlags " . showsPrec 11 x)
 
-instance Read VkCullModeFlags where
+instance Read CullModeFlags where
   readPrec = parens ( choose [ ("VK_CULL_MODE_FRONT_BIT", pure VK_CULL_MODE_FRONT_BIT)
                              , ("VK_CULL_MODE_BACK_BIT", pure VK_CULL_MODE_BACK_BIT)
                              , ("VK_CULL_MODE_NONE", pure VK_CULL_MODE_NONE)
                              , ("VK_CULL_MODE_FRONT_AND_BACK", pure VK_CULL_MODE_FRONT_AND_BACK)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCullModeFlags")
+                        expectP (Ident "CullModeFlags")
                         v <- step readPrec
-                        pure (VkCullModeFlags v)
+                        pure (CullModeFlags v)
                         )
                     )
 
 
-pattern VK_CULL_MODE_FRONT_BIT = VkCullModeFlags 0x1
+pattern VK_CULL_MODE_FRONT_BIT = CullModeFlags 0x1
 
-pattern VK_CULL_MODE_BACK_BIT = VkCullModeFlags 0x2
+pattern VK_CULL_MODE_BACK_BIT = CullModeFlags 0x2
 
-pattern VK_CULL_MODE_NONE = VkCullModeFlags 0x0
+pattern VK_CULL_MODE_NONE = CullModeFlags 0x0
 
-pattern VK_CULL_MODE_FRONT_AND_BACK = VkCullModeFlags 0x3
+pattern VK_CULL_MODE_FRONT_AND_BACK = CullModeFlags 0x3
 
--- ** VkPipelineDepthStencilStateCreateFlags
+-- ** PipelineDepthStencilStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineDepthStencilStateCreateFlags = VkPipelineDepthStencilStateCreateFlags VkFlags
+newtype PipelineDepthStencilStateCreateFlags = PipelineDepthStencilStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data PipelineShaderStageCreateInfo =
-  PipelineShaderStageCreateInfo{ sType :: VkStructureType 
+  PipelineShaderStageCreateInfo{ sType :: StructureType 
                                , pNext :: Ptr Void 
-                               , flags :: VkPipelineShaderStageCreateFlags 
-                               , stage :: VkShaderStageFlags 
+                               , flags :: PipelineShaderStageCreateFlags 
+                               , stage :: ShaderStageFlags 
                                , _module :: ShaderModule 
                                , pName :: Ptr CChar 
                                , pSpecializationInfo :: Ptr SpecializationInfo 
@@ -247,45 +247,45 @@ instance Storable PipelineShaderStageCreateInfo where
 
 -- ** VkColorComponentFlags
 
-newtype VkColorComponentFlags = VkColorComponentFlags VkFlags
+newtype ColorComponentFlags = ColorComponentFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkColorComponentFlags where
+instance Show ColorComponentFlags where
   showsPrec _ VK_COLOR_COMPONENT_R_BIT = showString "VK_COLOR_COMPONENT_R_BIT"
   showsPrec _ VK_COLOR_COMPONENT_G_BIT = showString "VK_COLOR_COMPONENT_G_BIT"
   showsPrec _ VK_COLOR_COMPONENT_B_BIT = showString "VK_COLOR_COMPONENT_B_BIT"
   showsPrec _ VK_COLOR_COMPONENT_A_BIT = showString "VK_COLOR_COMPONENT_A_BIT"
   
-  showsPrec p (VkColorComponentFlags x) = showParen (p >= 11) (showString "VkColorComponentFlags " . showsPrec 11 x)
+  showsPrec p (ColorComponentFlags x) = showParen (p >= 11) (showString "ColorComponentFlags " . showsPrec 11 x)
 
-instance Read VkColorComponentFlags where
+instance Read ColorComponentFlags where
   readPrec = parens ( choose [ ("VK_COLOR_COMPONENT_R_BIT", pure VK_COLOR_COMPONENT_R_BIT)
                              , ("VK_COLOR_COMPONENT_G_BIT", pure VK_COLOR_COMPONENT_G_BIT)
                              , ("VK_COLOR_COMPONENT_B_BIT", pure VK_COLOR_COMPONENT_B_BIT)
                              , ("VK_COLOR_COMPONENT_A_BIT", pure VK_COLOR_COMPONENT_A_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkColorComponentFlags")
+                        expectP (Ident "ColorComponentFlags")
                         v <- step readPrec
-                        pure (VkColorComponentFlags v)
+                        pure (ColorComponentFlags v)
                         )
                     )
 
 
-pattern VK_COLOR_COMPONENT_R_BIT = VkColorComponentFlags 0x1
+pattern VK_COLOR_COMPONENT_R_BIT = ColorComponentFlags 0x1
 
-pattern VK_COLOR_COMPONENT_G_BIT = VkColorComponentFlags 0x2
+pattern VK_COLOR_COMPONENT_G_BIT = ColorComponentFlags 0x2
 
-pattern VK_COLOR_COMPONENT_B_BIT = VkColorComponentFlags 0x4
+pattern VK_COLOR_COMPONENT_B_BIT = ColorComponentFlags 0x4
 
-pattern VK_COLOR_COMPONENT_A_BIT = VkColorComponentFlags 0x8
+pattern VK_COLOR_COMPONENT_A_BIT = ColorComponentFlags 0x8
 
 
 
 data ComputePipelineCreateInfo =
-  ComputePipelineCreateInfo{ sType :: VkStructureType 
+  ComputePipelineCreateInfo{ sType :: StructureType 
                            , pNext :: Ptr Void 
-                           , flags :: VkPipelineCreateFlags 
+                           , flags :: PipelineCreateFlags 
                            , stage :: PipelineShaderStageCreateInfo 
                            , layout :: PipelineLayout 
                            , basePipelineHandle :: Pipeline 
@@ -312,12 +312,12 @@ instance Storable ComputePipelineCreateInfo where
                 *> poke (ptr `plusPtr` 88) (basePipelineIndex (poked :: ComputePipelineCreateInfo))
 
 
--- ** VkStencilOp
+-- ** StencilOp
 
-newtype VkStencilOp = VkStencilOp Int32
+newtype StencilOp = StencilOp Int32
   deriving (Eq, Storable)
 
-instance Show VkStencilOp where
+instance Show StencilOp where
   showsPrec _ VK_STENCIL_OP_KEEP = showString "VK_STENCIL_OP_KEEP"
   showsPrec _ VK_STENCIL_OP_ZERO = showString "VK_STENCIL_OP_ZERO"
   showsPrec _ VK_STENCIL_OP_REPLACE = showString "VK_STENCIL_OP_REPLACE"
@@ -326,9 +326,9 @@ instance Show VkStencilOp where
   showsPrec _ VK_STENCIL_OP_INVERT = showString "VK_STENCIL_OP_INVERT"
   showsPrec _ VK_STENCIL_OP_INCREMENT_AND_WRAP = showString "VK_STENCIL_OP_INCREMENT_AND_WRAP"
   showsPrec _ VK_STENCIL_OP_DECREMENT_AND_WRAP = showString "VK_STENCIL_OP_DECREMENT_AND_WRAP"
-  showsPrec p (VkStencilOp x) = showParen (p >= 11) (showString "VkStencilOp " . showsPrec 11 x)
+  showsPrec p (StencilOp x) = showParen (p >= 11) (showString "StencilOp " . showsPrec 11 x)
 
-instance Read VkStencilOp where
+instance Read StencilOp where
   readPrec = parens ( choose [ ("VK_STENCIL_OP_KEEP", pure VK_STENCIL_OP_KEEP)
                              , ("VK_STENCIL_OP_ZERO", pure VK_STENCIL_OP_ZERO)
                              , ("VK_STENCIL_OP_REPLACE", pure VK_STENCIL_OP_REPLACE)
@@ -339,28 +339,28 @@ instance Read VkStencilOp where
                              , ("VK_STENCIL_OP_DECREMENT_AND_WRAP", pure VK_STENCIL_OP_DECREMENT_AND_WRAP)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkStencilOp")
+                        expectP (Ident "StencilOp")
                         v <- step readPrec
-                        pure (VkStencilOp v)
+                        pure (StencilOp v)
                         )
                     )
 
 
-pattern VK_STENCIL_OP_KEEP = VkStencilOp 0
+pattern VK_STENCIL_OP_KEEP = StencilOp 0
 
-pattern VK_STENCIL_OP_ZERO = VkStencilOp 1
+pattern VK_STENCIL_OP_ZERO = StencilOp 1
 
-pattern VK_STENCIL_OP_REPLACE = VkStencilOp 2
+pattern VK_STENCIL_OP_REPLACE = StencilOp 2
 
-pattern VK_STENCIL_OP_INCREMENT_AND_CLAMP = VkStencilOp 3
+pattern VK_STENCIL_OP_INCREMENT_AND_CLAMP = StencilOp 3
 
-pattern VK_STENCIL_OP_DECREMENT_AND_CLAMP = VkStencilOp 4
+pattern VK_STENCIL_OP_DECREMENT_AND_CLAMP = StencilOp 4
 
-pattern VK_STENCIL_OP_INVERT = VkStencilOp 5
+pattern VK_STENCIL_OP_INVERT = StencilOp 5
 
-pattern VK_STENCIL_OP_INCREMENT_AND_WRAP = VkStencilOp 6
+pattern VK_STENCIL_OP_INCREMENT_AND_WRAP = StencilOp 6
 
-pattern VK_STENCIL_OP_DECREMENT_AND_WRAP = VkStencilOp 7
+pattern VK_STENCIL_OP_DECREMENT_AND_WRAP = StencilOp 7
 
 
 data SpecializationInfo =
@@ -384,17 +384,17 @@ instance Storable SpecializationInfo where
                 *> poke (ptr `plusPtr` 24) (pData (poked :: SpecializationInfo))
 
 
--- ** VkPipelineColorBlendStateCreateFlags
+-- ** PipelineColorBlendStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineColorBlendStateCreateFlags = VkPipelineColorBlendStateCreateFlags VkFlags
+newtype PipelineColorBlendStateCreateFlags = PipelineColorBlendStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 newtype Pipeline = Pipeline Word64
   deriving (Eq, Storable)
 
--- ** VkPipelineInputAssemblyStateCreateFlags
+-- ** PipelineInputAssemblyStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineInputAssemblyStateCreateFlags = VkPipelineInputAssemblyStateCreateFlags VkFlags
+newtype PipelineInputAssemblyStateCreateFlags = PipelineInputAssemblyStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkCreateGraphicsPipelines
@@ -403,75 +403,75 @@ foreign import ccall "vkCreateGraphicsPipelines" vkCreateGraphicsPipelines ::
   PipelineCache ->
     Word32 ->
       Ptr GraphicsPipelineCreateInfo ->
-        Ptr AllocationCallbacks -> Ptr Pipeline -> IO VkResult
+        Ptr AllocationCallbacks -> Ptr Pipeline -> IO Result
 
--- ** VkFrontFace
+-- ** FrontFace
 
-newtype VkFrontFace = VkFrontFace Int32
+newtype FrontFace = FrontFace Int32
   deriving (Eq, Storable)
 
-instance Show VkFrontFace where
+instance Show FrontFace where
   showsPrec _ VK_FRONT_FACE_COUNTER_CLOCKWISE = showString "VK_FRONT_FACE_COUNTER_CLOCKWISE"
   showsPrec _ VK_FRONT_FACE_CLOCKWISE = showString "VK_FRONT_FACE_CLOCKWISE"
-  showsPrec p (VkFrontFace x) = showParen (p >= 11) (showString "VkFrontFace " . showsPrec 11 x)
+  showsPrec p (FrontFace x) = showParen (p >= 11) (showString "FrontFace " . showsPrec 11 x)
 
-instance Read VkFrontFace where
+instance Read FrontFace where
   readPrec = parens ( choose [ ("VK_FRONT_FACE_COUNTER_CLOCKWISE", pure VK_FRONT_FACE_COUNTER_CLOCKWISE)
                              , ("VK_FRONT_FACE_CLOCKWISE", pure VK_FRONT_FACE_CLOCKWISE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFrontFace")
+                        expectP (Ident "FrontFace")
                         v <- step readPrec
-                        pure (VkFrontFace v)
+                        pure (FrontFace v)
                         )
                     )
 
 
-pattern VK_FRONT_FACE_COUNTER_CLOCKWISE = VkFrontFace 0
+pattern VK_FRONT_FACE_COUNTER_CLOCKWISE = FrontFace 0
 
-pattern VK_FRONT_FACE_CLOCKWISE = VkFrontFace 1
+pattern VK_FRONT_FACE_CLOCKWISE = FrontFace 1
 
--- ** VkPolygonMode
+-- ** PolygonMode
 
-newtype VkPolygonMode = VkPolygonMode Int32
+newtype PolygonMode = PolygonMode Int32
   deriving (Eq, Storable)
 
-instance Show VkPolygonMode where
+instance Show PolygonMode where
   showsPrec _ VK_POLYGON_MODE_FILL = showString "VK_POLYGON_MODE_FILL"
   showsPrec _ VK_POLYGON_MODE_LINE = showString "VK_POLYGON_MODE_LINE"
   showsPrec _ VK_POLYGON_MODE_POINT = showString "VK_POLYGON_MODE_POINT"
-  showsPrec p (VkPolygonMode x) = showParen (p >= 11) (showString "VkPolygonMode " . showsPrec 11 x)
+  showsPrec p (PolygonMode x) = showParen (p >= 11) (showString "PolygonMode " . showsPrec 11 x)
 
-instance Read VkPolygonMode where
+instance Read PolygonMode where
   readPrec = parens ( choose [ ("VK_POLYGON_MODE_FILL", pure VK_POLYGON_MODE_FILL)
                              , ("VK_POLYGON_MODE_LINE", pure VK_POLYGON_MODE_LINE)
                              , ("VK_POLYGON_MODE_POINT", pure VK_POLYGON_MODE_POINT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPolygonMode")
+                        expectP (Ident "PolygonMode")
                         v <- step readPrec
-                        pure (VkPolygonMode v)
+                        pure (PolygonMode v)
                         )
                     )
 
 
-pattern VK_POLYGON_MODE_FILL = VkPolygonMode 0
+pattern VK_POLYGON_MODE_FILL = PolygonMode 0
 
-pattern VK_POLYGON_MODE_LINE = VkPolygonMode 1
+pattern VK_POLYGON_MODE_LINE = PolygonMode 1
 
-pattern VK_POLYGON_MODE_POINT = VkPolygonMode 2
+pattern VK_POLYGON_MODE_POINT = PolygonMode 2
 
--- ** VkPipelineViewportStateCreateFlags
+-- ** PipelineViewportStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineViewportStateCreateFlags = VkPipelineViewportStateCreateFlags VkFlags
+newtype PipelineViewportStateCreateFlags = PipelineViewportStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
--- ** VkLogicOp
+-- ** LogicOp
 
-newtype VkLogicOp = VkLogicOp Int32
+newtype LogicOp = LogicOp Int32
   deriving (Eq, Storable)
 
-instance Show VkLogicOp where
+instance Show LogicOp where
   showsPrec _ VK_LOGIC_OP_CLEAR = showString "VK_LOGIC_OP_CLEAR"
   showsPrec _ VK_LOGIC_OP_AND = showString "VK_LOGIC_OP_AND"
   showsPrec _ VK_LOGIC_OP_AND_REVERSE = showString "VK_LOGIC_OP_AND_REVERSE"
@@ -488,9 +488,9 @@ instance Show VkLogicOp where
   showsPrec _ VK_LOGIC_OP_OR_INVERTED = showString "VK_LOGIC_OP_OR_INVERTED"
   showsPrec _ VK_LOGIC_OP_NAND = showString "VK_LOGIC_OP_NAND"
   showsPrec _ VK_LOGIC_OP_SET = showString "VK_LOGIC_OP_SET"
-  showsPrec p (VkLogicOp x) = showParen (p >= 11) (showString "VkLogicOp " . showsPrec 11 x)
+  showsPrec p (LogicOp x) = showParen (p >= 11) (showString "LogicOp " . showsPrec 11 x)
 
-instance Read VkLogicOp where
+instance Read LogicOp where
   readPrec = parens ( choose [ ("VK_LOGIC_OP_CLEAR", pure VK_LOGIC_OP_CLEAR)
                              , ("VK_LOGIC_OP_AND", pure VK_LOGIC_OP_AND)
                              , ("VK_LOGIC_OP_AND_REVERSE", pure VK_LOGIC_OP_AND_REVERSE)
@@ -509,88 +509,88 @@ instance Read VkLogicOp where
                              , ("VK_LOGIC_OP_SET", pure VK_LOGIC_OP_SET)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkLogicOp")
+                        expectP (Ident "LogicOp")
                         v <- step readPrec
-                        pure (VkLogicOp v)
+                        pure (LogicOp v)
                         )
                     )
 
 
-pattern VK_LOGIC_OP_CLEAR = VkLogicOp 0
+pattern VK_LOGIC_OP_CLEAR = LogicOp 0
 
-pattern VK_LOGIC_OP_AND = VkLogicOp 1
+pattern VK_LOGIC_OP_AND = LogicOp 1
 
-pattern VK_LOGIC_OP_AND_REVERSE = VkLogicOp 2
+pattern VK_LOGIC_OP_AND_REVERSE = LogicOp 2
 
-pattern VK_LOGIC_OP_COPY = VkLogicOp 3
+pattern VK_LOGIC_OP_COPY = LogicOp 3
 
-pattern VK_LOGIC_OP_AND_INVERTED = VkLogicOp 4
+pattern VK_LOGIC_OP_AND_INVERTED = LogicOp 4
 
-pattern VK_LOGIC_OP_NO_OP = VkLogicOp 5
+pattern VK_LOGIC_OP_NO_OP = LogicOp 5
 
-pattern VK_LOGIC_OP_XOR = VkLogicOp 6
+pattern VK_LOGIC_OP_XOR = LogicOp 6
 
-pattern VK_LOGIC_OP_OR = VkLogicOp 7
+pattern VK_LOGIC_OP_OR = LogicOp 7
 
-pattern VK_LOGIC_OP_NOR = VkLogicOp 8
+pattern VK_LOGIC_OP_NOR = LogicOp 8
 
-pattern VK_LOGIC_OP_EQUIVALENT = VkLogicOp 9
+pattern VK_LOGIC_OP_EQUIVALENT = LogicOp 9
 
-pattern VK_LOGIC_OP_INVERT = VkLogicOp 10
+pattern VK_LOGIC_OP_INVERT = LogicOp 10
 
-pattern VK_LOGIC_OP_OR_REVERSE = VkLogicOp 11
+pattern VK_LOGIC_OP_OR_REVERSE = LogicOp 11
 
-pattern VK_LOGIC_OP_COPY_INVERTED = VkLogicOp 12
+pattern VK_LOGIC_OP_COPY_INVERTED = LogicOp 12
 
-pattern VK_LOGIC_OP_OR_INVERTED = VkLogicOp 13
+pattern VK_LOGIC_OP_OR_INVERTED = LogicOp 13
 
-pattern VK_LOGIC_OP_NAND = VkLogicOp 14
+pattern VK_LOGIC_OP_NAND = LogicOp 14
 
-pattern VK_LOGIC_OP_SET = VkLogicOp 15
+pattern VK_LOGIC_OP_SET = LogicOp 15
 
 -- ** VkPipelineCreateFlags
 
-newtype VkPipelineCreateFlags = VkPipelineCreateFlags VkFlags
+newtype PipelineCreateFlags = PipelineCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkPipelineCreateFlags where
+instance Show PipelineCreateFlags where
   showsPrec _ VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = showString "VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT"
   showsPrec _ VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = showString "VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT"
   showsPrec _ VK_PIPELINE_CREATE_DERIVATIVE_BIT = showString "VK_PIPELINE_CREATE_DERIVATIVE_BIT"
   
-  showsPrec p (VkPipelineCreateFlags x) = showParen (p >= 11) (showString "VkPipelineCreateFlags " . showsPrec 11 x)
+  showsPrec p (PipelineCreateFlags x) = showParen (p >= 11) (showString "PipelineCreateFlags " . showsPrec 11 x)
 
-instance Read VkPipelineCreateFlags where
+instance Read PipelineCreateFlags where
   readPrec = parens ( choose [ ("VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT", pure VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT)
                              , ("VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT", pure VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)
                              , ("VK_PIPELINE_CREATE_DERIVATIVE_BIT", pure VK_PIPELINE_CREATE_DERIVATIVE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineCreateFlags")
+                        expectP (Ident "PipelineCreateFlags")
                         v <- step readPrec
-                        pure (VkPipelineCreateFlags v)
+                        pure (PipelineCreateFlags v)
                         )
                     )
 
 
-pattern VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = VkPipelineCreateFlags 0x1
+pattern VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = PipelineCreateFlags 0x1
 
-pattern VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = VkPipelineCreateFlags 0x2
+pattern VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = PipelineCreateFlags 0x2
 
-pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = VkPipelineCreateFlags 0x4
+pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = PipelineCreateFlags 0x4
 
 
--- ** VkPipelineRasterizationStateCreateFlags
+-- ** PipelineRasterizationStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineRasterizationStateCreateFlags = VkPipelineRasterizationStateCreateFlags VkFlags
+newtype PipelineRasterizationStateCreateFlags = PipelineRasterizationStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
--- ** VkDynamicState
+-- ** DynamicState
 
-newtype VkDynamicState = VkDynamicState Int32
+newtype DynamicState = DynamicState Int32
   deriving (Eq, Storable)
 
-instance Show VkDynamicState where
+instance Show DynamicState where
   showsPrec _ VK_DYNAMIC_STATE_VIEWPORT = showString "VK_DYNAMIC_STATE_VIEWPORT"
   showsPrec _ VK_DYNAMIC_STATE_SCISSOR = showString "VK_DYNAMIC_STATE_SCISSOR"
   showsPrec _ VK_DYNAMIC_STATE_LINE_WIDTH = showString "VK_DYNAMIC_STATE_LINE_WIDTH"
@@ -600,9 +600,9 @@ instance Show VkDynamicState where
   showsPrec _ VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = showString "VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK"
   showsPrec _ VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = showString "VK_DYNAMIC_STATE_STENCIL_WRITE_MASK"
   showsPrec _ VK_DYNAMIC_STATE_STENCIL_REFERENCE = showString "VK_DYNAMIC_STATE_STENCIL_REFERENCE"
-  showsPrec p (VkDynamicState x) = showParen (p >= 11) (showString "VkDynamicState " . showsPrec 11 x)
+  showsPrec p (DynamicState x) = showParen (p >= 11) (showString "DynamicState " . showsPrec 11 x)
 
-instance Read VkDynamicState where
+instance Read DynamicState where
   readPrec = parens ( choose [ ("VK_DYNAMIC_STATE_VIEWPORT", pure VK_DYNAMIC_STATE_VIEWPORT)
                              , ("VK_DYNAMIC_STATE_SCISSOR", pure VK_DYNAMIC_STATE_SCISSOR)
                              , ("VK_DYNAMIC_STATE_LINE_WIDTH", pure VK_DYNAMIC_STATE_LINE_WIDTH)
@@ -614,72 +614,72 @@ instance Read VkDynamicState where
                              , ("VK_DYNAMIC_STATE_STENCIL_REFERENCE", pure VK_DYNAMIC_STATE_STENCIL_REFERENCE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkDynamicState")
+                        expectP (Ident "DynamicState")
                         v <- step readPrec
-                        pure (VkDynamicState v)
+                        pure (DynamicState v)
                         )
                     )
 
 
-pattern VK_DYNAMIC_STATE_VIEWPORT = VkDynamicState 0
+pattern VK_DYNAMIC_STATE_VIEWPORT = DynamicState 0
 
-pattern VK_DYNAMIC_STATE_SCISSOR = VkDynamicState 1
+pattern VK_DYNAMIC_STATE_SCISSOR = DynamicState 1
 
-pattern VK_DYNAMIC_STATE_LINE_WIDTH = VkDynamicState 2
+pattern VK_DYNAMIC_STATE_LINE_WIDTH = DynamicState 2
 
-pattern VK_DYNAMIC_STATE_DEPTH_BIAS = VkDynamicState 3
+pattern VK_DYNAMIC_STATE_DEPTH_BIAS = DynamicState 3
 
-pattern VK_DYNAMIC_STATE_BLEND_CONSTANTS = VkDynamicState 4
+pattern VK_DYNAMIC_STATE_BLEND_CONSTANTS = DynamicState 4
 
-pattern VK_DYNAMIC_STATE_DEPTH_BOUNDS = VkDynamicState 5
+pattern VK_DYNAMIC_STATE_DEPTH_BOUNDS = DynamicState 5
 
-pattern VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = VkDynamicState 6
+pattern VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK = DynamicState 6
 
-pattern VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = VkDynamicState 7
+pattern VK_DYNAMIC_STATE_STENCIL_WRITE_MASK = DynamicState 7
 
-pattern VK_DYNAMIC_STATE_STENCIL_REFERENCE = VkDynamicState 8
+pattern VK_DYNAMIC_STATE_STENCIL_REFERENCE = DynamicState 8
 
--- ** VkPipelineBindPoint
+-- ** PipelineBindPoint
 
-newtype VkPipelineBindPoint = VkPipelineBindPoint Int32
+newtype PipelineBindPoint = PipelineBindPoint Int32
   deriving (Eq, Storable)
 
-instance Show VkPipelineBindPoint where
+instance Show PipelineBindPoint where
   showsPrec _ VK_PIPELINE_BIND_POINT_GRAPHICS = showString "VK_PIPELINE_BIND_POINT_GRAPHICS"
   showsPrec _ VK_PIPELINE_BIND_POINT_COMPUTE = showString "VK_PIPELINE_BIND_POINT_COMPUTE"
-  showsPrec p (VkPipelineBindPoint x) = showParen (p >= 11) (showString "VkPipelineBindPoint " . showsPrec 11 x)
+  showsPrec p (PipelineBindPoint x) = showParen (p >= 11) (showString "PipelineBindPoint " . showsPrec 11 x)
 
-instance Read VkPipelineBindPoint where
+instance Read PipelineBindPoint where
   readPrec = parens ( choose [ ("VK_PIPELINE_BIND_POINT_GRAPHICS", pure VK_PIPELINE_BIND_POINT_GRAPHICS)
                              , ("VK_PIPELINE_BIND_POINT_COMPUTE", pure VK_PIPELINE_BIND_POINT_COMPUTE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineBindPoint")
+                        expectP (Ident "PipelineBindPoint")
                         v <- step readPrec
-                        pure (VkPipelineBindPoint v)
+                        pure (PipelineBindPoint v)
                         )
                     )
 
 
-pattern VK_PIPELINE_BIND_POINT_GRAPHICS = VkPipelineBindPoint 0
+pattern VK_PIPELINE_BIND_POINT_GRAPHICS = PipelineBindPoint 0
 
-pattern VK_PIPELINE_BIND_POINT_COMPUTE = VkPipelineBindPoint 1
+pattern VK_PIPELINE_BIND_POINT_COMPUTE = PipelineBindPoint 1
 
--- ** VkPipelineDynamicStateCreateFlags
+-- ** PipelineDynamicStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineDynamicStateCreateFlags = VkPipelineDynamicStateCreateFlags VkFlags
+newtype PipelineDynamicStateCreateFlags = PipelineDynamicStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data PipelineRasterizationStateCreateInfo =
-  PipelineRasterizationStateCreateInfo{ sType :: VkStructureType 
+  PipelineRasterizationStateCreateInfo{ sType :: StructureType 
                                       , pNext :: Ptr Void 
-                                      , flags :: VkPipelineRasterizationStateCreateFlags 
+                                      , flags :: PipelineRasterizationStateCreateFlags 
                                       , depthClampEnable :: VkBool32 
                                       , rasterizerDiscardEnable :: VkBool32 
-                                      , polygonMode :: VkPolygonMode 
-                                      , cullMode :: VkCullModeFlags 
-                                      , frontFace :: VkFrontFace 
+                                      , polygonMode :: PolygonMode 
+                                      , cullMode :: CullModeFlags 
+                                      , frontFace :: FrontFace 
                                       , depthBiasEnable :: VkBool32 
                                       , depthBiasConstantFactor :: CFloat 
                                       , depthBiasClamp :: CFloat 
@@ -719,20 +719,20 @@ instance Storable PipelineRasterizationStateCreateInfo where
                 *> poke (ptr `plusPtr` 56) (lineWidth (poked :: PipelineRasterizationStateCreateInfo))
 
 
--- ** VkBlendOp
+-- ** BlendOp
 
-newtype VkBlendOp = VkBlendOp Int32
+newtype BlendOp = BlendOp Int32
   deriving (Eq, Storable)
 
-instance Show VkBlendOp where
+instance Show BlendOp where
   showsPrec _ VK_BLEND_OP_ADD = showString "VK_BLEND_OP_ADD"
   showsPrec _ VK_BLEND_OP_SUBTRACT = showString "VK_BLEND_OP_SUBTRACT"
   showsPrec _ VK_BLEND_OP_REVERSE_SUBTRACT = showString "VK_BLEND_OP_REVERSE_SUBTRACT"
   showsPrec _ VK_BLEND_OP_MIN = showString "VK_BLEND_OP_MIN"
   showsPrec _ VK_BLEND_OP_MAX = showString "VK_BLEND_OP_MAX"
-  showsPrec p (VkBlendOp x) = showParen (p >= 11) (showString "VkBlendOp " . showsPrec 11 x)
+  showsPrec p (BlendOp x) = showParen (p >= 11) (showString "BlendOp " . showsPrec 11 x)
 
-instance Read VkBlendOp where
+instance Read BlendOp where
   readPrec = parens ( choose [ ("VK_BLEND_OP_ADD", pure VK_BLEND_OP_ADD)
                              , ("VK_BLEND_OP_SUBTRACT", pure VK_BLEND_OP_SUBTRACT)
                              , ("VK_BLEND_OP_REVERSE_SUBTRACT", pure VK_BLEND_OP_REVERSE_SUBTRACT)
@@ -740,37 +740,37 @@ instance Read VkBlendOp where
                              , ("VK_BLEND_OP_MAX", pure VK_BLEND_OP_MAX)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBlendOp")
+                        expectP (Ident "BlendOp")
                         v <- step readPrec
-                        pure (VkBlendOp v)
+                        pure (BlendOp v)
                         )
                     )
 
 
-pattern VK_BLEND_OP_ADD = VkBlendOp 0
+pattern VK_BLEND_OP_ADD = BlendOp 0
 
-pattern VK_BLEND_OP_SUBTRACT = VkBlendOp 1
+pattern VK_BLEND_OP_SUBTRACT = BlendOp 1
 
-pattern VK_BLEND_OP_REVERSE_SUBTRACT = VkBlendOp 2
+pattern VK_BLEND_OP_REVERSE_SUBTRACT = BlendOp 2
 
-pattern VK_BLEND_OP_MIN = VkBlendOp 3
+pattern VK_BLEND_OP_MIN = BlendOp 3
 
-pattern VK_BLEND_OP_MAX = VkBlendOp 4
+pattern VK_BLEND_OP_MAX = BlendOp 4
 
 -- ** vkDestroyPipeline
 foreign import ccall "vkDestroyPipeline" vkDestroyPipeline ::
   Device -> Pipeline -> Ptr AllocationCallbacks -> IO ()
 
--- ** VkPipelineShaderStageCreateFlags
+-- ** PipelineShaderStageCreateFlags
 -- | Opaque flag
-newtype VkPipelineShaderStageCreateFlags = VkPipelineShaderStageCreateFlags VkFlags
+newtype PipelineShaderStageCreateFlags = PipelineShaderStageCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data PipelineViewportStateCreateInfo =
-  PipelineViewportStateCreateInfo{ sType :: VkStructureType 
+  PipelineViewportStateCreateInfo{ sType :: StructureType 
                                  , pNext :: Ptr Void 
-                                 , flags :: VkPipelineViewportStateCreateFlags 
+                                 , flags :: PipelineViewportStateCreateFlags 
                                  , viewportCount :: Word32 
                                  , pViewports :: Ptr Viewport 
                                  , scissorCount :: Word32 
@@ -797,16 +797,16 @@ instance Storable PipelineViewportStateCreateInfo where
                 *> poke (ptr `plusPtr` 40) (pScissors (poked :: PipelineViewportStateCreateInfo))
 
 
--- ** VkPipelineTessellationStateCreateFlags
+-- ** PipelineTessellationStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineTessellationStateCreateFlags = VkPipelineTessellationStateCreateFlags VkFlags
+newtype PipelineTessellationStateCreateFlags = PipelineTessellationStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data PipelineVertexInputStateCreateInfo =
-  PipelineVertexInputStateCreateInfo{ sType :: VkStructureType 
+  PipelineVertexInputStateCreateInfo{ sType :: StructureType 
                                     , pNext :: Ptr Void 
-                                    , flags :: VkPipelineVertexInputStateCreateFlags 
+                                    , flags :: PipelineVertexInputStateCreateFlags 
                                     , vertexBindingDescriptionCount :: Word32 
                                     , pVertexBindingDescriptions :: Ptr VertexInputBindingDescription 
                                     , vertexAttributeDescriptionCount :: Word32 
@@ -833,12 +833,12 @@ instance Storable PipelineVertexInputStateCreateInfo where
                 *> poke (ptr `plusPtr` 40) (pVertexAttributeDescriptions (poked :: PipelineVertexInputStateCreateInfo))
 
 
--- ** VkPrimitiveTopology
+-- ** PrimitiveTopology
 
-newtype VkPrimitiveTopology = VkPrimitiveTopology Int32
+newtype PrimitiveTopology = PrimitiveTopology Int32
   deriving (Eq, Storable)
 
-instance Show VkPrimitiveTopology where
+instance Show PrimitiveTopology where
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_POINT_LIST = showString "VK_PRIMITIVE_TOPOLOGY_POINT_LIST"
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_LIST = showString "VK_PRIMITIVE_TOPOLOGY_LINE_LIST"
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_LINE_STRIP = showString "VK_PRIMITIVE_TOPOLOGY_LINE_STRIP"
@@ -850,9 +850,9 @@ instance Show VkPrimitiveTopology where
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY"
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = showString "VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY"
   showsPrec _ VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = showString "VK_PRIMITIVE_TOPOLOGY_PATCH_LIST"
-  showsPrec p (VkPrimitiveTopology x) = showParen (p >= 11) (showString "VkPrimitiveTopology " . showsPrec 11 x)
+  showsPrec p (PrimitiveTopology x) = showParen (p >= 11) (showString "PrimitiveTopology " . showsPrec 11 x)
 
-instance Read VkPrimitiveTopology where
+instance Read PrimitiveTopology where
   readPrec = parens ( choose [ ("VK_PRIMITIVE_TOPOLOGY_POINT_LIST", pure VK_PRIMITIVE_TOPOLOGY_POINT_LIST)
                              , ("VK_PRIMITIVE_TOPOLOGY_LINE_LIST", pure VK_PRIMITIVE_TOPOLOGY_LINE_LIST)
                              , ("VK_PRIMITIVE_TOPOLOGY_LINE_STRIP", pure VK_PRIMITIVE_TOPOLOGY_LINE_STRIP)
@@ -866,41 +866,41 @@ instance Read VkPrimitiveTopology where
                              , ("VK_PRIMITIVE_TOPOLOGY_PATCH_LIST", pure VK_PRIMITIVE_TOPOLOGY_PATCH_LIST)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPrimitiveTopology")
+                        expectP (Ident "PrimitiveTopology")
                         v <- step readPrec
-                        pure (VkPrimitiveTopology v)
+                        pure (PrimitiveTopology v)
                         )
                     )
 
 
-pattern VK_PRIMITIVE_TOPOLOGY_POINT_LIST = VkPrimitiveTopology 0
+pattern VK_PRIMITIVE_TOPOLOGY_POINT_LIST = PrimitiveTopology 0
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST = VkPrimitiveTopology 1
+pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST = PrimitiveTopology 1
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP = VkPrimitiveTopology 2
+pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP = PrimitiveTopology 2
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST = VkPrimitiveTopology 3
+pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST = PrimitiveTopology 3
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP = VkPrimitiveTopology 4
+pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP = PrimitiveTopology 4
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN = VkPrimitiveTopology 5
+pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN = PrimitiveTopology 5
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY = VkPrimitiveTopology 6
+pattern VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY = PrimitiveTopology 6
 
-pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY = VkPrimitiveTopology 7
+pattern VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY = PrimitiveTopology 7
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY = VkPrimitiveTopology 8
+pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST_WITH_ADJACENCY = PrimitiveTopology 8
 
-pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = VkPrimitiveTopology 9
+pattern VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP_WITH_ADJACENCY = PrimitiveTopology 9
 
-pattern VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = VkPrimitiveTopology 10
+pattern VK_PRIMITIVE_TOPOLOGY_PATCH_LIST = PrimitiveTopology 10
 
 
 data PipelineInputAssemblyStateCreateInfo =
-  PipelineInputAssemblyStateCreateInfo{ sType :: VkStructureType 
+  PipelineInputAssemblyStateCreateInfo{ sType :: StructureType 
                                       , pNext :: Ptr Void 
-                                      , flags :: VkPipelineInputAssemblyStateCreateFlags 
-                                      , topology :: VkPrimitiveTopology 
+                                      , flags :: PipelineInputAssemblyStateCreateFlags 
+                                      , topology :: PrimitiveTopology 
                                       , primitiveRestartEnable :: VkBool32 
                                       }
   deriving (Eq)
@@ -922,11 +922,11 @@ instance Storable PipelineInputAssemblyStateCreateInfo where
 
 
 data PipelineColorBlendStateCreateInfo =
-  PipelineColorBlendStateCreateInfo{ sType :: VkStructureType 
+  PipelineColorBlendStateCreateInfo{ sType :: StructureType 
                                    , pNext :: Ptr Void 
-                                   , flags :: VkPipelineColorBlendStateCreateFlags 
+                                   , flags :: PipelineColorBlendStateCreateFlags 
                                    , logicOpEnable :: VkBool32 
-                                   , logicOp :: VkLogicOp 
+                                   , logicOp :: LogicOp 
                                    , attachmentCount :: Word32 
                                    , pAttachments :: Ptr PipelineColorBlendAttachmentState 
                                    , blendConstants :: Vector 4 CFloat 
@@ -956,11 +956,11 @@ instance Storable PipelineColorBlendStateCreateInfo where
 
 
 data PipelineDynamicStateCreateInfo =
-  PipelineDynamicStateCreateInfo{ sType :: VkStructureType 
+  PipelineDynamicStateCreateInfo{ sType :: StructureType 
                                 , pNext :: Ptr Void 
-                                , flags :: VkPipelineDynamicStateCreateFlags 
+                                , flags :: PipelineDynamicStateCreateFlags 
                                 , dynamicStateCount :: Word32 
-                                , pDynamicStates :: Ptr VkDynamicState 
+                                , pDynamicStates :: Ptr DynamicState 
                                 }
   deriving (Eq)
 
@@ -998,43 +998,43 @@ instance Storable SpecializationMapEntry where
                 *> poke (ptr `plusPtr` 8) (size (poked :: SpecializationMapEntry))
 
 
--- ** VkPipelineVertexInputStateCreateFlags
+-- ** PipelineVertexInputStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineVertexInputStateCreateFlags = VkPipelineVertexInputStateCreateFlags VkFlags
+newtype PipelineVertexInputStateCreateFlags = PipelineVertexInputStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
--- ** VkVertexInputRate
+-- ** VertexInputRate
 
-newtype VkVertexInputRate = VkVertexInputRate Int32
+newtype VertexInputRate = VertexInputRate Int32
   deriving (Eq, Storable)
 
-instance Show VkVertexInputRate where
+instance Show VertexInputRate where
   showsPrec _ VK_VERTEX_INPUT_RATE_VERTEX = showString "VK_VERTEX_INPUT_RATE_VERTEX"
   showsPrec _ VK_VERTEX_INPUT_RATE_INSTANCE = showString "VK_VERTEX_INPUT_RATE_INSTANCE"
-  showsPrec p (VkVertexInputRate x) = showParen (p >= 11) (showString "VkVertexInputRate " . showsPrec 11 x)
+  showsPrec p (VertexInputRate x) = showParen (p >= 11) (showString "VertexInputRate " . showsPrec 11 x)
 
-instance Read VkVertexInputRate where
+instance Read VertexInputRate where
   readPrec = parens ( choose [ ("VK_VERTEX_INPUT_RATE_VERTEX", pure VK_VERTEX_INPUT_RATE_VERTEX)
                              , ("VK_VERTEX_INPUT_RATE_INSTANCE", pure VK_VERTEX_INPUT_RATE_INSTANCE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkVertexInputRate")
+                        expectP (Ident "VertexInputRate")
                         v <- step readPrec
-                        pure (VkVertexInputRate v)
+                        pure (VertexInputRate v)
                         )
                     )
 
 
-pattern VK_VERTEX_INPUT_RATE_VERTEX = VkVertexInputRate 0
+pattern VK_VERTEX_INPUT_RATE_VERTEX = VertexInputRate 0
 
-pattern VK_VERTEX_INPUT_RATE_INSTANCE = VkVertexInputRate 1
+pattern VK_VERTEX_INPUT_RATE_INSTANCE = VertexInputRate 1
 
 -- ** VkPipelineStageFlags
 
-newtype VkPipelineStageFlags = VkPipelineStageFlags VkFlags
+newtype PipelineStageFlags = PipelineStageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkPipelineStageFlags where
+instance Show PipelineStageFlags where
   showsPrec _ VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = showString "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT"
   showsPrec _ VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = showString "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT"
   showsPrec _ VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = showString "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT"
@@ -1053,9 +1053,9 @@ instance Show VkPipelineStageFlags where
   showsPrec _ VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = showString "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT"
   showsPrec _ VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = showString "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT"
   
-  showsPrec p (VkPipelineStageFlags x) = showParen (p >= 11) (showString "VkPipelineStageFlags " . showsPrec 11 x)
+  showsPrec p (PipelineStageFlags x) = showParen (p >= 11) (showString "PipelineStageFlags " . showsPrec 11 x)
 
-instance Read VkPipelineStageFlags where
+instance Read PipelineStageFlags where
   readPrec = parens ( choose [ ("VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT", pure VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT)
                              , ("VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT", pure VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT)
                              , ("VK_PIPELINE_STAGE_VERTEX_INPUT_BIT", pure VK_PIPELINE_STAGE_VERTEX_INPUT_BIT)
@@ -1075,58 +1075,58 @@ instance Read VkPipelineStageFlags where
                              , ("VK_PIPELINE_STAGE_ALL_COMMANDS_BIT", pure VK_PIPELINE_STAGE_ALL_COMMANDS_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineStageFlags")
+                        expectP (Ident "PipelineStageFlags")
                         v <- step readPrec
-                        pure (VkPipelineStageFlags v)
+                        pure (PipelineStageFlags v)
                         )
                     )
 
 -- | Before subsequent commands are processed
-pattern VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = VkPipelineStageFlags 0x1
+pattern VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = PipelineStageFlags 0x1
 -- | Draw/DispatchIndirect command fetch
-pattern VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = VkPipelineStageFlags 0x2
+pattern VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = PipelineStageFlags 0x2
 -- | Vertex/index fetch
-pattern VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = VkPipelineStageFlags 0x4
+pattern VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = PipelineStageFlags 0x4
 -- | Vertex shading
-pattern VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = VkPipelineStageFlags 0x8
+pattern VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = PipelineStageFlags 0x8
 -- | Tessellation control shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = VkPipelineStageFlags 0x10
+pattern VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = PipelineStageFlags 0x10
 -- | Tessellation evaluation shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = VkPipelineStageFlags 0x20
+pattern VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = PipelineStageFlags 0x20
 -- | Geometry shading
-pattern VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = VkPipelineStageFlags 0x40
+pattern VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = PipelineStageFlags 0x40
 -- | Fragment shading
-pattern VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = VkPipelineStageFlags 0x80
+pattern VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = PipelineStageFlags 0x80
 -- | Early fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = VkPipelineStageFlags 0x100
+pattern VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = PipelineStageFlags 0x100
 -- | Late fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = VkPipelineStageFlags 0x200
+pattern VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = PipelineStageFlags 0x200
 -- | Color attachment writes
-pattern VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = VkPipelineStageFlags 0x400
+pattern VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = PipelineStageFlags 0x400
 -- | Compute shading
-pattern VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = VkPipelineStageFlags 0x800
+pattern VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = PipelineStageFlags 0x800
 -- | Transfer/copy operations
-pattern VK_PIPELINE_STAGE_TRANSFER_BIT = VkPipelineStageFlags 0x1000
+pattern VK_PIPELINE_STAGE_TRANSFER_BIT = PipelineStageFlags 0x1000
 -- | After previous commands have completed
-pattern VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = VkPipelineStageFlags 0x2000
+pattern VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = PipelineStageFlags 0x2000
 -- | Indicates host (CPU) is a source/sink of the dependency
-pattern VK_PIPELINE_STAGE_HOST_BIT = VkPipelineStageFlags 0x4000
+pattern VK_PIPELINE_STAGE_HOST_BIT = PipelineStageFlags 0x4000
 -- | All stages of the graphics pipeline
-pattern VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = VkPipelineStageFlags 0x8000
+pattern VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = PipelineStageFlags 0x8000
 -- | All stages supported on the queue
-pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = VkPipelineStageFlags 0x10000
+pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = PipelineStageFlags 0x10000
 
 
 
 data PipelineColorBlendAttachmentState =
   PipelineColorBlendAttachmentState{ blendEnable :: VkBool32 
-                                   , srcColorBlendFactor :: VkBlendFactor 
-                                   , dstColorBlendFactor :: VkBlendFactor 
-                                   , colorBlendOp :: VkBlendOp 
-                                   , srcAlphaBlendFactor :: VkBlendFactor 
-                                   , dstAlphaBlendFactor :: VkBlendFactor 
-                                   , alphaBlendOp :: VkBlendOp 
-                                   , colorWriteMask :: VkColorComponentFlags 
+                                   , srcColorBlendFactor :: BlendFactor 
+                                   , dstColorBlendFactor :: BlendFactor 
+                                   , colorBlendOp :: BlendOp 
+                                   , srcAlphaBlendFactor :: BlendFactor 
+                                   , dstAlphaBlendFactor :: BlendFactor 
+                                   , alphaBlendOp :: BlendOp 
+                                   , colorWriteMask :: ColorComponentFlags 
                                    }
   deriving (Eq)
 
@@ -1151,12 +1151,12 @@ instance Storable PipelineColorBlendAttachmentState where
                 *> poke (ptr `plusPtr` 28) (colorWriteMask (poked :: PipelineColorBlendAttachmentState))
 
 
--- ** VkBlendFactor
+-- ** BlendFactor
 
-newtype VkBlendFactor = VkBlendFactor Int32
+newtype BlendFactor = BlendFactor Int32
   deriving (Eq, Storable)
 
-instance Show VkBlendFactor where
+instance Show BlendFactor where
   showsPrec _ VK_BLEND_FACTOR_ZERO = showString "VK_BLEND_FACTOR_ZERO"
   showsPrec _ VK_BLEND_FACTOR_ONE = showString "VK_BLEND_FACTOR_ONE"
   showsPrec _ VK_BLEND_FACTOR_SRC_COLOR = showString "VK_BLEND_FACTOR_SRC_COLOR"
@@ -1176,9 +1176,9 @@ instance Show VkBlendFactor where
   showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR"
   showsPrec _ VK_BLEND_FACTOR_SRC1_ALPHA = showString "VK_BLEND_FACTOR_SRC1_ALPHA"
   showsPrec _ VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = showString "VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA"
-  showsPrec p (VkBlendFactor x) = showParen (p >= 11) (showString "VkBlendFactor " . showsPrec 11 x)
+  showsPrec p (BlendFactor x) = showParen (p >= 11) (showString "BlendFactor " . showsPrec 11 x)
 
-instance Read VkBlendFactor where
+instance Read BlendFactor where
   readPrec = parens ( choose [ ("VK_BLEND_FACTOR_ZERO", pure VK_BLEND_FACTOR_ZERO)
                              , ("VK_BLEND_FACTOR_ONE", pure VK_BLEND_FACTOR_ONE)
                              , ("VK_BLEND_FACTOR_SRC_COLOR", pure VK_BLEND_FACTOR_SRC_COLOR)
@@ -1200,65 +1200,65 @@ instance Read VkBlendFactor where
                              , ("VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA", pure VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBlendFactor")
+                        expectP (Ident "BlendFactor")
                         v <- step readPrec
-                        pure (VkBlendFactor v)
+                        pure (BlendFactor v)
                         )
                     )
 
 
-pattern VK_BLEND_FACTOR_ZERO = VkBlendFactor 0
+pattern VK_BLEND_FACTOR_ZERO = BlendFactor 0
 
-pattern VK_BLEND_FACTOR_ONE = VkBlendFactor 1
+pattern VK_BLEND_FACTOR_ONE = BlendFactor 1
 
-pattern VK_BLEND_FACTOR_SRC_COLOR = VkBlendFactor 2
+pattern VK_BLEND_FACTOR_SRC_COLOR = BlendFactor 2
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR = VkBlendFactor 3
+pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR = BlendFactor 3
 
-pattern VK_BLEND_FACTOR_DST_COLOR = VkBlendFactor 4
+pattern VK_BLEND_FACTOR_DST_COLOR = BlendFactor 4
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR = VkBlendFactor 5
+pattern VK_BLEND_FACTOR_ONE_MINUS_DST_COLOR = BlendFactor 5
 
-pattern VK_BLEND_FACTOR_SRC_ALPHA = VkBlendFactor 6
+pattern VK_BLEND_FACTOR_SRC_ALPHA = BlendFactor 6
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA = VkBlendFactor 7
+pattern VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA = BlendFactor 7
 
-pattern VK_BLEND_FACTOR_DST_ALPHA = VkBlendFactor 8
+pattern VK_BLEND_FACTOR_DST_ALPHA = BlendFactor 8
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA = VkBlendFactor 9
+pattern VK_BLEND_FACTOR_ONE_MINUS_DST_ALPHA = BlendFactor 9
 
-pattern VK_BLEND_FACTOR_CONSTANT_COLOR = VkBlendFactor 10
+pattern VK_BLEND_FACTOR_CONSTANT_COLOR = BlendFactor 10
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR = VkBlendFactor 11
+pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_COLOR = BlendFactor 11
 
-pattern VK_BLEND_FACTOR_CONSTANT_ALPHA = VkBlendFactor 12
+pattern VK_BLEND_FACTOR_CONSTANT_ALPHA = BlendFactor 12
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = VkBlendFactor 13
+pattern VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA = BlendFactor 13
 
-pattern VK_BLEND_FACTOR_SRC_ALPHA_SATURATE = VkBlendFactor 14
+pattern VK_BLEND_FACTOR_SRC_ALPHA_SATURATE = BlendFactor 14
 
-pattern VK_BLEND_FACTOR_SRC1_COLOR = VkBlendFactor 15
+pattern VK_BLEND_FACTOR_SRC1_COLOR = BlendFactor 15
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR = VkBlendFactor 16
+pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_COLOR = BlendFactor 16
 
-pattern VK_BLEND_FACTOR_SRC1_ALPHA = VkBlendFactor 17
+pattern VK_BLEND_FACTOR_SRC1_ALPHA = BlendFactor 17
 
-pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = VkBlendFactor 18
+pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = BlendFactor 18
 
 newtype VkSampleMask = VkSampleMask Word32
   deriving (Eq, Storable)
 
--- ** VkPipelineMultisampleStateCreateFlags
+-- ** PipelineMultisampleStateCreateFlags
 -- | Opaque flag
-newtype VkPipelineMultisampleStateCreateFlags = VkPipelineMultisampleStateCreateFlags VkFlags
+newtype PipelineMultisampleStateCreateFlags = PipelineMultisampleStateCreateFlags VkFlags
   deriving (Eq, Storable)
 
 
 data PipelineMultisampleStateCreateInfo =
-  PipelineMultisampleStateCreateInfo{ sType :: VkStructureType 
+  PipelineMultisampleStateCreateInfo{ sType :: StructureType 
                                     , pNext :: Ptr Void 
-                                    , flags :: VkPipelineMultisampleStateCreateFlags 
-                                    , rasterizationSamples :: VkSampleCountFlags 
+                                    , flags :: PipelineMultisampleStateCreateFlags 
+                                    , rasterizationSamples :: SampleCountFlags 
                                     , sampleShadingEnable :: VkBool32 
                                     , minSampleShading :: CFloat 
                                     , pSampleMask :: Ptr VkSampleMask 
@@ -1294,7 +1294,7 @@ instance Storable PipelineMultisampleStateCreateInfo where
 data VertexInputBindingDescription =
   VertexInputBindingDescription{ binding :: Word32 
                                , stride :: Word32 
-                               , inputRate :: VkVertexInputRate 
+                               , inputRate :: VertexInputRate 
                                }
   deriving (Eq)
 
@@ -1311,12 +1311,12 @@ instance Storable VertexInputBindingDescription where
 
 
 data PipelineDepthStencilStateCreateInfo =
-  PipelineDepthStencilStateCreateInfo{ sType :: VkStructureType 
+  PipelineDepthStencilStateCreateInfo{ sType :: StructureType 
                                      , pNext :: Ptr Void 
-                                     , flags :: VkPipelineDepthStencilStateCreateFlags 
+                                     , flags :: PipelineDepthStencilStateCreateFlags 
                                      , depthTestEnable :: VkBool32 
                                      , depthWriteEnable :: VkBool32 
-                                     , depthCompareOp :: VkCompareOp 
+                                     , depthCompareOp :: CompareOp 
                                      , depthBoundsTestEnable :: VkBool32 
                                      , stencilTestEnable :: VkBool32 
                                      , front :: StencilOpState 
@@ -1361,14 +1361,14 @@ foreign import ccall "vkCreateComputePipelines" vkCreateComputePipelines ::
   PipelineCache ->
     Word32 ->
       Ptr ComputePipelineCreateInfo ->
-        Ptr AllocationCallbacks -> Ptr Pipeline -> IO VkResult
+        Ptr AllocationCallbacks -> Ptr Pipeline -> IO Result
 
 
 data StencilOpState =
-  StencilOpState{ failOp :: VkStencilOp 
-                , passOp :: VkStencilOp 
-                , depthFailOp :: VkStencilOp 
-                , compareOp :: VkCompareOp 
+  StencilOpState{ failOp :: StencilOp 
+                , passOp :: StencilOp 
+                , depthFailOp :: StencilOp 
+                , compareOp :: CompareOp 
                 , compareMask :: Word32 
                 , writeMask :: Word32 
                 , reference :: Word32 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -175,7 +175,7 @@ instance Storable GraphicsPipelineCreateInfo where
                 *> poke (ptr `plusPtr` 136) (basePipelineIndex (poked :: GraphicsPipelineCreateInfo))
 
 
--- ** VkCullModeFlags
+-- ** CullModeFlags
 
 newtype CullModeFlags = CullModeFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -245,7 +245,7 @@ instance Storable PipelineShaderStageCreateInfo where
                 *> poke (ptr `plusPtr` 40) (pSpecializationInfo (poked :: PipelineShaderStageCreateInfo))
 
 
--- ** VkColorComponentFlags
+-- ** ColorComponentFlags
 
 newtype ColorComponentFlags = ColorComponentFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -548,7 +548,7 @@ pattern VK_LOGIC_OP_NAND = LogicOp 14
 
 pattern VK_LOGIC_OP_SET = LogicOp 15
 
--- ** VkPipelineCreateFlags
+-- ** PipelineCreateFlags
 
 newtype PipelineCreateFlags = PipelineCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -1029,7 +1029,7 @@ pattern VK_VERTEX_INPUT_RATE_VERTEX = VertexInputRate 0
 
 pattern VK_VERTEX_INPUT_RATE_INSTANCE = VertexInputRate 1
 
--- ** VkPipelineStageFlags
+-- ** PipelineStageFlags
 
 newtype PipelineStageFlags = PipelineStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -181,17 +181,17 @@ newtype CullModeFlags = CullModeFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CullModeFlags where
-  showsPrec _ VK_CULL_MODE_FRONT_BIT = showString "VK_CULL_MODE_FRONT_BIT"
-  showsPrec _ VK_CULL_MODE_BACK_BIT = showString "VK_CULL_MODE_BACK_BIT"
-  showsPrec _ VK_CULL_MODE_NONE = showString "VK_CULL_MODE_NONE"
-  showsPrec _ VK_CULL_MODE_FRONT_AND_BACK = showString "VK_CULL_MODE_FRONT_AND_BACK"
+  showsPrec _ CullModeFrontBit = showString "CullModeFrontBit"
+  showsPrec _ CullModeBackBit = showString "CullModeBackBit"
+  showsPrec _ CullModeNone = showString "CullModeNone"
+  showsPrec _ CullModeFrontAndBack = showString "CullModeFrontAndBack"
   showsPrec p (CullModeFlags x) = showParen (p >= 11) (showString "CullModeFlags " . showsPrec 11 x)
 
 instance Read CullModeFlags where
-  readPrec = parens ( choose [ ("VK_CULL_MODE_FRONT_BIT", pure VK_CULL_MODE_FRONT_BIT)
-                             , ("VK_CULL_MODE_BACK_BIT", pure VK_CULL_MODE_BACK_BIT)
-                             , ("VK_CULL_MODE_NONE", pure VK_CULL_MODE_NONE)
-                             , ("VK_CULL_MODE_FRONT_AND_BACK", pure VK_CULL_MODE_FRONT_AND_BACK)
+  readPrec = parens ( choose [ ("CullModeFrontBit", pure CullModeFrontBit)
+                             , ("CullModeBackBit", pure CullModeBackBit)
+                             , ("CullModeNone", pure CullModeNone)
+                             , ("CullModeFrontAndBack", pure CullModeFrontAndBack)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CullModeFlags")
@@ -201,13 +201,13 @@ instance Read CullModeFlags where
                     )
 
 
-pattern VK_CULL_MODE_FRONT_BIT = CullModeFlags 0x1
+pattern CullModeFrontBit = CullModeFlags 0x1
 
-pattern VK_CULL_MODE_BACK_BIT = CullModeFlags 0x2
+pattern CullModeBackBit = CullModeFlags 0x2
 
-pattern VK_CULL_MODE_NONE = CullModeFlags 0x0
+pattern CullModeNone = CullModeFlags 0x0
 
-pattern VK_CULL_MODE_FRONT_AND_BACK = CullModeFlags 0x3
+pattern CullModeFrontAndBack = CullModeFlags 0x3
 
 -- ** PipelineDepthStencilStateCreateFlags
 -- | Opaque flag
@@ -251,18 +251,18 @@ newtype ColorComponentFlags = ColorComponentFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ColorComponentFlags where
-  showsPrec _ VK_COLOR_COMPONENT_R_BIT = showString "VK_COLOR_COMPONENT_R_BIT"
-  showsPrec _ VK_COLOR_COMPONENT_G_BIT = showString "VK_COLOR_COMPONENT_G_BIT"
-  showsPrec _ VK_COLOR_COMPONENT_B_BIT = showString "VK_COLOR_COMPONENT_B_BIT"
-  showsPrec _ VK_COLOR_COMPONENT_A_BIT = showString "VK_COLOR_COMPONENT_A_BIT"
+  showsPrec _ ColorComponentRBit = showString "ColorComponentRBit"
+  showsPrec _ ColorComponentGBit = showString "ColorComponentGBit"
+  showsPrec _ ColorComponentBBit = showString "ColorComponentBBit"
+  showsPrec _ ColorComponentABit = showString "ColorComponentABit"
   
   showsPrec p (ColorComponentFlags x) = showParen (p >= 11) (showString "ColorComponentFlags " . showsPrec 11 x)
 
 instance Read ColorComponentFlags where
-  readPrec = parens ( choose [ ("VK_COLOR_COMPONENT_R_BIT", pure VK_COLOR_COMPONENT_R_BIT)
-                             , ("VK_COLOR_COMPONENT_G_BIT", pure VK_COLOR_COMPONENT_G_BIT)
-                             , ("VK_COLOR_COMPONENT_B_BIT", pure VK_COLOR_COMPONENT_B_BIT)
-                             , ("VK_COLOR_COMPONENT_A_BIT", pure VK_COLOR_COMPONENT_A_BIT)
+  readPrec = parens ( choose [ ("ColorComponentRBit", pure ColorComponentRBit)
+                             , ("ColorComponentGBit", pure ColorComponentGBit)
+                             , ("ColorComponentBBit", pure ColorComponentBBit)
+                             , ("ColorComponentABit", pure ColorComponentABit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ColorComponentFlags")
@@ -272,13 +272,13 @@ instance Read ColorComponentFlags where
                     )
 
 
-pattern VK_COLOR_COMPONENT_R_BIT = ColorComponentFlags 0x1
+pattern ColorComponentRBit = ColorComponentFlags 0x1
 
-pattern VK_COLOR_COMPONENT_G_BIT = ColorComponentFlags 0x2
+pattern ColorComponentGBit = ColorComponentFlags 0x2
 
-pattern VK_COLOR_COMPONENT_B_BIT = ColorComponentFlags 0x4
+pattern ColorComponentBBit = ColorComponentFlags 0x4
 
-pattern VK_COLOR_COMPONENT_A_BIT = ColorComponentFlags 0x8
+pattern ColorComponentABit = ColorComponentFlags 0x8
 
 
 
@@ -554,16 +554,16 @@ newtype PipelineCreateFlags = PipelineCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show PipelineCreateFlags where
-  showsPrec _ VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = showString "VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT"
-  showsPrec _ VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = showString "VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT"
-  showsPrec _ VK_PIPELINE_CREATE_DERIVATIVE_BIT = showString "VK_PIPELINE_CREATE_DERIVATIVE_BIT"
+  showsPrec _ PipelineCreateDisableOptimizationBit = showString "PipelineCreateDisableOptimizationBit"
+  showsPrec _ PipelineCreateAllowDerivativesBit = showString "PipelineCreateAllowDerivativesBit"
+  showsPrec _ PipelineCreateDerivativeBit = showString "PipelineCreateDerivativeBit"
   
   showsPrec p (PipelineCreateFlags x) = showParen (p >= 11) (showString "PipelineCreateFlags " . showsPrec 11 x)
 
 instance Read PipelineCreateFlags where
-  readPrec = parens ( choose [ ("VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT", pure VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT)
-                             , ("VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT", pure VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)
-                             , ("VK_PIPELINE_CREATE_DERIVATIVE_BIT", pure VK_PIPELINE_CREATE_DERIVATIVE_BIT)
+  readPrec = parens ( choose [ ("PipelineCreateDisableOptimizationBit", pure PipelineCreateDisableOptimizationBit)
+                             , ("PipelineCreateAllowDerivativesBit", pure PipelineCreateAllowDerivativesBit)
+                             , ("PipelineCreateDerivativeBit", pure PipelineCreateDerivativeBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PipelineCreateFlags")
@@ -573,11 +573,11 @@ instance Read PipelineCreateFlags where
                     )
 
 
-pattern VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = PipelineCreateFlags 0x1
+pattern PipelineCreateDisableOptimizationBit = PipelineCreateFlags 0x1
 
-pattern VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = PipelineCreateFlags 0x2
+pattern PipelineCreateAllowDerivativesBit = PipelineCreateFlags 0x2
 
-pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = PipelineCreateFlags 0x4
+pattern PipelineCreateDerivativeBit = PipelineCreateFlags 0x4
 
 
 -- ** PipelineRasterizationStateCreateFlags
@@ -1035,44 +1035,44 @@ newtype PipelineStageFlags = PipelineStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show PipelineStageFlags where
-  showsPrec _ VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = showString "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = showString "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = showString "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = showString "VK_PIPELINE_STAGE_VERTEX_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = showString "VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = showString "VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = showString "VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = showString "VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = showString "VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = showString "VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = showString "VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = showString "VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_TRANSFER_BIT = showString "VK_PIPELINE_STAGE_TRANSFER_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = showString "VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_HOST_BIT = showString "VK_PIPELINE_STAGE_HOST_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = showString "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT"
-  showsPrec _ VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = showString "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT"
+  showsPrec _ PipelineStageTopOfPipeBit = showString "PipelineStageTopOfPipeBit"
+  showsPrec _ PipelineStageDrawIndirectBit = showString "PipelineStageDrawIndirectBit"
+  showsPrec _ PipelineStageVertexInputBit = showString "PipelineStageVertexInputBit"
+  showsPrec _ PipelineStageVertexShaderBit = showString "PipelineStageVertexShaderBit"
+  showsPrec _ PipelineStageTessellationControlShaderBit = showString "PipelineStageTessellationControlShaderBit"
+  showsPrec _ PipelineStageTessellationEvaluationShaderBit = showString "PipelineStageTessellationEvaluationShaderBit"
+  showsPrec _ PipelineStageGeometryShaderBit = showString "PipelineStageGeometryShaderBit"
+  showsPrec _ PipelineStageFragmentShaderBit = showString "PipelineStageFragmentShaderBit"
+  showsPrec _ PipelineStageEarlyFragmentTestsBit = showString "PipelineStageEarlyFragmentTestsBit"
+  showsPrec _ PipelineStageLateFragmentTestsBit = showString "PipelineStageLateFragmentTestsBit"
+  showsPrec _ PipelineStageColorAttachmentOutputBit = showString "PipelineStageColorAttachmentOutputBit"
+  showsPrec _ PipelineStageComputeShaderBit = showString "PipelineStageComputeShaderBit"
+  showsPrec _ PipelineStageTransferBit = showString "PipelineStageTransferBit"
+  showsPrec _ PipelineStageBottomOfPipeBit = showString "PipelineStageBottomOfPipeBit"
+  showsPrec _ PipelineStageHostBit = showString "PipelineStageHostBit"
+  showsPrec _ PipelineStageAllGraphicsBit = showString "PipelineStageAllGraphicsBit"
+  showsPrec _ PipelineStageAllCommandsBit = showString "PipelineStageAllCommandsBit"
   
   showsPrec p (PipelineStageFlags x) = showParen (p >= 11) (showString "PipelineStageFlags " . showsPrec 11 x)
 
 instance Read PipelineStageFlags where
-  readPrec = parens ( choose [ ("VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT", pure VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT)
-                             , ("VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT", pure VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT)
-                             , ("VK_PIPELINE_STAGE_VERTEX_INPUT_BIT", pure VK_PIPELINE_STAGE_VERTEX_INPUT_BIT)
-                             , ("VK_PIPELINE_STAGE_VERTEX_SHADER_BIT", pure VK_PIPELINE_STAGE_VERTEX_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT", pure VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT", pure VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT", pure VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT", pure VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT", pure VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT)
-                             , ("VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT", pure VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT)
-                             , ("VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT", pure VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT)
-                             , ("VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT", pure VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT)
-                             , ("VK_PIPELINE_STAGE_TRANSFER_BIT", pure VK_PIPELINE_STAGE_TRANSFER_BIT)
-                             , ("VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT", pure VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT)
-                             , ("VK_PIPELINE_STAGE_HOST_BIT", pure VK_PIPELINE_STAGE_HOST_BIT)
-                             , ("VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT", pure VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT)
-                             , ("VK_PIPELINE_STAGE_ALL_COMMANDS_BIT", pure VK_PIPELINE_STAGE_ALL_COMMANDS_BIT)
+  readPrec = parens ( choose [ ("PipelineStageTopOfPipeBit", pure PipelineStageTopOfPipeBit)
+                             , ("PipelineStageDrawIndirectBit", pure PipelineStageDrawIndirectBit)
+                             , ("PipelineStageVertexInputBit", pure PipelineStageVertexInputBit)
+                             , ("PipelineStageVertexShaderBit", pure PipelineStageVertexShaderBit)
+                             , ("PipelineStageTessellationControlShaderBit", pure PipelineStageTessellationControlShaderBit)
+                             , ("PipelineStageTessellationEvaluationShaderBit", pure PipelineStageTessellationEvaluationShaderBit)
+                             , ("PipelineStageGeometryShaderBit", pure PipelineStageGeometryShaderBit)
+                             , ("PipelineStageFragmentShaderBit", pure PipelineStageFragmentShaderBit)
+                             , ("PipelineStageEarlyFragmentTestsBit", pure PipelineStageEarlyFragmentTestsBit)
+                             , ("PipelineStageLateFragmentTestsBit", pure PipelineStageLateFragmentTestsBit)
+                             , ("PipelineStageColorAttachmentOutputBit", pure PipelineStageColorAttachmentOutputBit)
+                             , ("PipelineStageComputeShaderBit", pure PipelineStageComputeShaderBit)
+                             , ("PipelineStageTransferBit", pure PipelineStageTransferBit)
+                             , ("PipelineStageBottomOfPipeBit", pure PipelineStageBottomOfPipeBit)
+                             , ("PipelineStageHostBit", pure PipelineStageHostBit)
+                             , ("PipelineStageAllGraphicsBit", pure PipelineStageAllGraphicsBit)
+                             , ("PipelineStageAllCommandsBit", pure PipelineStageAllCommandsBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "PipelineStageFlags")
@@ -1082,39 +1082,39 @@ instance Read PipelineStageFlags where
                     )
 
 -- | Before subsequent commands are processed
-pattern VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = PipelineStageFlags 0x1
+pattern PipelineStageTopOfPipeBit = PipelineStageFlags 0x1
 -- | Draw/DispatchIndirect command fetch
-pattern VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = PipelineStageFlags 0x2
+pattern PipelineStageDrawIndirectBit = PipelineStageFlags 0x2
 -- | Vertex/index fetch
-pattern VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = PipelineStageFlags 0x4
+pattern PipelineStageVertexInputBit = PipelineStageFlags 0x4
 -- | Vertex shading
-pattern VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = PipelineStageFlags 0x8
+pattern PipelineStageVertexShaderBit = PipelineStageFlags 0x8
 -- | Tessellation control shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = PipelineStageFlags 0x10
+pattern PipelineStageTessellationControlShaderBit = PipelineStageFlags 0x10
 -- | Tessellation evaluation shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = PipelineStageFlags 0x20
+pattern PipelineStageTessellationEvaluationShaderBit = PipelineStageFlags 0x20
 -- | Geometry shading
-pattern VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = PipelineStageFlags 0x40
+pattern PipelineStageGeometryShaderBit = PipelineStageFlags 0x40
 -- | Fragment shading
-pattern VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = PipelineStageFlags 0x80
+pattern PipelineStageFragmentShaderBit = PipelineStageFlags 0x80
 -- | Early fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = PipelineStageFlags 0x100
+pattern PipelineStageEarlyFragmentTestsBit = PipelineStageFlags 0x100
 -- | Late fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = PipelineStageFlags 0x200
+pattern PipelineStageLateFragmentTestsBit = PipelineStageFlags 0x200
 -- | Color attachment writes
-pattern VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = PipelineStageFlags 0x400
+pattern PipelineStageColorAttachmentOutputBit = PipelineStageFlags 0x400
 -- | Compute shading
-pattern VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = PipelineStageFlags 0x800
+pattern PipelineStageComputeShaderBit = PipelineStageFlags 0x800
 -- | Transfer/copy operations
-pattern VK_PIPELINE_STAGE_TRANSFER_BIT = PipelineStageFlags 0x1000
+pattern PipelineStageTransferBit = PipelineStageFlags 0x1000
 -- | After previous commands have completed
-pattern VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = PipelineStageFlags 0x2000
+pattern PipelineStageBottomOfPipeBit = PipelineStageFlags 0x2000
 -- | Indicates host (CPU) is a source/sink of the dependency
-pattern VK_PIPELINE_STAGE_HOST_BIT = PipelineStageFlags 0x4000
+pattern PipelineStageHostBit = PipelineStageFlags 0x4000
 -- | All stages of the graphics pipeline
-pattern VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = PipelineStageFlags 0x8000
+pattern PipelineStageAllGraphicsBit = PipelineStageFlags 0x8000
 -- | All stages supported on the queue
-pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = PipelineStageFlags 0x10000
+pattern PipelineStageAllCommandsBit = PipelineStageFlags 0x10000
 
 
 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -5,80 +5,38 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Pipeline where
 
-import Data.Vector.Storable.Sized( Vector
+import Data.Vector.Storable.Sized( Vector(..)
                                  )
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import {-# SOURCE #-} Graphics.Vulkan.Pass( RenderPass
+import {-# SOURCE #-} Graphics.Vulkan.Pass( RenderPass(..)
                                           )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Graphics.Vulkan.Pipeline( VkVertexInputBindingDescription
-                               , VkColorComponentFlags
-                               , VkPolygonMode
-                               , VkPipelineTessellationStateCreateFlags
-                               , VkPipelineInputAssemblyStateCreateInfo
-                               , VkPipelineDepthStencilStateCreateInfo
-                               , VkPrimitiveTopology
-                               , VkPipelineShaderStageCreateFlags
-                               , VkPipelineCreateFlags
-                               , VkSampleMask
-                               , VkPipelineMultisampleStateCreateFlags
-                               , VkPipelineShaderStageCreateInfo
-                               , VkSpecializationMapEntry
-                               , VkPipelineVertexInputStateCreateFlags
-                               , VkPipelineInputAssemblyStateCreateFlags
-                               , VkPipelineRasterizationStateCreateInfo
-                               , VkDynamicState
-                               , VkPipelineColorBlendStateCreateFlags
-                               , VkPipelineDynamicStateCreateFlags
-                               , VkPipelineColorBlendStateCreateInfo
-                               , VkPipelineMultisampleStateCreateInfo
-                               , VkPipelineViewportStateCreateFlags
-                               , VkPipelineColorBlendAttachmentState
-                               , VkFrontFace
-                               , VkCullModeFlags
-                               , VkPipelineDepthStencilStateCreateFlags
-                               , VkVertexInputAttributeDescription
-                               , VkPipelineRasterizationStateCreateFlags
-                               , VkStencilOpState
-                               , VkPipelineVertexInputStateCreateInfo
-                               , VkSpecializationInfo
-                               , VkLogicOp
-                               , VkStencilOp
-                               , VkComputePipelineCreateInfo
-                               , VkPipelineViewportStateCreateInfo
-                               , VkPipelineTessellationStateCreateInfo
-                               , VkVertexInputRate
-                               , VkBlendFactor
-                               , VkGraphicsPipelineCreateInfo
-                               , VkBlendOp
-                               , VkPipelineDynamicStateCreateInfo
-                               , Pipeline
-                               )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.PipelineCache( PipelineCache
+import Graphics.Vulkan.PipelineCache( PipelineCache(..)
                                     )
-import Data.Int( Int32
+import Data.Int( Int32(..)
+               , Int32
                )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.PipelineLayout( PipelineLayout
+import Graphics.Vulkan.PipelineLayout( PipelineLayout(..)
                                      )
 import Text.Read( Read(..)
                 , parens
@@ -87,23 +45,23 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( ShaderModule
-                             , VkShaderStageFlagBits
+import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
+                             , ShaderModule(..)
                              )
-import Graphics.Vulkan.Sampler( VkCompareOp
-                              , VkSampleCountFlagBits
+import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
+                              , VkCompareOp(..)
                               )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkFormat
-                           , VkViewport
-                           , VkRect2D
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkRect2D(..)
+                           , VkBool32(..)
+                           , VkViewport(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CSize
-                      , CFloat
-                      , CChar
+import Foreign.C.Types( CFloat(..)
+                      , CChar(..)
+                      , CSize(..)
                       )
 
 
@@ -219,40 +177,37 @@ instance Storable VkGraphicsPipelineCreateInfo where
 
 -- ** VkCullModeFlags
 
-newtype VkCullModeFlagBits = VkCullModeFlagBits VkFlags
+newtype VkCullModeFlags = VkCullModeFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkCullModeFlagBits
-type VkCullModeFlags = VkCullModeFlagBits
-
-instance Show VkCullModeFlagBits where
+instance Show VkCullModeFlags where
   showsPrec _ VK_CULL_MODE_FRONT_BIT = showString "VK_CULL_MODE_FRONT_BIT"
   showsPrec _ VK_CULL_MODE_BACK_BIT = showString "VK_CULL_MODE_BACK_BIT"
   showsPrec _ VK_CULL_MODE_NONE = showString "VK_CULL_MODE_NONE"
   showsPrec _ VK_CULL_MODE_FRONT_AND_BACK = showString "VK_CULL_MODE_FRONT_AND_BACK"
-  showsPrec p (VkCullModeFlagBits x) = showParen (p >= 11) (showString "VkCullModeFlagBits " . showsPrec 11 x)
+  showsPrec p (VkCullModeFlags x) = showParen (p >= 11) (showString "VkCullModeFlags " . showsPrec 11 x)
 
-instance Read VkCullModeFlagBits where
+instance Read VkCullModeFlags where
   readPrec = parens ( choose [ ("VK_CULL_MODE_FRONT_BIT", pure VK_CULL_MODE_FRONT_BIT)
                              , ("VK_CULL_MODE_BACK_BIT", pure VK_CULL_MODE_BACK_BIT)
                              , ("VK_CULL_MODE_NONE", pure VK_CULL_MODE_NONE)
                              , ("VK_CULL_MODE_FRONT_AND_BACK", pure VK_CULL_MODE_FRONT_AND_BACK)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCullModeFlagBits")
+                        expectP (Ident "VkCullModeFlags")
                         v <- step readPrec
-                        pure (VkCullModeFlagBits v)
+                        pure (VkCullModeFlags v)
                         )
                     )
 
 
-pattern VK_CULL_MODE_FRONT_BIT = VkCullModeFlagBits 0x1
+pattern VK_CULL_MODE_FRONT_BIT = VkCullModeFlags 0x1
 
-pattern VK_CULL_MODE_BACK_BIT = VkCullModeFlagBits 0x2
+pattern VK_CULL_MODE_BACK_BIT = VkCullModeFlags 0x2
 
-pattern VK_CULL_MODE_NONE = VkCullModeFlagBits 0x0
+pattern VK_CULL_MODE_NONE = VkCullModeFlags 0x0
 
-pattern VK_CULL_MODE_FRONT_AND_BACK = VkCullModeFlagBits 0x3
+pattern VK_CULL_MODE_FRONT_AND_BACK = VkCullModeFlags 0x3
 
 -- ** VkPipelineDepthStencilStateCreateFlags
 -- | Opaque flag
@@ -264,7 +219,7 @@ data VkPipelineShaderStageCreateInfo =
   VkPipelineShaderStageCreateInfo{ sType :: VkStructureType 
                                  , pNext :: Ptr Void 
                                  , flags :: VkPipelineShaderStageCreateFlags 
-                                 , stage :: VkShaderStageFlagBits 
+                                 , stage :: VkShaderStageFlags 
                                  , _module :: ShaderModule 
                                  , pName :: Ptr CChar 
                                  , pSpecializationInfo :: Ptr VkSpecializationInfo 
@@ -292,41 +247,38 @@ instance Storable VkPipelineShaderStageCreateInfo where
 
 -- ** VkColorComponentFlags
 
-newtype VkColorComponentFlagBits = VkColorComponentFlagBits VkFlags
+newtype VkColorComponentFlags = VkColorComponentFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkColorComponentFlagBits
-type VkColorComponentFlags = VkColorComponentFlagBits
-
-instance Show VkColorComponentFlagBits where
+instance Show VkColorComponentFlags where
   showsPrec _ VK_COLOR_COMPONENT_R_BIT = showString "VK_COLOR_COMPONENT_R_BIT"
   showsPrec _ VK_COLOR_COMPONENT_G_BIT = showString "VK_COLOR_COMPONENT_G_BIT"
   showsPrec _ VK_COLOR_COMPONENT_B_BIT = showString "VK_COLOR_COMPONENT_B_BIT"
   showsPrec _ VK_COLOR_COMPONENT_A_BIT = showString "VK_COLOR_COMPONENT_A_BIT"
   
-  showsPrec p (VkColorComponentFlagBits x) = showParen (p >= 11) (showString "VkColorComponentFlagBits " . showsPrec 11 x)
+  showsPrec p (VkColorComponentFlags x) = showParen (p >= 11) (showString "VkColorComponentFlags " . showsPrec 11 x)
 
-instance Read VkColorComponentFlagBits where
+instance Read VkColorComponentFlags where
   readPrec = parens ( choose [ ("VK_COLOR_COMPONENT_R_BIT", pure VK_COLOR_COMPONENT_R_BIT)
                              , ("VK_COLOR_COMPONENT_G_BIT", pure VK_COLOR_COMPONENT_G_BIT)
                              , ("VK_COLOR_COMPONENT_B_BIT", pure VK_COLOR_COMPONENT_B_BIT)
                              , ("VK_COLOR_COMPONENT_A_BIT", pure VK_COLOR_COMPONENT_A_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkColorComponentFlagBits")
+                        expectP (Ident "VkColorComponentFlags")
                         v <- step readPrec
-                        pure (VkColorComponentFlagBits v)
+                        pure (VkColorComponentFlags v)
                         )
                     )
 
 
-pattern VK_COLOR_COMPONENT_R_BIT = VkColorComponentFlagBits 0x1
+pattern VK_COLOR_COMPONENT_R_BIT = VkColorComponentFlags 0x1
 
-pattern VK_COLOR_COMPONENT_G_BIT = VkColorComponentFlagBits 0x2
+pattern VK_COLOR_COMPONENT_G_BIT = VkColorComponentFlags 0x2
 
-pattern VK_COLOR_COMPONENT_B_BIT = VkColorComponentFlagBits 0x4
+pattern VK_COLOR_COMPONENT_B_BIT = VkColorComponentFlags 0x4
 
-pattern VK_COLOR_COMPONENT_A_BIT = VkColorComponentFlagBits 0x8
+pattern VK_COLOR_COMPONENT_A_BIT = VkColorComponentFlags 0x8
 
 
 
@@ -598,37 +550,34 @@ pattern VK_LOGIC_OP_SET = VkLogicOp 15
 
 -- ** VkPipelineCreateFlags
 
-newtype VkPipelineCreateFlagBits = VkPipelineCreateFlagBits VkFlags
+newtype VkPipelineCreateFlags = VkPipelineCreateFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkPipelineCreateFlagBits
-type VkPipelineCreateFlags = VkPipelineCreateFlagBits
-
-instance Show VkPipelineCreateFlagBits where
+instance Show VkPipelineCreateFlags where
   showsPrec _ VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = showString "VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT"
   showsPrec _ VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = showString "VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT"
   showsPrec _ VK_PIPELINE_CREATE_DERIVATIVE_BIT = showString "VK_PIPELINE_CREATE_DERIVATIVE_BIT"
   
-  showsPrec p (VkPipelineCreateFlagBits x) = showParen (p >= 11) (showString "VkPipelineCreateFlagBits " . showsPrec 11 x)
+  showsPrec p (VkPipelineCreateFlags x) = showParen (p >= 11) (showString "VkPipelineCreateFlags " . showsPrec 11 x)
 
-instance Read VkPipelineCreateFlagBits where
+instance Read VkPipelineCreateFlags where
   readPrec = parens ( choose [ ("VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT", pure VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT)
                              , ("VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT", pure VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT)
                              , ("VK_PIPELINE_CREATE_DERIVATIVE_BIT", pure VK_PIPELINE_CREATE_DERIVATIVE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineCreateFlagBits")
+                        expectP (Ident "VkPipelineCreateFlags")
                         v <- step readPrec
-                        pure (VkPipelineCreateFlagBits v)
+                        pure (VkPipelineCreateFlags v)
                         )
                     )
 
 
-pattern VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = VkPipelineCreateFlagBits 0x1
+pattern VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT = VkPipelineCreateFlags 0x1
 
-pattern VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = VkPipelineCreateFlagBits 0x2
+pattern VK_PIPELINE_CREATE_ALLOW_DERIVATIVES_BIT = VkPipelineCreateFlags 0x2
 
-pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = VkPipelineCreateFlagBits 0x4
+pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = VkPipelineCreateFlags 0x4
 
 
 -- ** VkPipelineRasterizationStateCreateFlags
@@ -1082,13 +1031,10 @@ pattern VK_VERTEX_INPUT_RATE_INSTANCE = VkVertexInputRate 1
 
 -- ** VkPipelineStageFlags
 
-newtype VkPipelineStageFlagBits = VkPipelineStageFlagBits VkFlags
+newtype VkPipelineStageFlags = VkPipelineStageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkPipelineStageFlagBits
-type VkPipelineStageFlags = VkPipelineStageFlagBits
-
-instance Show VkPipelineStageFlagBits where
+instance Show VkPipelineStageFlags where
   showsPrec _ VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = showString "VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT"
   showsPrec _ VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = showString "VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT"
   showsPrec _ VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = showString "VK_PIPELINE_STAGE_VERTEX_INPUT_BIT"
@@ -1107,9 +1053,9 @@ instance Show VkPipelineStageFlagBits where
   showsPrec _ VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = showString "VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT"
   showsPrec _ VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = showString "VK_PIPELINE_STAGE_ALL_COMMANDS_BIT"
   
-  showsPrec p (VkPipelineStageFlagBits x) = showParen (p >= 11) (showString "VkPipelineStageFlagBits " . showsPrec 11 x)
+  showsPrec p (VkPipelineStageFlags x) = showParen (p >= 11) (showString "VkPipelineStageFlags " . showsPrec 11 x)
 
-instance Read VkPipelineStageFlagBits where
+instance Read VkPipelineStageFlags where
   readPrec = parens ( choose [ ("VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT", pure VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT)
                              , ("VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT", pure VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT)
                              , ("VK_PIPELINE_STAGE_VERTEX_INPUT_BIT", pure VK_PIPELINE_STAGE_VERTEX_INPUT_BIT)
@@ -1129,46 +1075,46 @@ instance Read VkPipelineStageFlagBits where
                              , ("VK_PIPELINE_STAGE_ALL_COMMANDS_BIT", pure VK_PIPELINE_STAGE_ALL_COMMANDS_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkPipelineStageFlagBits")
+                        expectP (Ident "VkPipelineStageFlags")
                         v <- step readPrec
-                        pure (VkPipelineStageFlagBits v)
+                        pure (VkPipelineStageFlags v)
                         )
                     )
 
 -- | Before subsequent commands are processed
-pattern VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = VkPipelineStageFlagBits 0x1
+pattern VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT = VkPipelineStageFlags 0x1
 -- | Draw/DispatchIndirect command fetch
-pattern VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = VkPipelineStageFlagBits 0x2
+pattern VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT = VkPipelineStageFlags 0x2
 -- | Vertex/index fetch
-pattern VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = VkPipelineStageFlagBits 0x4
+pattern VK_PIPELINE_STAGE_VERTEX_INPUT_BIT = VkPipelineStageFlags 0x4
 -- | Vertex shading
-pattern VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = VkPipelineStageFlagBits 0x8
+pattern VK_PIPELINE_STAGE_VERTEX_SHADER_BIT = VkPipelineStageFlags 0x8
 -- | Tessellation control shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = VkPipelineStageFlagBits 0x10
+pattern VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT = VkPipelineStageFlags 0x10
 -- | Tessellation evaluation shading
-pattern VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = VkPipelineStageFlagBits 0x20
+pattern VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT = VkPipelineStageFlags 0x20
 -- | Geometry shading
-pattern VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = VkPipelineStageFlagBits 0x40
+pattern VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT = VkPipelineStageFlags 0x40
 -- | Fragment shading
-pattern VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = VkPipelineStageFlagBits 0x80
+pattern VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT = VkPipelineStageFlags 0x80
 -- | Early fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = VkPipelineStageFlagBits 0x100
+pattern VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT = VkPipelineStageFlags 0x100
 -- | Late fragment (depth and stencil) tests
-pattern VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = VkPipelineStageFlagBits 0x200
+pattern VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT = VkPipelineStageFlags 0x200
 -- | Color attachment writes
-pattern VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = VkPipelineStageFlagBits 0x400
+pattern VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT = VkPipelineStageFlags 0x400
 -- | Compute shading
-pattern VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = VkPipelineStageFlagBits 0x800
+pattern VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT = VkPipelineStageFlags 0x800
 -- | Transfer/copy operations
-pattern VK_PIPELINE_STAGE_TRANSFER_BIT = VkPipelineStageFlagBits 0x1000
+pattern VK_PIPELINE_STAGE_TRANSFER_BIT = VkPipelineStageFlags 0x1000
 -- | After previous commands have completed
-pattern VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = VkPipelineStageFlagBits 0x2000
+pattern VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT = VkPipelineStageFlags 0x2000
 -- | Indicates host (CPU) is a source/sink of the dependency
-pattern VK_PIPELINE_STAGE_HOST_BIT = VkPipelineStageFlagBits 0x4000
+pattern VK_PIPELINE_STAGE_HOST_BIT = VkPipelineStageFlags 0x4000
 -- | All stages of the graphics pipeline
-pattern VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = VkPipelineStageFlagBits 0x8000
+pattern VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT = VkPipelineStageFlags 0x8000
 -- | All stages supported on the queue
-pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = VkPipelineStageFlagBits 0x10000
+pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = VkPipelineStageFlags 0x10000
 
 
 
@@ -1312,7 +1258,7 @@ data VkPipelineMultisampleStateCreateInfo =
   VkPipelineMultisampleStateCreateInfo{ sType :: VkStructureType 
                                       , pNext :: Ptr Void 
                                       , flags :: VkPipelineMultisampleStateCreateFlags 
-                                      , rasterizationSamples :: VkSampleCountFlagBits 
+                                      , rasterizationSamples :: VkSampleCountFlags 
                                       , sampleShadingEnable :: VkBool32 
                                       , minSampleShading :: CFloat 
                                       , pSampleMask :: Ptr VkSampleMask 

--- a/src/Graphics/Vulkan/Pipeline.hs
+++ b/src/Graphics/Vulkan/Pipeline.hs
@@ -51,13 +51,13 @@ import Graphics.Vulkan.Shader( ShaderStageFlags(..)
 import Graphics.Vulkan.Sampler( CompareOp(..)
                               , SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
                            , Viewport(..)
-                           , VkBool32(..)
                            , Rect2D(..)
                            , Format(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       , CChar(..)
@@ -177,7 +177,7 @@ instance Storable GraphicsPipelineCreateInfo where
 
 -- ** VkCullModeFlags
 
-newtype CullModeFlags = CullModeFlags VkFlags
+newtype CullModeFlags = CullModeFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show CullModeFlags where
@@ -211,7 +211,7 @@ pattern VK_CULL_MODE_FRONT_AND_BACK = CullModeFlags 0x3
 
 -- ** PipelineDepthStencilStateCreateFlags
 -- | Opaque flag
-newtype PipelineDepthStencilStateCreateFlags = PipelineDepthStencilStateCreateFlags VkFlags
+newtype PipelineDepthStencilStateCreateFlags = PipelineDepthStencilStateCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -247,7 +247,7 @@ instance Storable PipelineShaderStageCreateInfo where
 
 -- ** VkColorComponentFlags
 
-newtype ColorComponentFlags = ColorComponentFlags VkFlags
+newtype ColorComponentFlags = ColorComponentFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ColorComponentFlags where
@@ -386,7 +386,7 @@ instance Storable SpecializationInfo where
 
 -- ** PipelineColorBlendStateCreateFlags
 -- | Opaque flag
-newtype PipelineColorBlendStateCreateFlags = PipelineColorBlendStateCreateFlags VkFlags
+newtype PipelineColorBlendStateCreateFlags = PipelineColorBlendStateCreateFlags Flags
   deriving (Eq, Storable)
 
 newtype Pipeline = Pipeline Word64
@@ -394,7 +394,7 @@ newtype Pipeline = Pipeline Word64
 
 -- ** PipelineInputAssemblyStateCreateFlags
 -- | Opaque flag
-newtype PipelineInputAssemblyStateCreateFlags = PipelineInputAssemblyStateCreateFlags VkFlags
+newtype PipelineInputAssemblyStateCreateFlags = PipelineInputAssemblyStateCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkCreateGraphicsPipelines
@@ -463,7 +463,7 @@ pattern VK_POLYGON_MODE_POINT = PolygonMode 2
 
 -- ** PipelineViewportStateCreateFlags
 -- | Opaque flag
-newtype PipelineViewportStateCreateFlags = PipelineViewportStateCreateFlags VkFlags
+newtype PipelineViewportStateCreateFlags = PipelineViewportStateCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** LogicOp
@@ -550,7 +550,7 @@ pattern VK_LOGIC_OP_SET = LogicOp 15
 
 -- ** VkPipelineCreateFlags
 
-newtype PipelineCreateFlags = PipelineCreateFlags VkFlags
+newtype PipelineCreateFlags = PipelineCreateFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show PipelineCreateFlags where
@@ -582,7 +582,7 @@ pattern VK_PIPELINE_CREATE_DERIVATIVE_BIT = PipelineCreateFlags 0x4
 
 -- ** PipelineRasterizationStateCreateFlags
 -- | Opaque flag
-newtype PipelineRasterizationStateCreateFlags = PipelineRasterizationStateCreateFlags VkFlags
+newtype PipelineRasterizationStateCreateFlags = PipelineRasterizationStateCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** DynamicState
@@ -667,7 +667,7 @@ pattern VK_PIPELINE_BIND_POINT_COMPUTE = PipelineBindPoint 1
 
 -- ** PipelineDynamicStateCreateFlags
 -- | Opaque flag
-newtype PipelineDynamicStateCreateFlags = PipelineDynamicStateCreateFlags VkFlags
+newtype PipelineDynamicStateCreateFlags = PipelineDynamicStateCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -675,12 +675,12 @@ data PipelineRasterizationStateCreateInfo =
   PipelineRasterizationStateCreateInfo{ sType :: StructureType 
                                       , pNext :: Ptr Void 
                                       , flags :: PipelineRasterizationStateCreateFlags 
-                                      , depthClampEnable :: VkBool32 
-                                      , rasterizerDiscardEnable :: VkBool32 
+                                      , depthClampEnable :: Bool32 
+                                      , rasterizerDiscardEnable :: Bool32 
                                       , polygonMode :: PolygonMode 
                                       , cullMode :: CullModeFlags 
                                       , frontFace :: FrontFace 
-                                      , depthBiasEnable :: VkBool32 
+                                      , depthBiasEnable :: Bool32 
                                       , depthBiasConstantFactor :: CFloat 
                                       , depthBiasClamp :: CFloat 
                                       , depthBiasSlopeFactor :: CFloat 
@@ -763,7 +763,7 @@ foreign import ccall "vkDestroyPipeline" vkDestroyPipeline ::
 
 -- ** PipelineShaderStageCreateFlags
 -- | Opaque flag
-newtype PipelineShaderStageCreateFlags = PipelineShaderStageCreateFlags VkFlags
+newtype PipelineShaderStageCreateFlags = PipelineShaderStageCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -799,7 +799,7 @@ instance Storable PipelineViewportStateCreateInfo where
 
 -- ** PipelineTessellationStateCreateFlags
 -- | Opaque flag
-newtype PipelineTessellationStateCreateFlags = PipelineTessellationStateCreateFlags VkFlags
+newtype PipelineTessellationStateCreateFlags = PipelineTessellationStateCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -901,7 +901,7 @@ data PipelineInputAssemblyStateCreateInfo =
                                       , pNext :: Ptr Void 
                                       , flags :: PipelineInputAssemblyStateCreateFlags 
                                       , topology :: PrimitiveTopology 
-                                      , primitiveRestartEnable :: VkBool32 
+                                      , primitiveRestartEnable :: Bool32 
                                       }
   deriving (Eq)
 
@@ -925,7 +925,7 @@ data PipelineColorBlendStateCreateInfo =
   PipelineColorBlendStateCreateInfo{ sType :: StructureType 
                                    , pNext :: Ptr Void 
                                    , flags :: PipelineColorBlendStateCreateFlags 
-                                   , logicOpEnable :: VkBool32 
+                                   , logicOpEnable :: Bool32 
                                    , logicOp :: LogicOp 
                                    , attachmentCount :: Word32 
                                    , pAttachments :: Ptr PipelineColorBlendAttachmentState 
@@ -1000,7 +1000,7 @@ instance Storable SpecializationMapEntry where
 
 -- ** PipelineVertexInputStateCreateFlags
 -- | Opaque flag
-newtype PipelineVertexInputStateCreateFlags = PipelineVertexInputStateCreateFlags VkFlags
+newtype PipelineVertexInputStateCreateFlags = PipelineVertexInputStateCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** VertexInputRate
@@ -1031,7 +1031,7 @@ pattern VK_VERTEX_INPUT_RATE_INSTANCE = VertexInputRate 1
 
 -- ** VkPipelineStageFlags
 
-newtype PipelineStageFlags = PipelineStageFlags VkFlags
+newtype PipelineStageFlags = PipelineStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show PipelineStageFlags where
@@ -1119,7 +1119,7 @@ pattern VK_PIPELINE_STAGE_ALL_COMMANDS_BIT = PipelineStageFlags 0x10000
 
 
 data PipelineColorBlendAttachmentState =
-  PipelineColorBlendAttachmentState{ blendEnable :: VkBool32 
+  PipelineColorBlendAttachmentState{ blendEnable :: Bool32 
                                    , srcColorBlendFactor :: BlendFactor 
                                    , dstColorBlendFactor :: BlendFactor 
                                    , colorBlendOp :: BlendOp 
@@ -1245,12 +1245,12 @@ pattern VK_BLEND_FACTOR_SRC1_ALPHA = BlendFactor 17
 
 pattern VK_BLEND_FACTOR_ONE_MINUS_SRC1_ALPHA = BlendFactor 18
 
-newtype VkSampleMask = VkSampleMask Word32
+newtype SampleMask = SampleMask Word32
   deriving (Eq, Storable)
 
 -- ** PipelineMultisampleStateCreateFlags
 -- | Opaque flag
-newtype PipelineMultisampleStateCreateFlags = PipelineMultisampleStateCreateFlags VkFlags
+newtype PipelineMultisampleStateCreateFlags = PipelineMultisampleStateCreateFlags Flags
   deriving (Eq, Storable)
 
 
@@ -1259,11 +1259,11 @@ data PipelineMultisampleStateCreateInfo =
                                     , pNext :: Ptr Void 
                                     , flags :: PipelineMultisampleStateCreateFlags 
                                     , rasterizationSamples :: SampleCountFlags 
-                                    , sampleShadingEnable :: VkBool32 
+                                    , sampleShadingEnable :: Bool32 
                                     , minSampleShading :: CFloat 
-                                    , pSampleMask :: Ptr VkSampleMask 
-                                    , alphaToCoverageEnable :: VkBool32 
-                                    , alphaToOneEnable :: VkBool32 
+                                    , pSampleMask :: Ptr SampleMask 
+                                    , alphaToCoverageEnable :: Bool32 
+                                    , alphaToOneEnable :: Bool32 
                                     }
   deriving (Eq)
 
@@ -1314,11 +1314,11 @@ data PipelineDepthStencilStateCreateInfo =
   PipelineDepthStencilStateCreateInfo{ sType :: StructureType 
                                      , pNext :: Ptr Void 
                                      , flags :: PipelineDepthStencilStateCreateFlags 
-                                     , depthTestEnable :: VkBool32 
-                                     , depthWriteEnable :: VkBool32 
+                                     , depthTestEnable :: Bool32 
+                                     , depthWriteEnable :: Bool32 
                                      , depthCompareOp :: CompareOp 
-                                     , depthBoundsTestEnable :: VkBool32 
-                                     , stencilTestEnable :: VkBool32 
+                                     , depthBoundsTestEnable :: Bool32 
+                                     , stencilTestEnable :: Bool32 
                                      , front :: StencilOpState 
                                      , back :: StencilOpState 
                                      , minDepthBounds :: CFloat 

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -3,8 +3,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineCache where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Data.Word( Word64
                 , Word32
                 )
@@ -15,21 +13,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
-                      , CSize(..)
                       )
 
 -- ** vkCreatePipelineCache

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineCache where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -34,24 +34,24 @@ import Foreign.C.Types( CSize
 
 -- ** vkCreatePipelineCache
 foreign import ccall "vkCreatePipelineCache" vkCreatePipelineCache ::
-  VkDevice ->
+  Device ->
   Ptr VkPipelineCacheCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkPipelineCache -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr PipelineCache -> IO VkResult
 
 -- ** vkGetPipelineCacheData
 foreign import ccall "vkGetPipelineCacheData" vkGetPipelineCacheData ::
-  VkDevice -> VkPipelineCache -> Ptr CSize -> Ptr Void -> IO VkResult
+  Device -> PipelineCache -> Ptr CSize -> Ptr Void -> IO VkResult
 
-newtype VkPipelineCache = VkPipelineCache Word64
+newtype PipelineCache = PipelineCache Word64
   deriving (Eq, Storable)
 
 
 data VkPipelineCacheCreateInfo =
-  VkPipelineCacheCreateInfo{ vkSType :: VkStructureType 
-                           , vkPNext :: Ptr Void 
-                           , vkFlags :: VkPipelineCacheCreateFlags 
-                           , vkInitialDataSize :: CSize 
-                           , vkPInitialData :: Ptr Void 
+  VkPipelineCacheCreateInfo{ sType :: VkStructureType 
+                           , pNext :: Ptr Void 
+                           , flags :: VkPipelineCacheCreateFlags 
+                           , initialDataSize :: CSize 
+                           , pInitialData :: Ptr Void 
                            }
   deriving (Eq)
 
@@ -63,17 +63,17 @@ instance Storable VkPipelineCacheCreateInfo where
                                        <*> peek (ptr `plusPtr` 16)
                                        <*> peek (ptr `plusPtr` 24)
                                        <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkInitialDataSize (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPInitialData (poked :: VkPipelineCacheCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 24) (initialDataSize (poked :: VkPipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pInitialData (poked :: VkPipelineCacheCreateInfo))
 
 
 -- ** vkMergePipelineCaches
 foreign import ccall "vkMergePipelineCaches" vkMergePipelineCaches ::
-  VkDevice ->
-  VkPipelineCache -> Word32 -> Ptr VkPipelineCache -> IO VkResult
+  Device ->
+  PipelineCache -> Word32 -> Ptr PipelineCache -> IO VkResult
 
 -- ** VkPipelineCacheCreateFlags
 -- | Opaque flag
@@ -82,5 +82,5 @@ newtype VkPipelineCacheCreateFlags = VkPipelineCacheCreateFlags VkFlags
 
 -- ** vkDestroyPipelineCache
 foreign import ccall "vkDestroyPipelineCache" vkDestroyPipelineCache ::
-  VkDevice -> VkPipelineCache -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> PipelineCache -> Ptr VkAllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -35,7 +35,7 @@ foreign import ccall "vkGetPipelineCacheData" getPipelineCacheData ::
   Device -> PipelineCache -> Ptr CSize -> Ptr Void -> IO Result
 
 newtype PipelineCache = PipelineCache Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data PipelineCacheCreateInfo =
@@ -45,7 +45,7 @@ data PipelineCacheCreateInfo =
                          , initialDataSize :: CSize 
                          , pInitialData :: Ptr Void 
                          }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineCacheCreateInfo where
   sizeOf ~_ = 40
@@ -69,7 +69,7 @@ foreign import ccall "vkMergePipelineCaches" mergePipelineCaches ::
 -- ** PipelineCacheCreateFlags
 -- | Opaque flag
 newtype PipelineCacheCreateFlags = PipelineCacheCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroyPipelineCache
 foreign import ccall "vkDestroyPipelineCache" destroyPipelineCache ::

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -3,29 +3,25 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineCache where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.PipelineCache( VkPipelineCacheCreateInfo
-                                    , PipelineCache
-                                    , VkPipelineCacheCreateFlags
-                                    )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CSize
+import Foreign.C.Types( CSize(..)
                       )
 
 -- ** vkCreatePipelineCache

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -3,16 +3,28 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineCache where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.PipelineCache( VkPipelineCacheCreateInfo
+                                    , PipelineCache
+                                    , VkPipelineCacheCreateFlags
+                                    )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       )
 

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -15,7 +15,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFlags(..)
@@ -27,8 +27,8 @@ import Foreign.C.Types( CSize(..)
 -- ** vkCreatePipelineCache
 foreign import ccall "vkCreatePipelineCache" vkCreatePipelineCache ::
   Device ->
-  Ptr VkPipelineCacheCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr PipelineCache -> IO VkResult
+  Ptr PipelineCacheCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr PipelineCache -> IO VkResult
 
 -- ** vkGetPipelineCacheData
 foreign import ccall "vkGetPipelineCacheData" vkGetPipelineCacheData ::
@@ -38,28 +38,28 @@ newtype PipelineCache = PipelineCache Word64
   deriving (Eq, Storable)
 
 
-data VkPipelineCacheCreateInfo =
-  VkPipelineCacheCreateInfo{ sType :: VkStructureType 
-                           , pNext :: Ptr Void 
-                           , flags :: VkPipelineCacheCreateFlags 
-                           , initialDataSize :: CSize 
-                           , pInitialData :: Ptr Void 
-                           }
+data PipelineCacheCreateInfo =
+  PipelineCacheCreateInfo{ sType :: VkStructureType 
+                         , pNext :: Ptr Void 
+                         , flags :: VkPipelineCacheCreateFlags 
+                         , initialDataSize :: CSize 
+                         , pInitialData :: Ptr Void 
+                         }
   deriving (Eq)
 
-instance Storable VkPipelineCacheCreateInfo where
+instance Storable PipelineCacheCreateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkPipelineCacheCreateInfo <$> peek (ptr `plusPtr` 0)
-                                       <*> peek (ptr `plusPtr` 8)
-                                       <*> peek (ptr `plusPtr` 16)
-                                       <*> peek (ptr `plusPtr` 24)
-                                       <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 24) (initialDataSize (poked :: VkPipelineCacheCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pInitialData (poked :: VkPipelineCacheCreateInfo))
+  peek ptr = PipelineCacheCreateInfo <$> peek (ptr `plusPtr` 0)
+                                     <*> peek (ptr `plusPtr` 8)
+                                     <*> peek (ptr `plusPtr` 16)
+                                     <*> peek (ptr `plusPtr` 24)
+                                     <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 24) (initialDataSize (poked :: PipelineCacheCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pInitialData (poked :: PipelineCacheCreateInfo))
 
 
 -- ** vkMergePipelineCaches
@@ -74,5 +74,5 @@ newtype VkPipelineCacheCreateFlags = VkPipelineCacheCreateFlags VkFlags
 
 -- ** vkDestroyPipelineCache
 foreign import ccall "vkDestroyPipelineCache" vkDestroyPipelineCache ::
-  Device -> PipelineCache -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> PipelineCache -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -17,9 +17,9 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
@@ -68,7 +68,7 @@ foreign import ccall "vkMergePipelineCaches" vkMergePipelineCaches ::
 
 -- ** PipelineCacheCreateFlags
 -- | Opaque flag
-newtype PipelineCacheCreateFlags = PipelineCacheCreateFlags VkFlags
+newtype PipelineCacheCreateFlags = PipelineCacheCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkDestroyPipelineCache

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -24,14 +24,14 @@ import Graphics.Vulkan.Core( StructureType(..)
 import Foreign.C.Types( CSize(..)
                       )
 
--- ** vkCreatePipelineCache
-foreign import ccall "vkCreatePipelineCache" vkCreatePipelineCache ::
+-- ** createPipelineCache
+foreign import ccall "vkCreatePipelineCache" createPipelineCache ::
   Device ->
   Ptr PipelineCacheCreateInfo ->
     Ptr AllocationCallbacks -> Ptr PipelineCache -> IO Result
 
--- ** vkGetPipelineCacheData
-foreign import ccall "vkGetPipelineCacheData" vkGetPipelineCacheData ::
+-- ** getPipelineCacheData
+foreign import ccall "vkGetPipelineCacheData" getPipelineCacheData ::
   Device -> PipelineCache -> Ptr CSize -> Ptr Void -> IO Result
 
 newtype PipelineCache = PipelineCache Word64
@@ -62,8 +62,8 @@ instance Storable PipelineCacheCreateInfo where
                 *> poke (ptr `plusPtr` 32) (pInitialData (poked :: PipelineCacheCreateInfo))
 
 
--- ** vkMergePipelineCaches
-foreign import ccall "vkMergePipelineCaches" vkMergePipelineCaches ::
+-- ** mergePipelineCaches
+foreign import ccall "vkMergePipelineCaches" mergePipelineCaches ::
   Device -> PipelineCache -> Word32 -> Ptr PipelineCache -> IO Result
 
 -- ** PipelineCacheCreateFlags
@@ -71,7 +71,7 @@ foreign import ccall "vkMergePipelineCaches" vkMergePipelineCaches ::
 newtype PipelineCacheCreateFlags = PipelineCacheCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkDestroyPipelineCache
-foreign import ccall "vkDestroyPipelineCache" vkDestroyPipelineCache ::
+-- ** destroyPipelineCache
+foreign import ccall "vkDestroyPipelineCache" destroyPipelineCache ::
   Device -> PipelineCache -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/PipelineCache.hs
+++ b/src/Graphics/Vulkan/PipelineCache.hs
@@ -17,9 +17,9 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
@@ -28,20 +28,20 @@ import Foreign.C.Types( CSize(..)
 foreign import ccall "vkCreatePipelineCache" vkCreatePipelineCache ::
   Device ->
   Ptr PipelineCacheCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr PipelineCache -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr PipelineCache -> IO Result
 
 -- ** vkGetPipelineCacheData
 foreign import ccall "vkGetPipelineCacheData" vkGetPipelineCacheData ::
-  Device -> PipelineCache -> Ptr CSize -> Ptr Void -> IO VkResult
+  Device -> PipelineCache -> Ptr CSize -> Ptr Void -> IO Result
 
 newtype PipelineCache = PipelineCache Word64
   deriving (Eq, Storable)
 
 
 data PipelineCacheCreateInfo =
-  PipelineCacheCreateInfo{ sType :: VkStructureType 
+  PipelineCacheCreateInfo{ sType :: StructureType 
                          , pNext :: Ptr Void 
-                         , flags :: VkPipelineCacheCreateFlags 
+                         , flags :: PipelineCacheCreateFlags 
                          , initialDataSize :: CSize 
                          , pInitialData :: Ptr Void 
                          }
@@ -64,12 +64,11 @@ instance Storable PipelineCacheCreateInfo where
 
 -- ** vkMergePipelineCaches
 foreign import ccall "vkMergePipelineCaches" vkMergePipelineCaches ::
-  Device ->
-  PipelineCache -> Word32 -> Ptr PipelineCache -> IO VkResult
+  Device -> PipelineCache -> Word32 -> Ptr PipelineCache -> IO Result
 
--- ** VkPipelineCacheCreateFlags
+-- ** PipelineCacheCreateFlags
 -- | Opaque flag
-newtype VkPipelineCacheCreateFlags = VkPipelineCacheCreateFlags VkFlags
+newtype PipelineCacheCreateFlags = PipelineCacheCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkDestroyPipelineCache

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineLayout where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -11,7 +11,7 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( VkDescriptorSetLayout(..)
+import Graphics.Vulkan.DescriptorSet( DescriptorSetLayout(..)
                                     )
 import Foreign.Storable( Storable(..)
                        )
@@ -41,18 +41,18 @@ import Foreign.C.Types( CSize(..)
 newtype VkPipelineLayoutCreateFlags = VkPipelineLayoutCreateFlags VkFlags
   deriving (Eq, Storable)
 
-newtype VkPipelineLayout = VkPipelineLayout Word64
+newtype PipelineLayout = PipelineLayout Word64
   deriving (Eq, Storable)
 
 -- ** vkDestroyPipelineLayout
 foreign import ccall "vkDestroyPipelineLayout" vkDestroyPipelineLayout ::
-  VkDevice -> VkPipelineLayout -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> PipelineLayout -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkPushConstantRange =
-  VkPushConstantRange{ vkStageFlags :: VkShaderStageFlags 
-                     , vkOffset :: Word32 
-                     , vkSize :: Word32 
+  VkPushConstantRange{ stageFlags :: VkShaderStageFlags 
+                     , offset :: Word32 
+                     , size :: Word32 
                      }
   deriving (Eq)
 
@@ -62,20 +62,20 @@ instance Storable VkPushConstantRange where
   peek ptr = VkPushConstantRange <$> peek (ptr `plusPtr` 0)
                                  <*> peek (ptr `plusPtr` 4)
                                  <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkStageFlags (poked :: VkPushConstantRange))
-                *> poke (ptr `plusPtr` 4) (vkOffset (poked :: VkPushConstantRange))
-                *> poke (ptr `plusPtr` 8) (vkSize (poked :: VkPushConstantRange))
+  poke ptr poked = poke (ptr `plusPtr` 0) (stageFlags (poked :: VkPushConstantRange))
+                *> poke (ptr `plusPtr` 4) (offset (poked :: VkPushConstantRange))
+                *> poke (ptr `plusPtr` 8) (size (poked :: VkPushConstantRange))
 
 
 
 data VkPipelineLayoutCreateInfo =
-  VkPipelineLayoutCreateInfo{ vkSType :: VkStructureType 
-                            , vkPNext :: Ptr Void 
-                            , vkFlags :: VkPipelineLayoutCreateFlags 
-                            , vkSetLayoutCount :: Word32 
-                            , vkPSetLayouts :: Ptr VkDescriptorSetLayout 
-                            , vkPushConstantRangeCount :: Word32 
-                            , vkPPushConstantRanges :: Ptr VkPushConstantRange 
+  VkPipelineLayoutCreateInfo{ sType :: VkStructureType 
+                            , pNext :: Ptr Void 
+                            , flags :: VkPipelineLayoutCreateFlags 
+                            , setLayoutCount :: Word32 
+                            , pSetLayouts :: Ptr DescriptorSetLayout 
+                            , pushConstantRangeCount :: Word32 
+                            , pPushConstantRanges :: Ptr VkPushConstantRange 
                             }
   deriving (Eq)
 
@@ -89,18 +89,18 @@ instance Storable VkPipelineLayoutCreateInfo where
                                         <*> peek (ptr `plusPtr` 24)
                                         <*> peek (ptr `plusPtr` 32)
                                         <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkSetLayoutCount (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkPSetLayouts (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPushConstantRangeCount (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkPPushConstantRanges (poked :: VkPipelineLayoutCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 20) (setLayoutCount (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pSetLayouts (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pushConstantRangeCount (poked :: VkPipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pPushConstantRanges (poked :: VkPipelineLayoutCreateInfo))
 
 
 -- ** vkCreatePipelineLayout
 foreign import ccall "vkCreatePipelineLayout" vkCreatePipelineLayout ::
-  VkDevice ->
+  Device ->
   Ptr VkPipelineLayoutCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkPipelineLayout -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr PipelineLayout -> IO VkResult
 

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -3,38 +3,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineLayout where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( DescriptorSetLayout(..)
-                                    )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Shader( VkShaderStageFlagBits(..)
-                             , VkShaderStageFlags(..)
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** VkPipelineLayoutCreateFlags
 -- | Opaque flag

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -21,14 +21,14 @@ import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Shader( ShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 -- ** PipelineLayoutCreateFlags
 -- | Opaque flag
-newtype PipelineLayoutCreateFlags = PipelineLayoutCreateFlags VkFlags
+newtype PipelineLayoutCreateFlags = PipelineLayoutCreateFlags Flags
   deriving (Eq, Storable)
 
 newtype PipelineLayout = PipelineLayout Word64

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -34,8 +34,8 @@ newtype PipelineLayoutCreateFlags = PipelineLayoutCreateFlags Flags
 newtype PipelineLayout = PipelineLayout Word64
   deriving (Eq, Storable)
 
--- ** vkDestroyPipelineLayout
-foreign import ccall "vkDestroyPipelineLayout" vkDestroyPipelineLayout ::
+-- ** destroyPipelineLayout
+foreign import ccall "vkDestroyPipelineLayout" destroyPipelineLayout ::
   Device -> PipelineLayout -> Ptr AllocationCallbacks -> IO ()
 
 
@@ -88,8 +88,8 @@ instance Storable PipelineLayoutCreateInfo where
                 *> poke (ptr `plusPtr` 40) (pPushConstantRanges (poked :: PipelineLayoutCreateInfo))
 
 
--- ** vkCreatePipelineLayout
-foreign import ccall "vkCreatePipelineLayout" vkCreatePipelineLayout ::
+-- ** createPipelineLayout
+foreign import ccall "vkCreatePipelineLayout" createPipelineLayout ::
   Device ->
   Ptr PipelineLayoutCreateInfo ->
     Ptr AllocationCallbacks -> Ptr PipelineLayout -> IO Result

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -17,7 +17,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
                              )
@@ -36,61 +36,61 @@ newtype PipelineLayout = PipelineLayout Word64
 
 -- ** vkDestroyPipelineLayout
 foreign import ccall "vkDestroyPipelineLayout" vkDestroyPipelineLayout ::
-  Device -> PipelineLayout -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> PipelineLayout -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkPushConstantRange =
-  VkPushConstantRange{ stageFlags :: VkShaderStageFlags 
-                     , offset :: Word32 
-                     , size :: Word32 
-                     }
+data PushConstantRange =
+  PushConstantRange{ stageFlags :: VkShaderStageFlags 
+                   , offset :: Word32 
+                   , size :: Word32 
+                   }
   deriving (Eq)
 
-instance Storable VkPushConstantRange where
+instance Storable PushConstantRange where
   sizeOf ~_ = 12
   alignment ~_ = 4
-  peek ptr = VkPushConstantRange <$> peek (ptr `plusPtr` 0)
-                                 <*> peek (ptr `plusPtr` 4)
-                                 <*> peek (ptr `plusPtr` 8)
-  poke ptr poked = poke (ptr `plusPtr` 0) (stageFlags (poked :: VkPushConstantRange))
-                *> poke (ptr `plusPtr` 4) (offset (poked :: VkPushConstantRange))
-                *> poke (ptr `plusPtr` 8) (size (poked :: VkPushConstantRange))
+  peek ptr = PushConstantRange <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 4)
+                               <*> peek (ptr `plusPtr` 8)
+  poke ptr poked = poke (ptr `plusPtr` 0) (stageFlags (poked :: PushConstantRange))
+                *> poke (ptr `plusPtr` 4) (offset (poked :: PushConstantRange))
+                *> poke (ptr `plusPtr` 8) (size (poked :: PushConstantRange))
 
 
 
-data VkPipelineLayoutCreateInfo =
-  VkPipelineLayoutCreateInfo{ sType :: VkStructureType 
-                            , pNext :: Ptr Void 
-                            , flags :: VkPipelineLayoutCreateFlags 
-                            , setLayoutCount :: Word32 
-                            , pSetLayouts :: Ptr DescriptorSetLayout 
-                            , pushConstantRangeCount :: Word32 
-                            , pPushConstantRanges :: Ptr VkPushConstantRange 
-                            }
+data PipelineLayoutCreateInfo =
+  PipelineLayoutCreateInfo{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkPipelineLayoutCreateFlags 
+                          , setLayoutCount :: Word32 
+                          , pSetLayouts :: Ptr DescriptorSetLayout 
+                          , pushConstantRangeCount :: Word32 
+                          , pPushConstantRanges :: Ptr PushConstantRange 
+                          }
   deriving (Eq)
 
-instance Storable VkPipelineLayoutCreateInfo where
+instance Storable PipelineLayoutCreateInfo where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkPipelineLayoutCreateInfo <$> peek (ptr `plusPtr` 0)
-                                        <*> peek (ptr `plusPtr` 8)
-                                        <*> peek (ptr `plusPtr` 16)
-                                        <*> peek (ptr `plusPtr` 20)
-                                        <*> peek (ptr `plusPtr` 24)
-                                        <*> peek (ptr `plusPtr` 32)
-                                        <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 20) (setLayoutCount (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 24) (pSetLayouts (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pushConstantRangeCount (poked :: VkPipelineLayoutCreateInfo))
-                *> poke (ptr `plusPtr` 40) (pPushConstantRanges (poked :: VkPipelineLayoutCreateInfo))
+  peek ptr = PipelineLayoutCreateInfo <$> peek (ptr `plusPtr` 0)
+                                      <*> peek (ptr `plusPtr` 8)
+                                      <*> peek (ptr `plusPtr` 16)
+                                      <*> peek (ptr `plusPtr` 20)
+                                      <*> peek (ptr `plusPtr` 24)
+                                      <*> peek (ptr `plusPtr` 32)
+                                      <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 20) (setLayoutCount (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 24) (pSetLayouts (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pushConstantRangeCount (poked :: PipelineLayoutCreateInfo))
+                *> poke (ptr `plusPtr` 40) (pPushConstantRanges (poked :: PipelineLayoutCreateInfo))
 
 
 -- ** vkCreatePipelineLayout
 foreign import ccall "vkCreatePipelineLayout" vkCreatePipelineLayout ::
   Device ->
-  Ptr VkPipelineLayoutCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr PipelineLayout -> IO VkResult
+  Ptr PipelineLayoutCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr PipelineLayout -> IO VkResult
 

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -29,10 +29,10 @@ import Graphics.Vulkan.Core( StructureType(..)
 -- ** PipelineLayoutCreateFlags
 -- | Opaque flag
 newtype PipelineLayoutCreateFlags = PipelineLayoutCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 newtype PipelineLayout = PipelineLayout Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroyPipelineLayout
 foreign import ccall "vkDestroyPipelineLayout" destroyPipelineLayout ::
@@ -44,7 +44,7 @@ data PushConstantRange =
                    , offset :: Word32 
                    , size :: Word32 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PushConstantRange where
   sizeOf ~_ = 12
@@ -67,7 +67,7 @@ data PipelineLayoutCreateInfo =
                           , pushConstantRangeCount :: Word32 
                           , pPushConstantRanges :: Ptr PushConstantRange 
                           }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable PipelineLayoutCreateInfo where
   sizeOf ~_ = 48

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -3,16 +3,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineLayout where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Data.Word( Word64
                 , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.DescriptorSet( DescriptorSetLayout
+                                    )
 import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.PipelineLayout( VkPipelineLayoutCreateFlags
+                                     , VkPipelineLayoutCreateInfo
+                                     , VkPushConstantRange
+                                     , PipelineLayout
+                                     )
+import Graphics.Vulkan.Shader( VkShaderStageFlags
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 -- ** VkPipelineLayoutCreateFlags
 -- | Opaque flag

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -3,32 +3,27 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.PipelineLayout where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.DescriptorSet( DescriptorSetLayout
+import Graphics.Vulkan.DescriptorSet( DescriptorSetLayout(..)
                                     )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.PipelineLayout( VkPipelineLayoutCreateFlags
-                                     , VkPipelineLayoutCreateInfo
-                                     , VkPushConstantRange
-                                     , PipelineLayout
-                                     )
-import Graphics.Vulkan.Shader( VkShaderStageFlags
+import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
 
 -- ** VkPipelineLayoutCreateFlags

--- a/src/Graphics/Vulkan/PipelineLayout.hs
+++ b/src/Graphics/Vulkan/PipelineLayout.hs
@@ -19,16 +19,16 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Shader( VkShaderStageFlags(..)
+import Graphics.Vulkan.Shader( ShaderStageFlags(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 
--- ** VkPipelineLayoutCreateFlags
+-- ** PipelineLayoutCreateFlags
 -- | Opaque flag
-newtype VkPipelineLayoutCreateFlags = VkPipelineLayoutCreateFlags VkFlags
+newtype PipelineLayoutCreateFlags = PipelineLayoutCreateFlags VkFlags
   deriving (Eq, Storable)
 
 newtype PipelineLayout = PipelineLayout Word64
@@ -40,7 +40,7 @@ foreign import ccall "vkDestroyPipelineLayout" vkDestroyPipelineLayout ::
 
 
 data PushConstantRange =
-  PushConstantRange{ stageFlags :: VkShaderStageFlags 
+  PushConstantRange{ stageFlags :: ShaderStageFlags 
                    , offset :: Word32 
                    , size :: Word32 
                    }
@@ -59,9 +59,9 @@ instance Storable PushConstantRange where
 
 
 data PipelineLayoutCreateInfo =
-  PipelineLayoutCreateInfo{ sType :: VkStructureType 
+  PipelineLayoutCreateInfo{ sType :: StructureType 
                           , pNext :: Ptr Void 
-                          , flags :: VkPipelineLayoutCreateFlags 
+                          , flags :: PipelineLayoutCreateFlags 
                           , setLayoutCount :: Word32 
                           , pSetLayouts :: Ptr DescriptorSetLayout 
                           , pushConstantRangeCount :: Word32 
@@ -92,5 +92,5 @@ instance Storable PipelineLayoutCreateInfo where
 foreign import ccall "vkCreatePipelineLayout" vkCreatePipelineLayout ::
   Device ->
   Ptr PipelineLayoutCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr PipelineLayout -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr PipelineLayout -> IO Result
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Query where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -53,8 +53,8 @@ import Foreign.C.Types( CSize
 
 -- ** vkGetQueryPoolResults
 foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
-  VkDevice ->
-  VkQueryPool ->
+  Device ->
+  QueryPool ->
     Word32 ->
       Word32 ->
         CSize ->
@@ -62,16 +62,16 @@ foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
 
 -- ** vkDestroyQueryPool
 foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
-  VkDevice -> VkQueryPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> QueryPool -> Ptr VkAllocationCallbacks -> IO ()
 
 
 data VkQueryPoolCreateInfo =
-  VkQueryPoolCreateInfo{ vkSType :: VkStructureType 
-                       , vkPNext :: Ptr Void 
-                       , vkFlags :: VkQueryPoolCreateFlags 
-                       , vkQueryType :: VkQueryType 
-                       , vkQueryCount :: Word32 
-                       , vkPipelineStatistics :: VkQueryPipelineStatisticFlags 
+  VkQueryPoolCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkQueryPoolCreateFlags 
+                       , queryType :: VkQueryType 
+                       , queryCount :: Word32 
+                       , pipelineStatistics :: VkQueryPipelineStatisticFlags 
                        }
   deriving (Eq)
 
@@ -84,12 +84,12 @@ instance Storable VkQueryPoolCreateInfo where
                                    <*> peek (ptr `plusPtr` 20)
                                    <*> peek (ptr `plusPtr` 24)
                                    <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkQueryType (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkQueryCount (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkPipelineStatistics (poked :: VkQueryPoolCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkQueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkQueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkQueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queryType (poked :: VkQueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 24) (queryCount (poked :: VkQueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 28) (pipelineStatistics (poked :: VkQueryPoolCreateInfo))
 
 
 -- ** VkQueryResultFlags
@@ -161,14 +161,14 @@ pattern VK_QUERY_TYPE_PIPELINE_STATISTICS = VkQueryType 1
 
 pattern VK_QUERY_TYPE_TIMESTAMP = VkQueryType 2
 
-newtype VkQueryPool = VkQueryPool Word64
+newtype QueryPool = QueryPool Word64
   deriving (Eq, Storable)
 
 -- ** vkCreateQueryPool
 foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
-  VkDevice ->
+  Device ->
   Ptr VkQueryPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkQueryPool -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr QueryPool -> IO VkResult
 
 -- ** VkQueryControlFlags
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Query where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -26,15 +24,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -42,13 +31,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
-                      , CSize(..)
                       )
 
 -- ** vkGetQueryPoolResults

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -43,16 +43,16 @@ import Graphics.Vulkan.Core( StructureType(..)
 import Foreign.C.Types( CSize(..)
                       )
 
--- ** vkGetQueryPoolResults
-foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
+-- ** getQueryPoolResults
+foreign import ccall "vkGetQueryPoolResults" getQueryPoolResults ::
   Device ->
   QueryPool ->
     Word32 ->
       Word32 ->
         CSize -> Ptr Void -> DeviceSize -> QueryResultFlags -> IO Result
 
--- ** vkDestroyQueryPool
-foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
+-- ** destroyQueryPool
+foreign import ccall "vkDestroyQueryPool" destroyQueryPool ::
   Device -> QueryPool -> Ptr AllocationCallbacks -> IO ()
 
 
@@ -152,8 +152,8 @@ pattern VK_QUERY_TYPE_TIMESTAMP = QueryType 2
 newtype QueryPool = QueryPool Word64
   deriving (Eq, Storable)
 
--- ** vkCreateQueryPool
-foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
+-- ** createQueryPool
+foreign import ccall "vkCreateQueryPool" createQueryPool ::
   Device ->
   Ptr QueryPoolCreateInfo ->
     Ptr AllocationCallbacks -> Ptr QueryPool -> IO Result

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -89,18 +89,18 @@ newtype QueryResultFlags = QueryResultFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryResultFlags where
-  showsPrec _ VK_QUERY_RESULT_64_BIT = showString "VK_QUERY_RESULT_64_BIT"
-  showsPrec _ VK_QUERY_RESULT_WAIT_BIT = showString "VK_QUERY_RESULT_WAIT_BIT"
-  showsPrec _ VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = showString "VK_QUERY_RESULT_WITH_AVAILABILITY_BIT"
-  showsPrec _ VK_QUERY_RESULT_PARTIAL_BIT = showString "VK_QUERY_RESULT_PARTIAL_BIT"
+  showsPrec _ QueryResult64Bit = showString "QueryResult64Bit"
+  showsPrec _ QueryResultWaitBit = showString "QueryResultWaitBit"
+  showsPrec _ QueryResultWithAvailabilityBit = showString "QueryResultWithAvailabilityBit"
+  showsPrec _ QueryResultPartialBit = showString "QueryResultPartialBit"
   
   showsPrec p (QueryResultFlags x) = showParen (p >= 11) (showString "QueryResultFlags " . showsPrec 11 x)
 
 instance Read QueryResultFlags where
-  readPrec = parens ( choose [ ("VK_QUERY_RESULT_64_BIT", pure VK_QUERY_RESULT_64_BIT)
-                             , ("VK_QUERY_RESULT_WAIT_BIT", pure VK_QUERY_RESULT_WAIT_BIT)
-                             , ("VK_QUERY_RESULT_WITH_AVAILABILITY_BIT", pure VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)
-                             , ("VK_QUERY_RESULT_PARTIAL_BIT", pure VK_QUERY_RESULT_PARTIAL_BIT)
+  readPrec = parens ( choose [ ("QueryResult64Bit", pure QueryResult64Bit)
+                             , ("QueryResultWaitBit", pure QueryResultWaitBit)
+                             , ("QueryResultWithAvailabilityBit", pure QueryResultWithAvailabilityBit)
+                             , ("QueryResultPartialBit", pure QueryResultPartialBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "QueryResultFlags")
@@ -110,13 +110,13 @@ instance Read QueryResultFlags where
                     )
 
 -- | Results of the queries are written to the destination buffer as 64-bit values
-pattern VK_QUERY_RESULT_64_BIT = QueryResultFlags 0x1
+pattern QueryResult64Bit = QueryResultFlags 0x1
 -- | Results of the queries are waited on before proceeding with the result copy
-pattern VK_QUERY_RESULT_WAIT_BIT = QueryResultFlags 0x2
+pattern QueryResultWaitBit = QueryResultFlags 0x2
 -- | Besides the results of the query, the availability of the results is also written
-pattern VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = QueryResultFlags 0x4
+pattern QueryResultWithAvailabilityBit = QueryResultFlags 0x4
 -- | Copy the partial results of the query even if the final results aren't available
-pattern VK_QUERY_RESULT_PARTIAL_BIT = QueryResultFlags 0x8
+pattern QueryResultPartialBit = QueryResultFlags 0x8
 
 
 -- ** QueryType
@@ -164,12 +164,12 @@ newtype QueryControlFlags = QueryControlFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryControlFlags where
-  showsPrec _ VK_QUERY_CONTROL_PRECISE_BIT = showString "VK_QUERY_CONTROL_PRECISE_BIT"
+  showsPrec _ QueryControlPreciseBit = showString "QueryControlPreciseBit"
   
   showsPrec p (QueryControlFlags x) = showParen (p >= 11) (showString "QueryControlFlags " . showsPrec 11 x)
 
 instance Read QueryControlFlags where
-  readPrec = parens ( choose [ ("VK_QUERY_CONTROL_PRECISE_BIT", pure VK_QUERY_CONTROL_PRECISE_BIT)
+  readPrec = parens ( choose [ ("QueryControlPreciseBit", pure QueryControlPreciseBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "QueryControlFlags")
@@ -179,7 +179,7 @@ instance Read QueryControlFlags where
                     )
 
 -- | Require precise results to be collected by the query
-pattern VK_QUERY_CONTROL_PRECISE_BIT = QueryControlFlags 0x1
+pattern QueryControlPreciseBit = QueryControlFlags 0x1
 
 
 -- ** QueryPoolCreateFlags
@@ -193,32 +193,32 @@ newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryPipelineStatisticFlags where
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT"
-  showsPrec _ VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT"
+  showsPrec _ QueryPipelineStatisticInputAssemblyVerticesBit = showString "QueryPipelineStatisticInputAssemblyVerticesBit"
+  showsPrec _ QueryPipelineStatisticInputAssemblyPrimitivesBit = showString "QueryPipelineStatisticInputAssemblyPrimitivesBit"
+  showsPrec _ QueryPipelineStatisticVertexShaderInvocationsBit = showString "QueryPipelineStatisticVertexShaderInvocationsBit"
+  showsPrec _ QueryPipelineStatisticGeometryShaderInvocationsBit = showString "QueryPipelineStatisticGeometryShaderInvocationsBit"
+  showsPrec _ QueryPipelineStatisticGeometryShaderPrimitivesBit = showString "QueryPipelineStatisticGeometryShaderPrimitivesBit"
+  showsPrec _ QueryPipelineStatisticClippingInvocationsBit = showString "QueryPipelineStatisticClippingInvocationsBit"
+  showsPrec _ QueryPipelineStatisticClippingPrimitivesBit = showString "QueryPipelineStatisticClippingPrimitivesBit"
+  showsPrec _ QueryPipelineStatisticFragmentShaderInvocationsBit = showString "QueryPipelineStatisticFragmentShaderInvocationsBit"
+  showsPrec _ QueryPipelineStatisticTessellationControlShaderPatchesBit = showString "QueryPipelineStatisticTessellationControlShaderPatchesBit"
+  showsPrec _ QueryPipelineStatisticTessellationEvaluationShaderInvocationsBit = showString "QueryPipelineStatisticTessellationEvaluationShaderInvocationsBit"
+  showsPrec _ QueryPipelineStatisticComputeShaderInvocationsBit = showString "QueryPipelineStatisticComputeShaderInvocationsBit"
   
   showsPrec p (QueryPipelineStatisticFlags x) = showParen (p >= 11) (showString "QueryPipelineStatisticFlags " . showsPrec 11 x)
 
 instance Read QueryPipelineStatisticFlags where
-  readPrec = parens ( choose [ ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT)
-                             , ("VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT)
+  readPrec = parens ( choose [ ("QueryPipelineStatisticInputAssemblyVerticesBit", pure QueryPipelineStatisticInputAssemblyVerticesBit)
+                             , ("QueryPipelineStatisticInputAssemblyPrimitivesBit", pure QueryPipelineStatisticInputAssemblyPrimitivesBit)
+                             , ("QueryPipelineStatisticVertexShaderInvocationsBit", pure QueryPipelineStatisticVertexShaderInvocationsBit)
+                             , ("QueryPipelineStatisticGeometryShaderInvocationsBit", pure QueryPipelineStatisticGeometryShaderInvocationsBit)
+                             , ("QueryPipelineStatisticGeometryShaderPrimitivesBit", pure QueryPipelineStatisticGeometryShaderPrimitivesBit)
+                             , ("QueryPipelineStatisticClippingInvocationsBit", pure QueryPipelineStatisticClippingInvocationsBit)
+                             , ("QueryPipelineStatisticClippingPrimitivesBit", pure QueryPipelineStatisticClippingPrimitivesBit)
+                             , ("QueryPipelineStatisticFragmentShaderInvocationsBit", pure QueryPipelineStatisticFragmentShaderInvocationsBit)
+                             , ("QueryPipelineStatisticTessellationControlShaderPatchesBit", pure QueryPipelineStatisticTessellationControlShaderPatchesBit)
+                             , ("QueryPipelineStatisticTessellationEvaluationShaderInvocationsBit", pure QueryPipelineStatisticTessellationEvaluationShaderInvocationsBit)
+                             , ("QueryPipelineStatisticComputeShaderInvocationsBit", pure QueryPipelineStatisticComputeShaderInvocationsBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "QueryPipelineStatisticFlags")
@@ -228,26 +228,26 @@ instance Read QueryPipelineStatisticFlags where
                     )
 
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = QueryPipelineStatisticFlags 0x1
+pattern QueryPipelineStatisticInputAssemblyVerticesBit = QueryPipelineStatisticFlags 0x1
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x2
+pattern QueryPipelineStatisticInputAssemblyPrimitivesBit = QueryPipelineStatisticFlags 0x2
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x4
+pattern QueryPipelineStatisticVertexShaderInvocationsBit = QueryPipelineStatisticFlags 0x4
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x8
+pattern QueryPipelineStatisticGeometryShaderInvocationsBit = QueryPipelineStatisticFlags 0x8
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x10
+pattern QueryPipelineStatisticGeometryShaderPrimitivesBit = QueryPipelineStatisticFlags 0x10
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x20
+pattern QueryPipelineStatisticClippingInvocationsBit = QueryPipelineStatisticFlags 0x20
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x40
+pattern QueryPipelineStatisticClippingPrimitivesBit = QueryPipelineStatisticFlags 0x40
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x80
+pattern QueryPipelineStatisticFragmentShaderInvocationsBit = QueryPipelineStatisticFlags 0x80
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = QueryPipelineStatisticFlags 0x100
+pattern QueryPipelineStatisticTessellationControlShaderPatchesBit = QueryPipelineStatisticFlags 0x100
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x200
+pattern QueryPipelineStatisticTessellationEvaluationShaderInvocationsBit = QueryPipelineStatisticFlags 0x200
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x400
+pattern QueryPipelineStatisticComputeShaderInvocationsBit = QueryPipelineStatisticFlags 0x400
 
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -83,7 +83,7 @@ instance Storable QueryPoolCreateInfo where
                 *> poke (ptr `plusPtr` 28) (pipelineStatistics (poked :: QueryPoolCreateInfo))
 
 
--- ** VkQueryResultFlags
+-- ** QueryResultFlags
 
 newtype QueryResultFlags = QueryResultFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -158,7 +158,7 @@ foreign import ccall "vkCreateQueryPool" createQueryPool ::
   Ptr QueryPoolCreateInfo ->
     Ptr AllocationCallbacks -> Ptr QueryPool -> IO Result
 
--- ** VkQueryControlFlags
+-- ** QueryControlFlags
 
 newtype QueryControlFlags = QueryControlFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -187,7 +187,7 @@ pattern VK_QUERY_CONTROL_PRECISE_BIT = QueryControlFlags 0x1
 newtype QueryPoolCreateFlags = QueryPoolCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** VkQueryPipelineStatisticFlags
+-- ** QueryPipelineStatisticFlags
 
 newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -125,15 +125,15 @@ newtype QueryType = QueryType Int32
   deriving (Eq, Storable)
 
 instance Show QueryType where
-  showsPrec _ VK_QUERY_TYPE_OCCLUSION = showString "VK_QUERY_TYPE_OCCLUSION"
-  showsPrec _ VK_QUERY_TYPE_PIPELINE_STATISTICS = showString "VK_QUERY_TYPE_PIPELINE_STATISTICS"
-  showsPrec _ VK_QUERY_TYPE_TIMESTAMP = showString "VK_QUERY_TYPE_TIMESTAMP"
+  showsPrec _ QueryTypeOcclusion = showString "QueryTypeOcclusion"
+  showsPrec _ QueryTypePipelineStatistics = showString "QueryTypePipelineStatistics"
+  showsPrec _ QueryTypeTimestamp = showString "QueryTypeTimestamp"
   showsPrec p (QueryType x) = showParen (p >= 11) (showString "QueryType " . showsPrec 11 x)
 
 instance Read QueryType where
-  readPrec = parens ( choose [ ("VK_QUERY_TYPE_OCCLUSION", pure VK_QUERY_TYPE_OCCLUSION)
-                             , ("VK_QUERY_TYPE_PIPELINE_STATISTICS", pure VK_QUERY_TYPE_PIPELINE_STATISTICS)
-                             , ("VK_QUERY_TYPE_TIMESTAMP", pure VK_QUERY_TYPE_TIMESTAMP)
+  readPrec = parens ( choose [ ("QueryTypeOcclusion", pure QueryTypeOcclusion)
+                             , ("QueryTypePipelineStatistics", pure QueryTypePipelineStatistics)
+                             , ("QueryTypeTimestamp", pure QueryTypeTimestamp)
                              ] +++
                       prec 10 (do
                         expectP (Ident "QueryType")
@@ -143,11 +143,11 @@ instance Read QueryType where
                     )
 
 
-pattern VK_QUERY_TYPE_OCCLUSION = QueryType 0
+pattern QueryTypeOcclusion = QueryType 0
 -- | Optional
-pattern VK_QUERY_TYPE_PIPELINE_STATISTICS = QueryType 1
+pattern QueryTypePipelineStatistics = QueryType 1
 
-pattern VK_QUERY_TYPE_TIMESTAMP = QueryType 2
+pattern QueryTypeTimestamp = QueryType 2
 
 newtype QueryPool = QueryPool Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Query where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,6 +26,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -31,6 +35,18 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Query( VkQueryPoolCreateFlags
+                            , VkQueryType
+                            , VkQueryResultFlags
+                            , VkQueryPoolCreateInfo
+                            , QueryPool
+                            , VkQueryPipelineStatisticFlags
+                            )
+import Graphics.Vulkan.Core( VkResult
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       )
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -26,7 +26,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -54,34 +54,34 @@ foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
 
 -- ** vkDestroyQueryPool
 foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
-  Device -> QueryPool -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> QueryPool -> Ptr AllocationCallbacks -> IO ()
 
 
-data VkQueryPoolCreateInfo =
-  VkQueryPoolCreateInfo{ sType :: VkStructureType 
-                       , pNext :: Ptr Void 
-                       , flags :: VkQueryPoolCreateFlags 
-                       , queryType :: VkQueryType 
-                       , queryCount :: Word32 
-                       , pipelineStatistics :: VkQueryPipelineStatisticFlags 
-                       }
+data QueryPoolCreateInfo =
+  QueryPoolCreateInfo{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , flags :: VkQueryPoolCreateFlags 
+                     , queryType :: VkQueryType 
+                     , queryCount :: Word32 
+                     , pipelineStatistics :: VkQueryPipelineStatisticFlags 
+                     }
   deriving (Eq)
 
-instance Storable VkQueryPoolCreateInfo where
+instance Storable QueryPoolCreateInfo where
   sizeOf ~_ = 32
   alignment ~_ = 8
-  peek ptr = VkQueryPoolCreateInfo <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-                                   <*> peek (ptr `plusPtr` 20)
-                                   <*> peek (ptr `plusPtr` 24)
-                                   <*> peek (ptr `plusPtr` 28)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 20) (queryType (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 24) (queryCount (poked :: VkQueryPoolCreateInfo))
-                *> poke (ptr `plusPtr` 28) (pipelineStatistics (poked :: VkQueryPoolCreateInfo))
+  peek ptr = QueryPoolCreateInfo <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+                                 <*> peek (ptr `plusPtr` 20)
+                                 <*> peek (ptr `plusPtr` 24)
+                                 <*> peek (ptr `plusPtr` 28)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: QueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: QueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: QueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 20) (queryType (poked :: QueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 24) (queryCount (poked :: QueryPoolCreateInfo))
+                *> poke (ptr `plusPtr` 28) (pipelineStatistics (poked :: QueryPoolCreateInfo))
 
 
 -- ** VkQueryResultFlags
@@ -156,8 +156,8 @@ newtype QueryPool = QueryPool Word64
 -- ** vkCreateQueryPool
 foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
   Device ->
-  Ptr VkQueryPoolCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr QueryPool -> IO VkResult
+  Ptr QueryPoolCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr QueryPool -> IO VkResult
 
 -- ** VkQueryControlFlags
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Query where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
@@ -24,9 +24,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -35,19 +35,12 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Query( VkQueryPoolCreateFlags
-                            , VkQueryType
-                            , VkQueryResultFlags
-                            , VkQueryPoolCreateInfo
-                            , QueryPool
-                            , VkQueryPipelineStatisticFlags
-                            )
-import Graphics.Vulkan.Core( VkResult
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
                            )
-import Foreign.C.Types( CSize
+import Foreign.C.Types( CSize(..)
                       )
 
 -- ** vkGetQueryPoolResults
@@ -93,41 +86,38 @@ instance Storable VkQueryPoolCreateInfo where
 
 -- ** VkQueryResultFlags
 
-newtype VkQueryResultFlagBits = VkQueryResultFlagBits VkFlags
+newtype VkQueryResultFlags = VkQueryResultFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkQueryResultFlagBits
-type VkQueryResultFlags = VkQueryResultFlagBits
-
-instance Show VkQueryResultFlagBits where
+instance Show VkQueryResultFlags where
   showsPrec _ VK_QUERY_RESULT_64_BIT = showString "VK_QUERY_RESULT_64_BIT"
   showsPrec _ VK_QUERY_RESULT_WAIT_BIT = showString "VK_QUERY_RESULT_WAIT_BIT"
   showsPrec _ VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = showString "VK_QUERY_RESULT_WITH_AVAILABILITY_BIT"
   showsPrec _ VK_QUERY_RESULT_PARTIAL_BIT = showString "VK_QUERY_RESULT_PARTIAL_BIT"
   
-  showsPrec p (VkQueryResultFlagBits x) = showParen (p >= 11) (showString "VkQueryResultFlagBits " . showsPrec 11 x)
+  showsPrec p (VkQueryResultFlags x) = showParen (p >= 11) (showString "VkQueryResultFlags " . showsPrec 11 x)
 
-instance Read VkQueryResultFlagBits where
+instance Read VkQueryResultFlags where
   readPrec = parens ( choose [ ("VK_QUERY_RESULT_64_BIT", pure VK_QUERY_RESULT_64_BIT)
                              , ("VK_QUERY_RESULT_WAIT_BIT", pure VK_QUERY_RESULT_WAIT_BIT)
                              , ("VK_QUERY_RESULT_WITH_AVAILABILITY_BIT", pure VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)
                              , ("VK_QUERY_RESULT_PARTIAL_BIT", pure VK_QUERY_RESULT_PARTIAL_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryResultFlagBits")
+                        expectP (Ident "VkQueryResultFlags")
                         v <- step readPrec
-                        pure (VkQueryResultFlagBits v)
+                        pure (VkQueryResultFlags v)
                         )
                     )
 
 -- | Results of the queries are written to the destination buffer as 64-bit values
-pattern VK_QUERY_RESULT_64_BIT = VkQueryResultFlagBits 0x1
+pattern VK_QUERY_RESULT_64_BIT = VkQueryResultFlags 0x1
 -- | Results of the queries are waited on before proceeding with the result copy
-pattern VK_QUERY_RESULT_WAIT_BIT = VkQueryResultFlagBits 0x2
+pattern VK_QUERY_RESULT_WAIT_BIT = VkQueryResultFlags 0x2
 -- | Besides the results of the query, the availability of the results is also written
-pattern VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = VkQueryResultFlagBits 0x4
+pattern VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = VkQueryResultFlags 0x4
 -- | Copy the partial results of the query even if the final results aren't available
-pattern VK_QUERY_RESULT_PARTIAL_BIT = VkQueryResultFlagBits 0x8
+pattern VK_QUERY_RESULT_PARTIAL_BIT = VkQueryResultFlags 0x8
 
 
 -- ** VkQueryType
@@ -171,29 +161,26 @@ foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
 
 -- ** VkQueryControlFlags
 
-newtype VkQueryControlFlagBits = VkQueryControlFlagBits VkFlags
+newtype VkQueryControlFlags = VkQueryControlFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkQueryControlFlagBits
-type VkQueryControlFlags = VkQueryControlFlagBits
-
-instance Show VkQueryControlFlagBits where
+instance Show VkQueryControlFlags where
   showsPrec _ VK_QUERY_CONTROL_PRECISE_BIT = showString "VK_QUERY_CONTROL_PRECISE_BIT"
   
-  showsPrec p (VkQueryControlFlagBits x) = showParen (p >= 11) (showString "VkQueryControlFlagBits " . showsPrec 11 x)
+  showsPrec p (VkQueryControlFlags x) = showParen (p >= 11) (showString "VkQueryControlFlags " . showsPrec 11 x)
 
-instance Read VkQueryControlFlagBits where
+instance Read VkQueryControlFlags where
   readPrec = parens ( choose [ ("VK_QUERY_CONTROL_PRECISE_BIT", pure VK_QUERY_CONTROL_PRECISE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryControlFlagBits")
+                        expectP (Ident "VkQueryControlFlags")
                         v <- step readPrec
-                        pure (VkQueryControlFlagBits v)
+                        pure (VkQueryControlFlags v)
                         )
                     )
 
 -- | Require precise results to be collected by the query
-pattern VK_QUERY_CONTROL_PRECISE_BIT = VkQueryControlFlagBits 0x1
+pattern VK_QUERY_CONTROL_PRECISE_BIT = VkQueryControlFlags 0x1
 
 
 -- ** VkQueryPoolCreateFlags
@@ -203,13 +190,10 @@ newtype VkQueryPoolCreateFlags = VkQueryPoolCreateFlags VkFlags
 
 -- ** VkQueryPipelineStatisticFlags
 
-newtype VkQueryPipelineStatisticFlagBits = VkQueryPipelineStatisticFlagBits VkFlags
+newtype VkQueryPipelineStatisticFlags = VkQueryPipelineStatisticFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkQueryPipelineStatisticFlagBits
-type VkQueryPipelineStatisticFlags = VkQueryPipelineStatisticFlagBits
-
-instance Show VkQueryPipelineStatisticFlagBits where
+instance Show VkQueryPipelineStatisticFlags where
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT"
@@ -222,9 +206,9 @@ instance Show VkQueryPipelineStatisticFlagBits where
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT"
   
-  showsPrec p (VkQueryPipelineStatisticFlagBits x) = showParen (p >= 11) (showString "VkQueryPipelineStatisticFlagBits " . showsPrec 11 x)
+  showsPrec p (VkQueryPipelineStatisticFlags x) = showParen (p >= 11) (showString "VkQueryPipelineStatisticFlags " . showsPrec 11 x)
 
-instance Read VkQueryPipelineStatisticFlagBits where
+instance Read VkQueryPipelineStatisticFlags where
   readPrec = parens ( choose [ ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT)
                              , ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT)
                              , ("VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT)
@@ -238,33 +222,33 @@ instance Read VkQueryPipelineStatisticFlagBits where
                              , ("VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryPipelineStatisticFlagBits")
+                        expectP (Ident "VkQueryPipelineStatisticFlags")
                         v <- step readPrec
-                        pure (VkQueryPipelineStatisticFlagBits v)
+                        pure (VkQueryPipelineStatisticFlags v)
                         )
                     )
 
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = VkQueryPipelineStatisticFlagBits 0x1
+pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = VkQueryPipelineStatisticFlags 0x1
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = VkQueryPipelineStatisticFlagBits 0x2
+pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x2
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x4
+pattern VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x4
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x8
+pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x8
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = VkQueryPipelineStatisticFlagBits 0x10
+pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x10
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x20
+pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x20
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = VkQueryPipelineStatisticFlagBits 0x40
+pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x40
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x80
+pattern VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x80
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = VkQueryPipelineStatisticFlagBits 0x100
+pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = VkQueryPipelineStatisticFlags 0x100
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x200
+pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x200
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlagBits 0x400
+pattern VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x400
 
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -64,7 +64,7 @@ data QueryPoolCreateInfo =
                      , queryCount :: Word32 
                      , pipelineStatistics :: QueryPipelineStatisticFlags 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable QueryPoolCreateInfo where
   sizeOf ~_ = 32
@@ -86,7 +86,7 @@ instance Storable QueryPoolCreateInfo where
 -- ** QueryResultFlags
 
 newtype QueryResultFlags = QueryResultFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show QueryResultFlags where
   showsPrec _ QueryResult64Bit = showString "QueryResult64Bit"
@@ -122,7 +122,7 @@ pattern QueryResultPartialBit = QueryResultFlags 0x8
 -- ** QueryType
 
 newtype QueryType = QueryType Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show QueryType where
   showsPrec _ QueryTypeOcclusion = showString "QueryTypeOcclusion"
@@ -150,7 +150,7 @@ pattern QueryTypePipelineStatistics = QueryType 1
 pattern QueryTypeTimestamp = QueryType 2
 
 newtype QueryPool = QueryPool Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** createQueryPool
 foreign import ccall "vkCreateQueryPool" createQueryPool ::
@@ -161,7 +161,7 @@ foreign import ccall "vkCreateQueryPool" createQueryPool ::
 -- ** QueryControlFlags
 
 newtype QueryControlFlags = QueryControlFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show QueryControlFlags where
   showsPrec _ QueryControlPreciseBit = showString "QueryControlPreciseBit"
@@ -185,12 +185,12 @@ pattern QueryControlPreciseBit = QueryControlFlags 0x1
 -- ** QueryPoolCreateFlags
 -- | Opaque flag
 newtype QueryPoolCreateFlags = QueryPoolCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** QueryPipelineStatisticFlags
 
 newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show QueryPipelineStatisticFlags where
   showsPrec _ QueryPipelineStatisticInputAssemblyVerticesBit = showString "QueryPipelineStatisticInputAssemblyVerticesBit"

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -35,9 +35,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 import Foreign.C.Types( CSize(..)
@@ -49,8 +49,7 @@ foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
   QueryPool ->
     Word32 ->
       Word32 ->
-        CSize ->
-          Ptr Void -> VkDeviceSize -> VkQueryResultFlags -> IO VkResult
+        CSize -> Ptr Void -> VkDeviceSize -> QueryResultFlags -> IO Result
 
 -- ** vkDestroyQueryPool
 foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
@@ -58,12 +57,12 @@ foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
 
 
 data QueryPoolCreateInfo =
-  QueryPoolCreateInfo{ sType :: VkStructureType 
+  QueryPoolCreateInfo{ sType :: StructureType 
                      , pNext :: Ptr Void 
-                     , flags :: VkQueryPoolCreateFlags 
-                     , queryType :: VkQueryType 
+                     , flags :: QueryPoolCreateFlags 
+                     , queryType :: QueryType 
                      , queryCount :: Word32 
-                     , pipelineStatistics :: VkQueryPipelineStatisticFlags 
+                     , pipelineStatistics :: QueryPipelineStatisticFlags 
                      }
   deriving (Eq)
 
@@ -86,69 +85,69 @@ instance Storable QueryPoolCreateInfo where
 
 -- ** VkQueryResultFlags
 
-newtype VkQueryResultFlags = VkQueryResultFlags VkFlags
+newtype QueryResultFlags = QueryResultFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkQueryResultFlags where
+instance Show QueryResultFlags where
   showsPrec _ VK_QUERY_RESULT_64_BIT = showString "VK_QUERY_RESULT_64_BIT"
   showsPrec _ VK_QUERY_RESULT_WAIT_BIT = showString "VK_QUERY_RESULT_WAIT_BIT"
   showsPrec _ VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = showString "VK_QUERY_RESULT_WITH_AVAILABILITY_BIT"
   showsPrec _ VK_QUERY_RESULT_PARTIAL_BIT = showString "VK_QUERY_RESULT_PARTIAL_BIT"
   
-  showsPrec p (VkQueryResultFlags x) = showParen (p >= 11) (showString "VkQueryResultFlags " . showsPrec 11 x)
+  showsPrec p (QueryResultFlags x) = showParen (p >= 11) (showString "QueryResultFlags " . showsPrec 11 x)
 
-instance Read VkQueryResultFlags where
+instance Read QueryResultFlags where
   readPrec = parens ( choose [ ("VK_QUERY_RESULT_64_BIT", pure VK_QUERY_RESULT_64_BIT)
                              , ("VK_QUERY_RESULT_WAIT_BIT", pure VK_QUERY_RESULT_WAIT_BIT)
                              , ("VK_QUERY_RESULT_WITH_AVAILABILITY_BIT", pure VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)
                              , ("VK_QUERY_RESULT_PARTIAL_BIT", pure VK_QUERY_RESULT_PARTIAL_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryResultFlags")
+                        expectP (Ident "QueryResultFlags")
                         v <- step readPrec
-                        pure (VkQueryResultFlags v)
+                        pure (QueryResultFlags v)
                         )
                     )
 
 -- | Results of the queries are written to the destination buffer as 64-bit values
-pattern VK_QUERY_RESULT_64_BIT = VkQueryResultFlags 0x1
+pattern VK_QUERY_RESULT_64_BIT = QueryResultFlags 0x1
 -- | Results of the queries are waited on before proceeding with the result copy
-pattern VK_QUERY_RESULT_WAIT_BIT = VkQueryResultFlags 0x2
+pattern VK_QUERY_RESULT_WAIT_BIT = QueryResultFlags 0x2
 -- | Besides the results of the query, the availability of the results is also written
-pattern VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = VkQueryResultFlags 0x4
+pattern VK_QUERY_RESULT_WITH_AVAILABILITY_BIT = QueryResultFlags 0x4
 -- | Copy the partial results of the query even if the final results aren't available
-pattern VK_QUERY_RESULT_PARTIAL_BIT = VkQueryResultFlags 0x8
+pattern VK_QUERY_RESULT_PARTIAL_BIT = QueryResultFlags 0x8
 
 
--- ** VkQueryType
+-- ** QueryType
 
-newtype VkQueryType = VkQueryType Int32
+newtype QueryType = QueryType Int32
   deriving (Eq, Storable)
 
-instance Show VkQueryType where
+instance Show QueryType where
   showsPrec _ VK_QUERY_TYPE_OCCLUSION = showString "VK_QUERY_TYPE_OCCLUSION"
   showsPrec _ VK_QUERY_TYPE_PIPELINE_STATISTICS = showString "VK_QUERY_TYPE_PIPELINE_STATISTICS"
   showsPrec _ VK_QUERY_TYPE_TIMESTAMP = showString "VK_QUERY_TYPE_TIMESTAMP"
-  showsPrec p (VkQueryType x) = showParen (p >= 11) (showString "VkQueryType " . showsPrec 11 x)
+  showsPrec p (QueryType x) = showParen (p >= 11) (showString "QueryType " . showsPrec 11 x)
 
-instance Read VkQueryType where
+instance Read QueryType where
   readPrec = parens ( choose [ ("VK_QUERY_TYPE_OCCLUSION", pure VK_QUERY_TYPE_OCCLUSION)
                              , ("VK_QUERY_TYPE_PIPELINE_STATISTICS", pure VK_QUERY_TYPE_PIPELINE_STATISTICS)
                              , ("VK_QUERY_TYPE_TIMESTAMP", pure VK_QUERY_TYPE_TIMESTAMP)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryType")
+                        expectP (Ident "QueryType")
                         v <- step readPrec
-                        pure (VkQueryType v)
+                        pure (QueryType v)
                         )
                     )
 
 
-pattern VK_QUERY_TYPE_OCCLUSION = VkQueryType 0
+pattern VK_QUERY_TYPE_OCCLUSION = QueryType 0
 -- | Optional
-pattern VK_QUERY_TYPE_PIPELINE_STATISTICS = VkQueryType 1
+pattern VK_QUERY_TYPE_PIPELINE_STATISTICS = QueryType 1
 
-pattern VK_QUERY_TYPE_TIMESTAMP = VkQueryType 2
+pattern VK_QUERY_TYPE_TIMESTAMP = QueryType 2
 
 newtype QueryPool = QueryPool Word64
   deriving (Eq, Storable)
@@ -157,43 +156,43 @@ newtype QueryPool = QueryPool Word64
 foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
   Device ->
   Ptr QueryPoolCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr QueryPool -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr QueryPool -> IO Result
 
 -- ** VkQueryControlFlags
 
-newtype VkQueryControlFlags = VkQueryControlFlags VkFlags
+newtype QueryControlFlags = QueryControlFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkQueryControlFlags where
+instance Show QueryControlFlags where
   showsPrec _ VK_QUERY_CONTROL_PRECISE_BIT = showString "VK_QUERY_CONTROL_PRECISE_BIT"
   
-  showsPrec p (VkQueryControlFlags x) = showParen (p >= 11) (showString "VkQueryControlFlags " . showsPrec 11 x)
+  showsPrec p (QueryControlFlags x) = showParen (p >= 11) (showString "QueryControlFlags " . showsPrec 11 x)
 
-instance Read VkQueryControlFlags where
+instance Read QueryControlFlags where
   readPrec = parens ( choose [ ("VK_QUERY_CONTROL_PRECISE_BIT", pure VK_QUERY_CONTROL_PRECISE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryControlFlags")
+                        expectP (Ident "QueryControlFlags")
                         v <- step readPrec
-                        pure (VkQueryControlFlags v)
+                        pure (QueryControlFlags v)
                         )
                     )
 
 -- | Require precise results to be collected by the query
-pattern VK_QUERY_CONTROL_PRECISE_BIT = VkQueryControlFlags 0x1
+pattern VK_QUERY_CONTROL_PRECISE_BIT = QueryControlFlags 0x1
 
 
--- ** VkQueryPoolCreateFlags
+-- ** QueryPoolCreateFlags
 -- | Opaque flag
-newtype VkQueryPoolCreateFlags = VkQueryPoolCreateFlags VkFlags
+newtype QueryPoolCreateFlags = QueryPoolCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** VkQueryPipelineStatisticFlags
 
-newtype VkQueryPipelineStatisticFlags = VkQueryPipelineStatisticFlags VkFlags
+newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkQueryPipelineStatisticFlags where
+instance Show QueryPipelineStatisticFlags where
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT"
@@ -206,9 +205,9 @@ instance Show VkQueryPipelineStatisticFlags where
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT"
   showsPrec _ VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = showString "VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT"
   
-  showsPrec p (VkQueryPipelineStatisticFlags x) = showParen (p >= 11) (showString "VkQueryPipelineStatisticFlags " . showsPrec 11 x)
+  showsPrec p (QueryPipelineStatisticFlags x) = showParen (p >= 11) (showString "QueryPipelineStatisticFlags " . showsPrec 11 x)
 
-instance Read VkQueryPipelineStatisticFlags where
+instance Read QueryPipelineStatisticFlags where
   readPrec = parens ( choose [ ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT)
                              , ("VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT", pure VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT)
                              , ("VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT)
@@ -222,33 +221,33 @@ instance Read VkQueryPipelineStatisticFlags where
                              , ("VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT", pure VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkQueryPipelineStatisticFlags")
+                        expectP (Ident "QueryPipelineStatisticFlags")
                         v <- step readPrec
-                        pure (VkQueryPipelineStatisticFlags v)
+                        pure (QueryPipelineStatisticFlags v)
                         )
                     )
 
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = VkQueryPipelineStatisticFlags 0x1
+pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT = QueryPipelineStatisticFlags 0x1
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x2
+pattern VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x2
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x4
+pattern VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x4
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x8
+pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x8
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x10
+pattern VK_QUERY_PIPELINE_STATISTIC_GEOMETRY_SHADER_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x10
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x20
+pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x20
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = VkQueryPipelineStatisticFlags 0x40
+pattern VK_QUERY_PIPELINE_STATISTIC_CLIPPING_PRIMITIVES_BIT = QueryPipelineStatisticFlags 0x40
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x80
+pattern VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x80
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = VkQueryPipelineStatisticFlags 0x100
+pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT = QueryPipelineStatisticFlags 0x100
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x200
+pattern VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x200
 -- | Optional
-pattern VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = VkQueryPipelineStatisticFlags 0x400
+pattern VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT = QueryPipelineStatisticFlags 0x400
 
 

--- a/src/Graphics/Vulkan/Query.hs
+++ b/src/Graphics/Vulkan/Query.hs
@@ -35,10 +35,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
@@ -49,7 +49,7 @@ foreign import ccall "vkGetQueryPoolResults" vkGetQueryPoolResults ::
   QueryPool ->
     Word32 ->
       Word32 ->
-        CSize -> Ptr Void -> VkDeviceSize -> QueryResultFlags -> IO Result
+        CSize -> Ptr Void -> DeviceSize -> QueryResultFlags -> IO Result
 
 -- ** vkDestroyQueryPool
 foreign import ccall "vkDestroyQueryPool" vkDestroyQueryPool ::
@@ -85,7 +85,7 @@ instance Storable QueryPoolCreateInfo where
 
 -- ** VkQueryResultFlags
 
-newtype QueryResultFlags = QueryResultFlags VkFlags
+newtype QueryResultFlags = QueryResultFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryResultFlags where
@@ -160,7 +160,7 @@ foreign import ccall "vkCreateQueryPool" vkCreateQueryPool ::
 
 -- ** VkQueryControlFlags
 
-newtype QueryControlFlags = QueryControlFlags VkFlags
+newtype QueryControlFlags = QueryControlFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryControlFlags where
@@ -184,12 +184,12 @@ pattern VK_QUERY_CONTROL_PRECISE_BIT = QueryControlFlags 0x1
 
 -- ** QueryPoolCreateFlags
 -- | Opaque flag
-newtype QueryPoolCreateFlags = QueryPoolCreateFlags VkFlags
+newtype QueryPoolCreateFlags = QueryPoolCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** VkQueryPipelineStatisticFlags
 
-newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags VkFlags
+newtype QueryPipelineStatisticFlags = QueryPipelineStatisticFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show QueryPipelineStatisticFlags where

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -2,31 +2,15 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.Queue where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits(..)
-                               , VkPipelineStageFlags(..)
-                               )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
-                                    )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence(..)
-                            )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
-                                     )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 
 data VkQueue_T
 type Queue = Ptr VkQueue_T

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.Queue where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Graphics.Vulkan.Pipeline( VkPipelineStageFlagBits(..)
                                , VkPipelineStageFlags(..)
@@ -13,15 +13,15 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.CommandBuffer( VkCommandBuffer(..)
+import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
                                     )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( VkFence(..)
+import Graphics.Vulkan.Fence( Fence(..)
                             )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.QueueSemaphore( VkSemaphore(..)
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
 import Graphics.Vulkan.Core( VkResult(..)
                            , VkFlags(..)
@@ -29,35 +29,35 @@ import Graphics.Vulkan.Core( VkResult(..)
                            )
 
 data VkQueue_T
-type VkQueue = Ptr VkQueue_T
+type Queue = Ptr VkQueue_T
 
 -- ** vkDeviceWaitIdle
 foreign import ccall "vkDeviceWaitIdle" vkDeviceWaitIdle ::
-  VkDevice -> IO VkResult
+  Device -> IO VkResult
 
 -- ** vkQueueSubmit
 foreign import ccall "vkQueueSubmit" vkQueueSubmit ::
-  VkQueue -> Word32 -> Ptr VkSubmitInfo -> VkFence -> IO VkResult
+  Queue -> Word32 -> Ptr VkSubmitInfo -> Fence -> IO VkResult
 
 -- ** vkQueueWaitIdle
 foreign import ccall "vkQueueWaitIdle" vkQueueWaitIdle ::
-  VkQueue -> IO VkResult
+  Queue -> IO VkResult
 
 -- ** vkGetDeviceQueue
 foreign import ccall "vkGetDeviceQueue" vkGetDeviceQueue ::
-  VkDevice -> Word32 -> Word32 -> Ptr VkQueue -> IO ()
+  Device -> Word32 -> Word32 -> Ptr Queue -> IO ()
 
 
 data VkSubmitInfo =
-  VkSubmitInfo{ vkSType :: VkStructureType 
-              , vkPNext :: Ptr Void 
-              , vkWaitSemaphoreCount :: Word32 
-              , vkPWaitSemaphores :: Ptr VkSemaphore 
-              , vkPWaitDstStageMask :: Ptr VkPipelineStageFlags 
-              , vkCommandBufferCount :: Word32 
-              , vkPCommandBuffers :: Ptr VkCommandBuffer 
-              , vkSignalSemaphoreCount :: Word32 
-              , vkPSignalSemaphores :: Ptr VkSemaphore 
+  VkSubmitInfo{ sType :: VkStructureType 
+              , pNext :: Ptr Void 
+              , waitSemaphoreCount :: Word32 
+              , pWaitSemaphores :: Ptr Semaphore 
+              , pWaitDstStageMask :: Ptr VkPipelineStageFlags 
+              , commandBufferCount :: Word32 
+              , pCommandBuffers :: Ptr CommandBuffer 
+              , signalSemaphoreCount :: Word32 
+              , pSignalSemaphores :: Ptr Semaphore 
               }
   deriving (Eq)
 
@@ -73,14 +73,14 @@ instance Storable VkSubmitInfo where
                           <*> peek (ptr `plusPtr` 48)
                           <*> peek (ptr `plusPtr` 56)
                           <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 16) (vkWaitSemaphoreCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 24) (vkPWaitSemaphores (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 32) (vkPWaitDstStageMask (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 40) (vkCommandBufferCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 48) (vkPCommandBuffers (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 56) (vkSignalSemaphoreCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 64) (vkPSignalSemaphores (poked :: VkSubmitInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 32) (pWaitDstStageMask (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 40) (commandBufferCount (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 48) (pCommandBuffers (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 56) (signalSemaphoreCount (poked :: VkSubmitInfo))
+                *> poke (ptr `plusPtr` 64) (pSignalSemaphores (poked :: VkSubmitInfo))
 
 

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -57,7 +57,7 @@ data SubmitInfo =
             , signalSemaphoreCount :: Word32 
             , pSignalSemaphores :: Ptr Semaphore 
             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SubmitInfo where
   sizeOf ~_ = 72

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -2,30 +2,28 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.Queue where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlags
+import Graphics.Vulkan.Pipeline( VkPipelineStageFlags(..)
                                )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
+                  , Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.Queue( Queue
-                            , VkSubmitInfo
-                            )
-import Graphics.Vulkan.CommandBuffer( CommandBuffer
+import Graphics.Vulkan.CommandBuffer( CommandBuffer(..)
                                     )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence
+import Graphics.Vulkan.Fence( Fence(..)
                             )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.QueueSemaphore( Semaphore
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkResult
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkResult(..)
                            )
 
 data VkQueue_T

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -29,20 +29,20 @@ import Graphics.Vulkan.Core( StructureType(..)
 data VkQueue_T
 type Queue = Ptr VkQueue_T
 
--- ** vkDeviceWaitIdle
-foreign import ccall "vkDeviceWaitIdle" vkDeviceWaitIdle ::
+-- ** deviceWaitIdle
+foreign import ccall "vkDeviceWaitIdle" deviceWaitIdle ::
   Device -> IO Result
 
--- ** vkQueueSubmit
-foreign import ccall "vkQueueSubmit" vkQueueSubmit ::
+-- ** queueSubmit
+foreign import ccall "vkQueueSubmit" queueSubmit ::
   Queue -> Word32 -> Ptr SubmitInfo -> Fence -> IO Result
 
--- ** vkQueueWaitIdle
-foreign import ccall "vkQueueWaitIdle" vkQueueWaitIdle ::
+-- ** queueWaitIdle
+foreign import ccall "vkQueueWaitIdle" queueWaitIdle ::
   Queue -> IO Result
 
--- ** vkGetDeviceQueue
-foreign import ccall "vkGetDeviceQueue" vkGetDeviceQueue ::
+-- ** getDeviceQueue
+foreign import ccall "vkGetDeviceQueue" getDeviceQueue ::
   Device -> Word32 -> Word32 -> Ptr Queue -> IO ()
 
 

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -2,15 +2,31 @@
 {-# LANGUAGE Strict #-}
 module Graphics.Vulkan.Queue where
 
+import Graphics.Vulkan.Device( Device
+                             )
+import Graphics.Vulkan.Pipeline( VkPipelineStageFlags
+                               )
 import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.Queue( Queue
+                            , VkSubmitInfo
+                            )
+import Graphics.Vulkan.CommandBuffer( CommandBuffer
+                                    )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Fence( Fence
+                            )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.QueueSemaphore( Semaphore
+                                     )
+import Graphics.Vulkan.Core( VkResult
+                           , VkStructureType
+                           )
 
 data VkQueue_T
 type Queue = Ptr VkQueue_T

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -4,7 +4,7 @@ module Graphics.Vulkan.Queue where
 
 import Graphics.Vulkan.Device( Device(..)
                              )
-import Graphics.Vulkan.Pipeline( VkPipelineStageFlags(..)
+import Graphics.Vulkan.Pipeline( PipelineStageFlags(..)
                                )
 import Data.Word( Word32(..)
                 )
@@ -22,8 +22,8 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( StructureType(..)
+                           , Result(..)
                            )
 
 data VkQueue_T
@@ -31,15 +31,15 @@ type Queue = Ptr VkQueue_T
 
 -- ** vkDeviceWaitIdle
 foreign import ccall "vkDeviceWaitIdle" vkDeviceWaitIdle ::
-  Device -> IO VkResult
+  Device -> IO Result
 
 -- ** vkQueueSubmit
 foreign import ccall "vkQueueSubmit" vkQueueSubmit ::
-  Queue -> Word32 -> Ptr SubmitInfo -> Fence -> IO VkResult
+  Queue -> Word32 -> Ptr SubmitInfo -> Fence -> IO Result
 
 -- ** vkQueueWaitIdle
 foreign import ccall "vkQueueWaitIdle" vkQueueWaitIdle ::
-  Queue -> IO VkResult
+  Queue -> IO Result
 
 -- ** vkGetDeviceQueue
 foreign import ccall "vkGetDeviceQueue" vkGetDeviceQueue ::
@@ -47,11 +47,11 @@ foreign import ccall "vkGetDeviceQueue" vkGetDeviceQueue ::
 
 
 data SubmitInfo =
-  SubmitInfo{ sType :: VkStructureType 
+  SubmitInfo{ sType :: StructureType 
             , pNext :: Ptr Void 
             , waitSemaphoreCount :: Word32 
             , pWaitSemaphores :: Ptr Semaphore 
-            , pWaitDstStageMask :: Ptr VkPipelineStageFlags 
+            , pWaitDstStageMask :: Ptr PipelineStageFlags 
             , commandBufferCount :: Word32 
             , pCommandBuffers :: Ptr CommandBuffer 
             , signalSemaphoreCount :: Word32 

--- a/src/Graphics/Vulkan/Queue.hs
+++ b/src/Graphics/Vulkan/Queue.hs
@@ -35,7 +35,7 @@ foreign import ccall "vkDeviceWaitIdle" vkDeviceWaitIdle ::
 
 -- ** vkQueueSubmit
 foreign import ccall "vkQueueSubmit" vkQueueSubmit ::
-  Queue -> Word32 -> Ptr VkSubmitInfo -> Fence -> IO VkResult
+  Queue -> Word32 -> Ptr SubmitInfo -> Fence -> IO VkResult
 
 -- ** vkQueueWaitIdle
 foreign import ccall "vkQueueWaitIdle" vkQueueWaitIdle ::
@@ -46,39 +46,39 @@ foreign import ccall "vkGetDeviceQueue" vkGetDeviceQueue ::
   Device -> Word32 -> Word32 -> Ptr Queue -> IO ()
 
 
-data VkSubmitInfo =
-  VkSubmitInfo{ sType :: VkStructureType 
-              , pNext :: Ptr Void 
-              , waitSemaphoreCount :: Word32 
-              , pWaitSemaphores :: Ptr Semaphore 
-              , pWaitDstStageMask :: Ptr VkPipelineStageFlags 
-              , commandBufferCount :: Word32 
-              , pCommandBuffers :: Ptr CommandBuffer 
-              , signalSemaphoreCount :: Word32 
-              , pSignalSemaphores :: Ptr Semaphore 
-              }
+data SubmitInfo =
+  SubmitInfo{ sType :: VkStructureType 
+            , pNext :: Ptr Void 
+            , waitSemaphoreCount :: Word32 
+            , pWaitSemaphores :: Ptr Semaphore 
+            , pWaitDstStageMask :: Ptr VkPipelineStageFlags 
+            , commandBufferCount :: Word32 
+            , pCommandBuffers :: Ptr CommandBuffer 
+            , signalSemaphoreCount :: Word32 
+            , pSignalSemaphores :: Ptr Semaphore 
+            }
   deriving (Eq)
 
-instance Storable VkSubmitInfo where
+instance Storable SubmitInfo where
   sizeOf ~_ = 72
   alignment ~_ = 8
-  peek ptr = VkSubmitInfo <$> peek (ptr `plusPtr` 0)
-                          <*> peek (ptr `plusPtr` 8)
-                          <*> peek (ptr `plusPtr` 16)
-                          <*> peek (ptr `plusPtr` 24)
-                          <*> peek (ptr `plusPtr` 32)
-                          <*> peek (ptr `plusPtr` 40)
-                          <*> peek (ptr `plusPtr` 48)
-                          <*> peek (ptr `plusPtr` 56)
-                          <*> peek (ptr `plusPtr` 64)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 32) (pWaitDstStageMask (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 40) (commandBufferCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 48) (pCommandBuffers (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 56) (signalSemaphoreCount (poked :: VkSubmitInfo))
-                *> poke (ptr `plusPtr` 64) (pSignalSemaphores (poked :: VkSubmitInfo))
+  peek ptr = SubmitInfo <$> peek (ptr `plusPtr` 0)
+                        <*> peek (ptr `plusPtr` 8)
+                        <*> peek (ptr `plusPtr` 16)
+                        <*> peek (ptr `plusPtr` 24)
+                        <*> peek (ptr `plusPtr` 32)
+                        <*> peek (ptr `plusPtr` 40)
+                        <*> peek (ptr `plusPtr` 48)
+                        <*> peek (ptr `plusPtr` 56)
+                        <*> peek (ptr `plusPtr` 64)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 32) (pWaitDstStageMask (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 40) (commandBufferCount (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 48) (pCommandBuffers (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 56) (signalSemaphoreCount (poked :: SubmitInfo))
+                *> poke (ptr `plusPtr` 64) (pSignalSemaphores (poked :: SubmitInfo))
 
 

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.QueueSemaphore where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Data.Word( Word64
                 , Word32
@@ -38,16 +38,16 @@ newtype VkSemaphoreCreateFlags = VkSemaphoreCreateFlags VkFlags
 
 -- ** vkDestroySemaphore
 foreign import ccall "vkDestroySemaphore" vkDestroySemaphore ::
-  VkDevice -> VkSemaphore -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Semaphore -> Ptr VkAllocationCallbacks -> IO ()
 
-newtype VkSemaphore = VkSemaphore Word64
+newtype Semaphore = Semaphore Word64
   deriving (Eq, Storable)
 
 
 data VkSemaphoreCreateInfo =
-  VkSemaphoreCreateInfo{ vkSType :: VkStructureType 
-                       , vkPNext :: Ptr Void 
-                       , vkFlags :: VkSemaphoreCreateFlags 
+  VkSemaphoreCreateInfo{ sType :: VkStructureType 
+                       , pNext :: Ptr Void 
+                       , flags :: VkSemaphoreCreateFlags 
                        }
   deriving (Eq)
 
@@ -57,14 +57,14 @@ instance Storable VkSemaphoreCreateInfo where
   peek ptr = VkSemaphoreCreateInfo <$> peek (ptr `plusPtr` 0)
                                    <*> peek (ptr `plusPtr` 8)
                                    <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkSemaphoreCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkSemaphoreCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkSemaphoreCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSemaphoreCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSemaphoreCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSemaphoreCreateInfo))
 
 
 -- ** vkCreateSemaphore
 foreign import ccall "vkCreateSemaphore" vkCreateSemaphore ::
-  VkDevice ->
+  Device ->
   Ptr VkSemaphoreCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkSemaphore -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Semaphore -> IO VkResult
 

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -3,10 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.QueueSemaphore where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -15,21 +12,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
-import Foreign.C.Types( CSize(..)
-                      )
 
 -- ** VkSemaphoreCreateFlags
 -- | Opaque flag

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -24,14 +24,14 @@ import Graphics.Vulkan.Core( StructureType(..)
 -- ** SemaphoreCreateFlags
 -- | Opaque flag
 newtype SemaphoreCreateFlags = SemaphoreCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** destroySemaphore
 foreign import ccall "vkDestroySemaphore" destroySemaphore ::
   Device -> Semaphore -> Ptr AllocationCallbacks -> IO ()
 
 newtype Semaphore = Semaphore Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data SemaphoreCreateInfo =
@@ -39,7 +39,7 @@ data SemaphoreCreateInfo =
                      , pNext :: Ptr Void 
                      , flags :: SemaphoreCreateFlags 
                      }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SemaphoreCreateInfo where
   sizeOf ~_ = 24

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -16,14 +16,14 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 
--- ** VkSemaphoreCreateFlags
+-- ** SemaphoreCreateFlags
 -- | Opaque flag
-newtype VkSemaphoreCreateFlags = VkSemaphoreCreateFlags VkFlags
+newtype SemaphoreCreateFlags = SemaphoreCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** vkDestroySemaphore
@@ -35,9 +35,9 @@ newtype Semaphore = Semaphore Word64
 
 
 data SemaphoreCreateInfo =
-  SemaphoreCreateInfo{ sType :: VkStructureType 
+  SemaphoreCreateInfo{ sType :: StructureType 
                      , pNext :: Ptr Void 
-                     , flags :: VkSemaphoreCreateFlags 
+                     , flags :: SemaphoreCreateFlags 
                      }
   deriving (Eq)
 
@@ -56,5 +56,5 @@ instance Storable SemaphoreCreateInfo where
 foreign import ccall "vkCreateSemaphore" vkCreateSemaphore ::
   Device ->
   Ptr SemaphoreCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Semaphore -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Semaphore -> IO Result
 

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.QueueSemaphore where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Data.Word( Word64
                 )
 import Foreign.Ptr( Ptr
@@ -12,6 +14,16 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
+import Graphics.Vulkan.QueueSemaphore( VkSemaphoreCreateFlags
+                                     , VkSemaphoreCreateInfo
+                                     , Semaphore
+                                     )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 
 -- ** VkSemaphoreCreateFlags
 -- | Opaque flag

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -3,26 +3,22 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.QueueSemaphore where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
-import Graphics.Vulkan.QueueSemaphore( VkSemaphoreCreateFlags
-                                     , VkSemaphoreCreateInfo
-                                     , Semaphore
-                                     )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
 
 -- ** VkSemaphoreCreateFlags

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -14,7 +14,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFlags(..)
@@ -28,33 +28,33 @@ newtype VkSemaphoreCreateFlags = VkSemaphoreCreateFlags VkFlags
 
 -- ** vkDestroySemaphore
 foreign import ccall "vkDestroySemaphore" vkDestroySemaphore ::
-  Device -> Semaphore -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Semaphore -> Ptr AllocationCallbacks -> IO ()
 
 newtype Semaphore = Semaphore Word64
   deriving (Eq, Storable)
 
 
-data VkSemaphoreCreateInfo =
-  VkSemaphoreCreateInfo{ sType :: VkStructureType 
-                       , pNext :: Ptr Void 
-                       , flags :: VkSemaphoreCreateFlags 
-                       }
+data SemaphoreCreateInfo =
+  SemaphoreCreateInfo{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , flags :: VkSemaphoreCreateFlags 
+                     }
   deriving (Eq)
 
-instance Storable VkSemaphoreCreateInfo where
+instance Storable SemaphoreCreateInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkSemaphoreCreateInfo <$> peek (ptr `plusPtr` 0)
-                                   <*> peek (ptr `plusPtr` 8)
-                                   <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSemaphoreCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSemaphoreCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSemaphoreCreateInfo))
+  peek ptr = SemaphoreCreateInfo <$> peek (ptr `plusPtr` 0)
+                                 <*> peek (ptr `plusPtr` 8)
+                                 <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SemaphoreCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: SemaphoreCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: SemaphoreCreateInfo))
 
 
 -- ** vkCreateSemaphore
 foreign import ccall "vkCreateSemaphore" vkCreateSemaphore ::
   Device ->
-  Ptr VkSemaphoreCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Semaphore -> IO VkResult
+  Ptr SemaphoreCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Semaphore -> IO VkResult
 

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -26,8 +26,8 @@ import Graphics.Vulkan.Core( StructureType(..)
 newtype SemaphoreCreateFlags = SemaphoreCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** vkDestroySemaphore
-foreign import ccall "vkDestroySemaphore" vkDestroySemaphore ::
+-- ** destroySemaphore
+foreign import ccall "vkDestroySemaphore" destroySemaphore ::
   Device -> Semaphore -> Ptr AllocationCallbacks -> IO ()
 
 newtype Semaphore = Semaphore Word64
@@ -52,8 +52,8 @@ instance Storable SemaphoreCreateInfo where
                 *> poke (ptr `plusPtr` 16) (flags (poked :: SemaphoreCreateInfo))
 
 
--- ** vkCreateSemaphore
-foreign import ccall "vkCreateSemaphore" vkCreateSemaphore ::
+-- ** createSemaphore
+foreign import ccall "vkCreateSemaphore" createSemaphore ::
   Device ->
   Ptr SemaphoreCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Semaphore -> IO Result

--- a/src/Graphics/Vulkan/QueueSemaphore.hs
+++ b/src/Graphics/Vulkan/QueueSemaphore.hs
@@ -16,14 +16,14 @@ import Data.Void( Void(..)
                 )
 import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 
 -- ** SemaphoreCreateFlags
 -- | Opaque flag
-newtype SemaphoreCreateFlags = SemaphoreCreateFlags VkFlags
+newtype SemaphoreCreateFlags = SemaphoreCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** vkDestroySemaphore

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Sampler where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -208,29 +208,29 @@ pattern VK_COMPARE_OP_GREATER_OR_EQUAL = VkCompareOp 6
 
 pattern VK_COMPARE_OP_ALWAYS = VkCompareOp 7
 
-newtype VkSampler = VkSampler Word64
+newtype Sampler = Sampler Word64
   deriving (Eq, Storable)
 
 
 data VkSamplerCreateInfo =
-  VkSamplerCreateInfo{ vkSType :: VkStructureType 
-                     , vkPNext :: Ptr Void 
-                     , vkFlags :: VkSamplerCreateFlags 
-                     , vkMagFilter :: VkFilter 
-                     , vkMinFilter :: VkFilter 
-                     , vkMipmapMode :: VkSamplerMipmapMode 
-                     , vkAddressModeU :: VkSamplerAddressMode 
-                     , vkAddressModeV :: VkSamplerAddressMode 
-                     , vkAddressModeW :: VkSamplerAddressMode 
-                     , vkMipLodBias :: CFloat 
-                     , vkAnisotropyEnable :: VkBool32 
-                     , vkMaxAnisotropy :: CFloat 
-                     , vkCompareEnable :: VkBool32 
-                     , vkCompareOp :: VkCompareOp 
-                     , vkMinLod :: CFloat 
-                     , vkMaxLod :: CFloat 
-                     , vkBorderColor :: VkBorderColor 
-                     , vkUnnormalizedCoordinates :: VkBool32 
+  VkSamplerCreateInfo{ sType :: VkStructureType 
+                     , pNext :: Ptr Void 
+                     , flags :: VkSamplerCreateFlags 
+                     , magFilter :: VkFilter 
+                     , minFilter :: VkFilter 
+                     , mipmapMode :: VkSamplerMipmapMode 
+                     , addressModeU :: VkSamplerAddressMode 
+                     , addressModeV :: VkSamplerAddressMode 
+                     , addressModeW :: VkSamplerAddressMode 
+                     , mipLodBias :: CFloat 
+                     , anisotropyEnable :: VkBool32 
+                     , maxAnisotropy :: CFloat 
+                     , compareEnable :: VkBool32 
+                     , compareOp :: VkCompareOp 
+                     , minLod :: CFloat 
+                     , maxLod :: CFloat 
+                     , borderColor :: VkBorderColor 
+                     , unnormalizedCoordinates :: VkBool32 
                      }
   deriving (Eq)
 
@@ -255,24 +255,24 @@ instance Storable VkSamplerCreateInfo where
                                  <*> peek (ptr `plusPtr` 68)
                                  <*> peek (ptr `plusPtr` 72)
                                  <*> peek (ptr `plusPtr` 76)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 20) (vkMagFilter (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkMinFilter (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 28) (vkMipmapMode (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkAddressModeU (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 36) (vkAddressModeV (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 40) (vkAddressModeW (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 44) (vkMipLodBias (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 48) (vkAnisotropyEnable (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 52) (vkMaxAnisotropy (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 56) (vkCompareEnable (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 60) (vkCompareOp (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 64) (vkMinLod (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 68) (vkMaxLod (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 72) (vkBorderColor (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 76) (vkUnnormalizedCoordinates (poked :: VkSamplerCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 20) (magFilter (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 24) (minFilter (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 28) (mipmapMode (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 32) (addressModeU (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 36) (addressModeV (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 40) (addressModeW (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 44) (mipLodBias (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 48) (anisotropyEnable (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 52) (maxAnisotropy (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 56) (compareEnable (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 60) (compareOp (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 64) (minLod (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 68) (maxLod (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 72) (borderColor (poked :: VkSamplerCreateInfo))
+                *> poke (ptr `plusPtr` 76) (unnormalizedCoordinates (poked :: VkSamplerCreateInfo))
 
 
 -- ** VkSamplerCreateFlags
@@ -308,9 +308,9 @@ pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = VkSamplerMipmapMode 1
 
 -- ** vkCreateSampler
 foreign import ccall "vkCreateSampler" vkCreateSampler ::
-  VkDevice ->
+  Device ->
   Ptr VkSamplerCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkSampler -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr Sampler -> IO VkResult
 
 -- ** VkSampleCountFlags
 
@@ -365,5 +365,5 @@ pattern VK_SAMPLE_COUNT_64_BIT = VkSampleCountFlagBits 0x40
 
 -- ** vkDestroySampler
 foreign import ccall "vkDestroySampler" vkDestroySampler ::
-  VkDevice -> VkSampler -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Sampler -> Ptr VkAllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -4,15 +4,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Sampler where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
 import Data.Word( Word64
-                , Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
@@ -26,15 +23,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -42,14 +30,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkBool32(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CFloat
-                      , CFloat(..)
-                      , CSize(..)
                       )
 
 -- ** VkSamplerAddressMode

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -48,19 +48,19 @@ newtype SamplerAddressMode = SamplerAddressMode Int32
   deriving (Eq, Storable)
 
 instance Show SamplerAddressMode where
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_REPEAT = showString "VK_SAMPLER_ADDRESS_MODE_REPEAT"
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = showString "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE"
+  showsPrec _ SamplerAddressModeRepeat = showString "SamplerAddressModeRepeat"
+  showsPrec _ SamplerAddressModeMirroredRepeat = showString "SamplerAddressModeMirroredRepeat"
+  showsPrec _ SamplerAddressModeClampToEdge = showString "SamplerAddressModeClampToEdge"
+  showsPrec _ SamplerAddressModeClampToBorder = showString "SamplerAddressModeClampToBorder"
+  showsPrec _ SamplerAddressModeMirrorClampToEdge = showString "SamplerAddressModeMirrorClampToEdge"
   showsPrec p (SamplerAddressMode x) = showParen (p >= 11) (showString "SamplerAddressMode " . showsPrec 11 x)
 
 instance Read SamplerAddressMode where
-  readPrec = parens ( choose [ ("VK_SAMPLER_ADDRESS_MODE_REPEAT", pure VK_SAMPLER_ADDRESS_MODE_REPEAT)
-                             , ("VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT", pure VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT)
-                             , ("VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                             , ("VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER", pure VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)
-                             , ("VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE)
+  readPrec = parens ( choose [ ("SamplerAddressModeRepeat", pure SamplerAddressModeRepeat)
+                             , ("SamplerAddressModeMirroredRepeat", pure SamplerAddressModeMirroredRepeat)
+                             , ("SamplerAddressModeClampToEdge", pure SamplerAddressModeClampToEdge)
+                             , ("SamplerAddressModeClampToBorder", pure SamplerAddressModeClampToBorder)
+                             , ("SamplerAddressModeMirrorClampToEdge", pure SamplerAddressModeMirrorClampToEdge)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SamplerAddressMode")
@@ -70,15 +70,15 @@ instance Read SamplerAddressMode where
                     )
 
 
-pattern VK_SAMPLER_ADDRESS_MODE_REPEAT = SamplerAddressMode 0
+pattern SamplerAddressModeRepeat = SamplerAddressMode 0
 
-pattern VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = SamplerAddressMode 1
+pattern SamplerAddressModeMirroredRepeat = SamplerAddressMode 1
 
-pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = SamplerAddressMode 2
+pattern SamplerAddressModeClampToEdge = SamplerAddressMode 2
 
-pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = SamplerAddressMode 3
+pattern SamplerAddressModeClampToBorder = SamplerAddressMode 3
 
-pattern VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = SamplerAddressMode 4
+pattern SamplerAddressModeMirrorClampToEdge = SamplerAddressMode 4
 
 -- ** Filter
 
@@ -86,13 +86,13 @@ newtype Filter = Filter Int32
   deriving (Eq, Storable)
 
 instance Show Filter where
-  showsPrec _ VK_FILTER_NEAREST = showString "VK_FILTER_NEAREST"
-  showsPrec _ VK_FILTER_LINEAR = showString "VK_FILTER_LINEAR"
+  showsPrec _ FilterNearest = showString "FilterNearest"
+  showsPrec _ FilterLinear = showString "FilterLinear"
   showsPrec p (Filter x) = showParen (p >= 11) (showString "Filter " . showsPrec 11 x)
 
 instance Read Filter where
-  readPrec = parens ( choose [ ("VK_FILTER_NEAREST", pure VK_FILTER_NEAREST)
-                             , ("VK_FILTER_LINEAR", pure VK_FILTER_LINEAR)
+  readPrec = parens ( choose [ ("FilterNearest", pure FilterNearest)
+                             , ("FilterLinear", pure FilterLinear)
                              ] +++
                       prec 10 (do
                         expectP (Ident "Filter")
@@ -102,9 +102,9 @@ instance Read Filter where
                     )
 
 
-pattern VK_FILTER_NEAREST = Filter 0
+pattern FilterNearest = Filter 0
 
-pattern VK_FILTER_LINEAR = Filter 1
+pattern FilterLinear = Filter 1
 
 -- ** BorderColor
 
@@ -112,21 +112,21 @@ newtype BorderColor = BorderColor Int32
   deriving (Eq, Storable)
 
 instance Show BorderColor where
-  showsPrec _ VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = showString "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK"
-  showsPrec _ VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = showString "VK_BORDER_COLOR_INT_TRANSPARENT_BLACK"
-  showsPrec _ VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = showString "VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK"
-  showsPrec _ VK_BORDER_COLOR_INT_OPAQUE_BLACK = showString "VK_BORDER_COLOR_INT_OPAQUE_BLACK"
-  showsPrec _ VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE = showString "VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE"
-  showsPrec _ VK_BORDER_COLOR_INT_OPAQUE_WHITE = showString "VK_BORDER_COLOR_INT_OPAQUE_WHITE"
+  showsPrec _ BorderColorFloatTransparentBlack = showString "BorderColorFloatTransparentBlack"
+  showsPrec _ BorderColorIntTransparentBlack = showString "BorderColorIntTransparentBlack"
+  showsPrec _ BorderColorFloatOpaqueBlack = showString "BorderColorFloatOpaqueBlack"
+  showsPrec _ BorderColorIntOpaqueBlack = showString "BorderColorIntOpaqueBlack"
+  showsPrec _ BorderColorFloatOpaqueWhite = showString "BorderColorFloatOpaqueWhite"
+  showsPrec _ BorderColorIntOpaqueWhite = showString "BorderColorIntOpaqueWhite"
   showsPrec p (BorderColor x) = showParen (p >= 11) (showString "BorderColor " . showsPrec 11 x)
 
 instance Read BorderColor where
-  readPrec = parens ( choose [ ("VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK", pure VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)
-                             , ("VK_BORDER_COLOR_INT_TRANSPARENT_BLACK", pure VK_BORDER_COLOR_INT_TRANSPARENT_BLACK)
-                             , ("VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK", pure VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK)
-                             , ("VK_BORDER_COLOR_INT_OPAQUE_BLACK", pure VK_BORDER_COLOR_INT_OPAQUE_BLACK)
-                             , ("VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE", pure VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE)
-                             , ("VK_BORDER_COLOR_INT_OPAQUE_WHITE", pure VK_BORDER_COLOR_INT_OPAQUE_WHITE)
+  readPrec = parens ( choose [ ("BorderColorFloatTransparentBlack", pure BorderColorFloatTransparentBlack)
+                             , ("BorderColorIntTransparentBlack", pure BorderColorIntTransparentBlack)
+                             , ("BorderColorFloatOpaqueBlack", pure BorderColorFloatOpaqueBlack)
+                             , ("BorderColorIntOpaqueBlack", pure BorderColorIntOpaqueBlack)
+                             , ("BorderColorFloatOpaqueWhite", pure BorderColorFloatOpaqueWhite)
+                             , ("BorderColorIntOpaqueWhite", pure BorderColorIntOpaqueWhite)
                              ] +++
                       prec 10 (do
                         expectP (Ident "BorderColor")
@@ -136,17 +136,17 @@ instance Read BorderColor where
                     )
 
 
-pattern VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = BorderColor 0
+pattern BorderColorFloatTransparentBlack = BorderColor 0
 
-pattern VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = BorderColor 1
+pattern BorderColorIntTransparentBlack = BorderColor 1
 
-pattern VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = BorderColor 2
+pattern BorderColorFloatOpaqueBlack = BorderColor 2
 
-pattern VK_BORDER_COLOR_INT_OPAQUE_BLACK = BorderColor 3
+pattern BorderColorIntOpaqueBlack = BorderColor 3
 
-pattern VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE = BorderColor 4
+pattern BorderColorFloatOpaqueWhite = BorderColor 4
 
-pattern VK_BORDER_COLOR_INT_OPAQUE_WHITE = BorderColor 5
+pattern BorderColorIntOpaqueWhite = BorderColor 5
 
 -- ** CompareOp
 
@@ -154,25 +154,25 @@ newtype CompareOp = CompareOp Int32
   deriving (Eq, Storable)
 
 instance Show CompareOp where
-  showsPrec _ VK_COMPARE_OP_NEVER = showString "VK_COMPARE_OP_NEVER"
-  showsPrec _ VK_COMPARE_OP_LESS = showString "VK_COMPARE_OP_LESS"
-  showsPrec _ VK_COMPARE_OP_EQUAL = showString "VK_COMPARE_OP_EQUAL"
-  showsPrec _ VK_COMPARE_OP_LESS_OR_EQUAL = showString "VK_COMPARE_OP_LESS_OR_EQUAL"
-  showsPrec _ VK_COMPARE_OP_GREATER = showString "VK_COMPARE_OP_GREATER"
-  showsPrec _ VK_COMPARE_OP_NOT_EQUAL = showString "VK_COMPARE_OP_NOT_EQUAL"
-  showsPrec _ VK_COMPARE_OP_GREATER_OR_EQUAL = showString "VK_COMPARE_OP_GREATER_OR_EQUAL"
-  showsPrec _ VK_COMPARE_OP_ALWAYS = showString "VK_COMPARE_OP_ALWAYS"
+  showsPrec _ CompareOpNever = showString "CompareOpNever"
+  showsPrec _ CompareOpLess = showString "CompareOpLess"
+  showsPrec _ CompareOpEqual = showString "CompareOpEqual"
+  showsPrec _ CompareOpLessOrEqual = showString "CompareOpLessOrEqual"
+  showsPrec _ CompareOpGreater = showString "CompareOpGreater"
+  showsPrec _ CompareOpNotEqual = showString "CompareOpNotEqual"
+  showsPrec _ CompareOpGreaterOrEqual = showString "CompareOpGreaterOrEqual"
+  showsPrec _ CompareOpAlways = showString "CompareOpAlways"
   showsPrec p (CompareOp x) = showParen (p >= 11) (showString "CompareOp " . showsPrec 11 x)
 
 instance Read CompareOp where
-  readPrec = parens ( choose [ ("VK_COMPARE_OP_NEVER", pure VK_COMPARE_OP_NEVER)
-                             , ("VK_COMPARE_OP_LESS", pure VK_COMPARE_OP_LESS)
-                             , ("VK_COMPARE_OP_EQUAL", pure VK_COMPARE_OP_EQUAL)
-                             , ("VK_COMPARE_OP_LESS_OR_EQUAL", pure VK_COMPARE_OP_LESS_OR_EQUAL)
-                             , ("VK_COMPARE_OP_GREATER", pure VK_COMPARE_OP_GREATER)
-                             , ("VK_COMPARE_OP_NOT_EQUAL", pure VK_COMPARE_OP_NOT_EQUAL)
-                             , ("VK_COMPARE_OP_GREATER_OR_EQUAL", pure VK_COMPARE_OP_GREATER_OR_EQUAL)
-                             , ("VK_COMPARE_OP_ALWAYS", pure VK_COMPARE_OP_ALWAYS)
+  readPrec = parens ( choose [ ("CompareOpNever", pure CompareOpNever)
+                             , ("CompareOpLess", pure CompareOpLess)
+                             , ("CompareOpEqual", pure CompareOpEqual)
+                             , ("CompareOpLessOrEqual", pure CompareOpLessOrEqual)
+                             , ("CompareOpGreater", pure CompareOpGreater)
+                             , ("CompareOpNotEqual", pure CompareOpNotEqual)
+                             , ("CompareOpGreaterOrEqual", pure CompareOpGreaterOrEqual)
+                             , ("CompareOpAlways", pure CompareOpAlways)
                              ] +++
                       prec 10 (do
                         expectP (Ident "CompareOp")
@@ -182,21 +182,21 @@ instance Read CompareOp where
                     )
 
 
-pattern VK_COMPARE_OP_NEVER = CompareOp 0
+pattern CompareOpNever = CompareOp 0
 
-pattern VK_COMPARE_OP_LESS = CompareOp 1
+pattern CompareOpLess = CompareOp 1
 
-pattern VK_COMPARE_OP_EQUAL = CompareOp 2
+pattern CompareOpEqual = CompareOp 2
 
-pattern VK_COMPARE_OP_LESS_OR_EQUAL = CompareOp 3
+pattern CompareOpLessOrEqual = CompareOp 3
 
-pattern VK_COMPARE_OP_GREATER = CompareOp 4
+pattern CompareOpGreater = CompareOp 4
 
-pattern VK_COMPARE_OP_NOT_EQUAL = CompareOp 5
+pattern CompareOpNotEqual = CompareOp 5
 
-pattern VK_COMPARE_OP_GREATER_OR_EQUAL = CompareOp 6
+pattern CompareOpGreaterOrEqual = CompareOp 6
 
-pattern VK_COMPARE_OP_ALWAYS = CompareOp 7
+pattern CompareOpAlways = CompareOp 7
 
 newtype Sampler = Sampler Word64
   deriving (Eq, Storable)
@@ -276,13 +276,13 @@ newtype SamplerMipmapMode = SamplerMipmapMode Int32
   deriving (Eq, Storable)
 
 instance Show SamplerMipmapMode where
-  showsPrec _ VK_SAMPLER_MIPMAP_MODE_NEAREST = showString "VK_SAMPLER_MIPMAP_MODE_NEAREST"
-  showsPrec _ VK_SAMPLER_MIPMAP_MODE_LINEAR = showString "VK_SAMPLER_MIPMAP_MODE_LINEAR"
+  showsPrec _ SamplerMipmapModeNearest = showString "SamplerMipmapModeNearest"
+  showsPrec _ SamplerMipmapModeLinear = showString "SamplerMipmapModeLinear"
   showsPrec p (SamplerMipmapMode x) = showParen (p >= 11) (showString "SamplerMipmapMode " . showsPrec 11 x)
 
 instance Read SamplerMipmapMode where
-  readPrec = parens ( choose [ ("VK_SAMPLER_MIPMAP_MODE_NEAREST", pure VK_SAMPLER_MIPMAP_MODE_NEAREST)
-                             , ("VK_SAMPLER_MIPMAP_MODE_LINEAR", pure VK_SAMPLER_MIPMAP_MODE_LINEAR)
+  readPrec = parens ( choose [ ("SamplerMipmapModeNearest", pure SamplerMipmapModeNearest)
+                             , ("SamplerMipmapModeLinear", pure SamplerMipmapModeLinear)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SamplerMipmapMode")
@@ -292,9 +292,9 @@ instance Read SamplerMipmapMode where
                     )
 
 -- | Choose nearest mip level
-pattern VK_SAMPLER_MIPMAP_MODE_NEAREST = SamplerMipmapMode 0
+pattern SamplerMipmapModeNearest = SamplerMipmapMode 0
 -- | Linear filter between mip levels
-pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = SamplerMipmapMode 1
+pattern SamplerMipmapModeLinear = SamplerMipmapMode 1
 
 -- ** createSampler
 foreign import ccall "vkCreateSampler" createSampler ::

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -296,8 +296,8 @@ pattern VK_SAMPLER_MIPMAP_MODE_NEAREST = SamplerMipmapMode 0
 -- | Linear filter between mip levels
 pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = SamplerMipmapMode 1
 
--- ** vkCreateSampler
-foreign import ccall "vkCreateSampler" vkCreateSampler ::
+-- ** createSampler
+foreign import ccall "vkCreateSampler" createSampler ::
   Device ->
   Ptr SamplerCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Sampler -> IO Result
@@ -350,7 +350,7 @@ pattern VK_SAMPLE_COUNT_32_BIT = SampleCountFlags 0x20
 pattern VK_SAMPLE_COUNT_64_BIT = SampleCountFlags 0x40
 
 
--- ** vkDestroySampler
-foreign import ccall "vkDestroySampler" vkDestroySampler ::
+-- ** destroySampler
+foreign import ccall "vkDestroySampler" destroySampler ::
   Device -> Sampler -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -34,10 +34,10 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
+import Graphics.Vulkan.Core( Bool32(..)
                            , StructureType(..)
-                           , VkBool32(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       )
@@ -213,14 +213,14 @@ data SamplerCreateInfo =
                    , addressModeV :: SamplerAddressMode 
                    , addressModeW :: SamplerAddressMode 
                    , mipLodBias :: CFloat 
-                   , anisotropyEnable :: VkBool32 
+                   , anisotropyEnable :: Bool32 
                    , maxAnisotropy :: CFloat 
-                   , compareEnable :: VkBool32 
+                   , compareEnable :: Bool32 
                    , compareOp :: CompareOp 
                    , minLod :: CFloat 
                    , maxLod :: CFloat 
                    , borderColor :: BorderColor 
-                   , unnormalizedCoordinates :: VkBool32 
+                   , unnormalizedCoordinates :: Bool32 
                    }
   deriving (Eq)
 
@@ -267,7 +267,7 @@ instance Storable SamplerCreateInfo where
 
 -- ** SamplerCreateFlags
 -- | Opaque flag
-newtype SamplerCreateFlags = SamplerCreateFlags VkFlags
+newtype SamplerCreateFlags = SamplerCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** SamplerMipmapMode
@@ -304,7 +304,7 @@ foreign import ccall "vkCreateSampler" vkCreateSampler ::
 
 -- ** VkSampleCountFlags
 
-newtype SampleCountFlags = SampleCountFlags VkFlags
+newtype SampleCountFlags = SampleCountFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SampleCountFlags where

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -308,24 +308,24 @@ newtype SampleCountFlags = SampleCountFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SampleCountFlags where
-  showsPrec _ VK_SAMPLE_COUNT_1_BIT = showString "VK_SAMPLE_COUNT_1_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_2_BIT = showString "VK_SAMPLE_COUNT_2_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_4_BIT = showString "VK_SAMPLE_COUNT_4_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_8_BIT = showString "VK_SAMPLE_COUNT_8_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_16_BIT = showString "VK_SAMPLE_COUNT_16_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_32_BIT = showString "VK_SAMPLE_COUNT_32_BIT"
-  showsPrec _ VK_SAMPLE_COUNT_64_BIT = showString "VK_SAMPLE_COUNT_64_BIT"
+  showsPrec _ SampleCount1Bit = showString "SampleCount1Bit"
+  showsPrec _ SampleCount2Bit = showString "SampleCount2Bit"
+  showsPrec _ SampleCount4Bit = showString "SampleCount4Bit"
+  showsPrec _ SampleCount8Bit = showString "SampleCount8Bit"
+  showsPrec _ SampleCount16Bit = showString "SampleCount16Bit"
+  showsPrec _ SampleCount32Bit = showString "SampleCount32Bit"
+  showsPrec _ SampleCount64Bit = showString "SampleCount64Bit"
   
   showsPrec p (SampleCountFlags x) = showParen (p >= 11) (showString "SampleCountFlags " . showsPrec 11 x)
 
 instance Read SampleCountFlags where
-  readPrec = parens ( choose [ ("VK_SAMPLE_COUNT_1_BIT", pure VK_SAMPLE_COUNT_1_BIT)
-                             , ("VK_SAMPLE_COUNT_2_BIT", pure VK_SAMPLE_COUNT_2_BIT)
-                             , ("VK_SAMPLE_COUNT_4_BIT", pure VK_SAMPLE_COUNT_4_BIT)
-                             , ("VK_SAMPLE_COUNT_8_BIT", pure VK_SAMPLE_COUNT_8_BIT)
-                             , ("VK_SAMPLE_COUNT_16_BIT", pure VK_SAMPLE_COUNT_16_BIT)
-                             , ("VK_SAMPLE_COUNT_32_BIT", pure VK_SAMPLE_COUNT_32_BIT)
-                             , ("VK_SAMPLE_COUNT_64_BIT", pure VK_SAMPLE_COUNT_64_BIT)
+  readPrec = parens ( choose [ ("SampleCount1Bit", pure SampleCount1Bit)
+                             , ("SampleCount2Bit", pure SampleCount2Bit)
+                             , ("SampleCount4Bit", pure SampleCount4Bit)
+                             , ("SampleCount8Bit", pure SampleCount8Bit)
+                             , ("SampleCount16Bit", pure SampleCount16Bit)
+                             , ("SampleCount32Bit", pure SampleCount32Bit)
+                             , ("SampleCount64Bit", pure SampleCount64Bit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SampleCountFlags")
@@ -335,19 +335,19 @@ instance Read SampleCountFlags where
                     )
 
 -- | Sample count 1 supported
-pattern VK_SAMPLE_COUNT_1_BIT = SampleCountFlags 0x1
+pattern SampleCount1Bit = SampleCountFlags 0x1
 -- | Sample count 2 supported
-pattern VK_SAMPLE_COUNT_2_BIT = SampleCountFlags 0x2
+pattern SampleCount2Bit = SampleCountFlags 0x2
 -- | Sample count 4 supported
-pattern VK_SAMPLE_COUNT_4_BIT = SampleCountFlags 0x4
+pattern SampleCount4Bit = SampleCountFlags 0x4
 -- | Sample count 8 supported
-pattern VK_SAMPLE_COUNT_8_BIT = SampleCountFlags 0x8
+pattern SampleCount8Bit = SampleCountFlags 0x8
 -- | Sample count 16 supported
-pattern VK_SAMPLE_COUNT_16_BIT = SampleCountFlags 0x10
+pattern SampleCount16Bit = SampleCountFlags 0x10
 -- | Sample count 32 supported
-pattern VK_SAMPLE_COUNT_32_BIT = SampleCountFlags 0x20
+pattern SampleCount32Bit = SampleCountFlags 0x20
 -- | Sample count 64 supported
-pattern VK_SAMPLE_COUNT_64_BIT = SampleCountFlags 0x40
+pattern SampleCount64Bit = SampleCountFlags 0x40
 
 
 -- ** destroySampler

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Sampler where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -23,6 +25,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -30,6 +34,20 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Sampler( VkCompareOp
+                              , VkFilter
+                              , Sampler
+                              , VkSamplerMipmapMode
+                              , VkBorderColor
+                              , VkSamplerAddressMode
+                              , VkSamplerCreateFlags
+                              , VkSamplerCreateInfo
+                              )
+import Graphics.Vulkan.Core( VkResult
+                           , VkBool32
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CFloat
                       )
 

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -34,28 +34,28 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
                            , VkBool32(..)
-                           , VkResult(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CFloat(..)
                       )
 
--- ** VkSamplerAddressMode
+-- ** SamplerAddressMode
 
-newtype VkSamplerAddressMode = VkSamplerAddressMode Int32
+newtype SamplerAddressMode = SamplerAddressMode Int32
   deriving (Eq, Storable)
 
-instance Show VkSamplerAddressMode where
+instance Show SamplerAddressMode where
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_REPEAT = showString "VK_SAMPLER_ADDRESS_MODE_REPEAT"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = showString "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE"
-  showsPrec p (VkSamplerAddressMode x) = showParen (p >= 11) (showString "VkSamplerAddressMode " . showsPrec 11 x)
+  showsPrec p (SamplerAddressMode x) = showParen (p >= 11) (showString "SamplerAddressMode " . showsPrec 11 x)
 
-instance Read VkSamplerAddressMode where
+instance Read SamplerAddressMode where
   readPrec = parens ( choose [ ("VK_SAMPLER_ADDRESS_MODE_REPEAT", pure VK_SAMPLER_ADDRESS_MODE_REPEAT)
                              , ("VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT", pure VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT)
                              , ("VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
@@ -63,64 +63,64 @@ instance Read VkSamplerAddressMode where
                              , ("VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSamplerAddressMode")
+                        expectP (Ident "SamplerAddressMode")
                         v <- step readPrec
-                        pure (VkSamplerAddressMode v)
+                        pure (SamplerAddressMode v)
                         )
                     )
 
 
-pattern VK_SAMPLER_ADDRESS_MODE_REPEAT = VkSamplerAddressMode 0
+pattern VK_SAMPLER_ADDRESS_MODE_REPEAT = SamplerAddressMode 0
 
-pattern VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = VkSamplerAddressMode 1
+pattern VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = SamplerAddressMode 1
 
-pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = VkSamplerAddressMode 2
+pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = SamplerAddressMode 2
 
-pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = VkSamplerAddressMode 3
+pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = SamplerAddressMode 3
 
-pattern VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = VkSamplerAddressMode 4
+pattern VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = SamplerAddressMode 4
 
--- ** VkFilter
+-- ** Filter
 
-newtype VkFilter = VkFilter Int32
+newtype Filter = Filter Int32
   deriving (Eq, Storable)
 
-instance Show VkFilter where
+instance Show Filter where
   showsPrec _ VK_FILTER_NEAREST = showString "VK_FILTER_NEAREST"
   showsPrec _ VK_FILTER_LINEAR = showString "VK_FILTER_LINEAR"
-  showsPrec p (VkFilter x) = showParen (p >= 11) (showString "VkFilter " . showsPrec 11 x)
+  showsPrec p (Filter x) = showParen (p >= 11) (showString "Filter " . showsPrec 11 x)
 
-instance Read VkFilter where
+instance Read Filter where
   readPrec = parens ( choose [ ("VK_FILTER_NEAREST", pure VK_FILTER_NEAREST)
                              , ("VK_FILTER_LINEAR", pure VK_FILTER_LINEAR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkFilter")
+                        expectP (Ident "Filter")
                         v <- step readPrec
-                        pure (VkFilter v)
+                        pure (Filter v)
                         )
                     )
 
 
-pattern VK_FILTER_NEAREST = VkFilter 0
+pattern VK_FILTER_NEAREST = Filter 0
 
-pattern VK_FILTER_LINEAR = VkFilter 1
+pattern VK_FILTER_LINEAR = Filter 1
 
--- ** VkBorderColor
+-- ** BorderColor
 
-newtype VkBorderColor = VkBorderColor Int32
+newtype BorderColor = BorderColor Int32
   deriving (Eq, Storable)
 
-instance Show VkBorderColor where
+instance Show BorderColor where
   showsPrec _ VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = showString "VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK"
   showsPrec _ VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = showString "VK_BORDER_COLOR_INT_TRANSPARENT_BLACK"
   showsPrec _ VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = showString "VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK"
   showsPrec _ VK_BORDER_COLOR_INT_OPAQUE_BLACK = showString "VK_BORDER_COLOR_INT_OPAQUE_BLACK"
   showsPrec _ VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE = showString "VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE"
   showsPrec _ VK_BORDER_COLOR_INT_OPAQUE_WHITE = showString "VK_BORDER_COLOR_INT_OPAQUE_WHITE"
-  showsPrec p (VkBorderColor x) = showParen (p >= 11) (showString "VkBorderColor " . showsPrec 11 x)
+  showsPrec p (BorderColor x) = showParen (p >= 11) (showString "BorderColor " . showsPrec 11 x)
 
-instance Read VkBorderColor where
+instance Read BorderColor where
   readPrec = parens ( choose [ ("VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK", pure VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)
                              , ("VK_BORDER_COLOR_INT_TRANSPARENT_BLACK", pure VK_BORDER_COLOR_INT_TRANSPARENT_BLACK)
                              , ("VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK", pure VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK)
@@ -129,31 +129,31 @@ instance Read VkBorderColor where
                              , ("VK_BORDER_COLOR_INT_OPAQUE_WHITE", pure VK_BORDER_COLOR_INT_OPAQUE_WHITE)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkBorderColor")
+                        expectP (Ident "BorderColor")
                         v <- step readPrec
-                        pure (VkBorderColor v)
+                        pure (BorderColor v)
                         )
                     )
 
 
-pattern VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = VkBorderColor 0
+pattern VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK = BorderColor 0
 
-pattern VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = VkBorderColor 1
+pattern VK_BORDER_COLOR_INT_TRANSPARENT_BLACK = BorderColor 1
 
-pattern VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = VkBorderColor 2
+pattern VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK = BorderColor 2
 
-pattern VK_BORDER_COLOR_INT_OPAQUE_BLACK = VkBorderColor 3
+pattern VK_BORDER_COLOR_INT_OPAQUE_BLACK = BorderColor 3
 
-pattern VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE = VkBorderColor 4
+pattern VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE = BorderColor 4
 
-pattern VK_BORDER_COLOR_INT_OPAQUE_WHITE = VkBorderColor 5
+pattern VK_BORDER_COLOR_INT_OPAQUE_WHITE = BorderColor 5
 
--- ** VkCompareOp
+-- ** CompareOp
 
-newtype VkCompareOp = VkCompareOp Int32
+newtype CompareOp = CompareOp Int32
   deriving (Eq, Storable)
 
-instance Show VkCompareOp where
+instance Show CompareOp where
   showsPrec _ VK_COMPARE_OP_NEVER = showString "VK_COMPARE_OP_NEVER"
   showsPrec _ VK_COMPARE_OP_LESS = showString "VK_COMPARE_OP_LESS"
   showsPrec _ VK_COMPARE_OP_EQUAL = showString "VK_COMPARE_OP_EQUAL"
@@ -162,9 +162,9 @@ instance Show VkCompareOp where
   showsPrec _ VK_COMPARE_OP_NOT_EQUAL = showString "VK_COMPARE_OP_NOT_EQUAL"
   showsPrec _ VK_COMPARE_OP_GREATER_OR_EQUAL = showString "VK_COMPARE_OP_GREATER_OR_EQUAL"
   showsPrec _ VK_COMPARE_OP_ALWAYS = showString "VK_COMPARE_OP_ALWAYS"
-  showsPrec p (VkCompareOp x) = showParen (p >= 11) (showString "VkCompareOp " . showsPrec 11 x)
+  showsPrec p (CompareOp x) = showParen (p >= 11) (showString "CompareOp " . showsPrec 11 x)
 
-instance Read VkCompareOp where
+instance Read CompareOp where
   readPrec = parens ( choose [ ("VK_COMPARE_OP_NEVER", pure VK_COMPARE_OP_NEVER)
                              , ("VK_COMPARE_OP_LESS", pure VK_COMPARE_OP_LESS)
                              , ("VK_COMPARE_OP_EQUAL", pure VK_COMPARE_OP_EQUAL)
@@ -175,51 +175,51 @@ instance Read VkCompareOp where
                              , ("VK_COMPARE_OP_ALWAYS", pure VK_COMPARE_OP_ALWAYS)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkCompareOp")
+                        expectP (Ident "CompareOp")
                         v <- step readPrec
-                        pure (VkCompareOp v)
+                        pure (CompareOp v)
                         )
                     )
 
 
-pattern VK_COMPARE_OP_NEVER = VkCompareOp 0
+pattern VK_COMPARE_OP_NEVER = CompareOp 0
 
-pattern VK_COMPARE_OP_LESS = VkCompareOp 1
+pattern VK_COMPARE_OP_LESS = CompareOp 1
 
-pattern VK_COMPARE_OP_EQUAL = VkCompareOp 2
+pattern VK_COMPARE_OP_EQUAL = CompareOp 2
 
-pattern VK_COMPARE_OP_LESS_OR_EQUAL = VkCompareOp 3
+pattern VK_COMPARE_OP_LESS_OR_EQUAL = CompareOp 3
 
-pattern VK_COMPARE_OP_GREATER = VkCompareOp 4
+pattern VK_COMPARE_OP_GREATER = CompareOp 4
 
-pattern VK_COMPARE_OP_NOT_EQUAL = VkCompareOp 5
+pattern VK_COMPARE_OP_NOT_EQUAL = CompareOp 5
 
-pattern VK_COMPARE_OP_GREATER_OR_EQUAL = VkCompareOp 6
+pattern VK_COMPARE_OP_GREATER_OR_EQUAL = CompareOp 6
 
-pattern VK_COMPARE_OP_ALWAYS = VkCompareOp 7
+pattern VK_COMPARE_OP_ALWAYS = CompareOp 7
 
 newtype Sampler = Sampler Word64
   deriving (Eq, Storable)
 
 
 data SamplerCreateInfo =
-  SamplerCreateInfo{ sType :: VkStructureType 
+  SamplerCreateInfo{ sType :: StructureType 
                    , pNext :: Ptr Void 
-                   , flags :: VkSamplerCreateFlags 
-                   , magFilter :: VkFilter 
-                   , minFilter :: VkFilter 
-                   , mipmapMode :: VkSamplerMipmapMode 
-                   , addressModeU :: VkSamplerAddressMode 
-                   , addressModeV :: VkSamplerAddressMode 
-                   , addressModeW :: VkSamplerAddressMode 
+                   , flags :: SamplerCreateFlags 
+                   , magFilter :: Filter 
+                   , minFilter :: Filter 
+                   , mipmapMode :: SamplerMipmapMode 
+                   , addressModeU :: SamplerAddressMode 
+                   , addressModeV :: SamplerAddressMode 
+                   , addressModeW :: SamplerAddressMode 
                    , mipLodBias :: CFloat 
                    , anisotropyEnable :: VkBool32 
                    , maxAnisotropy :: CFloat 
                    , compareEnable :: VkBool32 
-                   , compareOp :: VkCompareOp 
+                   , compareOp :: CompareOp 
                    , minLod :: CFloat 
                    , maxLod :: CFloat 
-                   , borderColor :: VkBorderColor 
+                   , borderColor :: BorderColor 
                    , unnormalizedCoordinates :: VkBool32 
                    }
   deriving (Eq)
@@ -265,49 +265,49 @@ instance Storable SamplerCreateInfo where
                 *> poke (ptr `plusPtr` 76) (unnormalizedCoordinates (poked :: SamplerCreateInfo))
 
 
--- ** VkSamplerCreateFlags
+-- ** SamplerCreateFlags
 -- | Opaque flag
-newtype VkSamplerCreateFlags = VkSamplerCreateFlags VkFlags
+newtype SamplerCreateFlags = SamplerCreateFlags VkFlags
   deriving (Eq, Storable)
 
--- ** VkSamplerMipmapMode
+-- ** SamplerMipmapMode
 
-newtype VkSamplerMipmapMode = VkSamplerMipmapMode Int32
+newtype SamplerMipmapMode = SamplerMipmapMode Int32
   deriving (Eq, Storable)
 
-instance Show VkSamplerMipmapMode where
+instance Show SamplerMipmapMode where
   showsPrec _ VK_SAMPLER_MIPMAP_MODE_NEAREST = showString "VK_SAMPLER_MIPMAP_MODE_NEAREST"
   showsPrec _ VK_SAMPLER_MIPMAP_MODE_LINEAR = showString "VK_SAMPLER_MIPMAP_MODE_LINEAR"
-  showsPrec p (VkSamplerMipmapMode x) = showParen (p >= 11) (showString "VkSamplerMipmapMode " . showsPrec 11 x)
+  showsPrec p (SamplerMipmapMode x) = showParen (p >= 11) (showString "SamplerMipmapMode " . showsPrec 11 x)
 
-instance Read VkSamplerMipmapMode where
+instance Read SamplerMipmapMode where
   readPrec = parens ( choose [ ("VK_SAMPLER_MIPMAP_MODE_NEAREST", pure VK_SAMPLER_MIPMAP_MODE_NEAREST)
                              , ("VK_SAMPLER_MIPMAP_MODE_LINEAR", pure VK_SAMPLER_MIPMAP_MODE_LINEAR)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSamplerMipmapMode")
+                        expectP (Ident "SamplerMipmapMode")
                         v <- step readPrec
-                        pure (VkSamplerMipmapMode v)
+                        pure (SamplerMipmapMode v)
                         )
                     )
 
 -- | Choose nearest mip level
-pattern VK_SAMPLER_MIPMAP_MODE_NEAREST = VkSamplerMipmapMode 0
+pattern VK_SAMPLER_MIPMAP_MODE_NEAREST = SamplerMipmapMode 0
 -- | Linear filter between mip levels
-pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = VkSamplerMipmapMode 1
+pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = SamplerMipmapMode 1
 
 -- ** vkCreateSampler
 foreign import ccall "vkCreateSampler" vkCreateSampler ::
   Device ->
   Ptr SamplerCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr Sampler -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr Sampler -> IO Result
 
 -- ** VkSampleCountFlags
 
-newtype VkSampleCountFlags = VkSampleCountFlags VkFlags
+newtype SampleCountFlags = SampleCountFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkSampleCountFlags where
+instance Show SampleCountFlags where
   showsPrec _ VK_SAMPLE_COUNT_1_BIT = showString "VK_SAMPLE_COUNT_1_BIT"
   showsPrec _ VK_SAMPLE_COUNT_2_BIT = showString "VK_SAMPLE_COUNT_2_BIT"
   showsPrec _ VK_SAMPLE_COUNT_4_BIT = showString "VK_SAMPLE_COUNT_4_BIT"
@@ -316,9 +316,9 @@ instance Show VkSampleCountFlags where
   showsPrec _ VK_SAMPLE_COUNT_32_BIT = showString "VK_SAMPLE_COUNT_32_BIT"
   showsPrec _ VK_SAMPLE_COUNT_64_BIT = showString "VK_SAMPLE_COUNT_64_BIT"
   
-  showsPrec p (VkSampleCountFlags x) = showParen (p >= 11) (showString "VkSampleCountFlags " . showsPrec 11 x)
+  showsPrec p (SampleCountFlags x) = showParen (p >= 11) (showString "SampleCountFlags " . showsPrec 11 x)
 
-instance Read VkSampleCountFlags where
+instance Read SampleCountFlags where
   readPrec = parens ( choose [ ("VK_SAMPLE_COUNT_1_BIT", pure VK_SAMPLE_COUNT_1_BIT)
                              , ("VK_SAMPLE_COUNT_2_BIT", pure VK_SAMPLE_COUNT_2_BIT)
                              , ("VK_SAMPLE_COUNT_4_BIT", pure VK_SAMPLE_COUNT_4_BIT)
@@ -328,26 +328,26 @@ instance Read VkSampleCountFlags where
                              , ("VK_SAMPLE_COUNT_64_BIT", pure VK_SAMPLE_COUNT_64_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSampleCountFlags")
+                        expectP (Ident "SampleCountFlags")
                         v <- step readPrec
-                        pure (VkSampleCountFlags v)
+                        pure (SampleCountFlags v)
                         )
                     )
 
 -- | Sample count 1 supported
-pattern VK_SAMPLE_COUNT_1_BIT = VkSampleCountFlags 0x1
+pattern VK_SAMPLE_COUNT_1_BIT = SampleCountFlags 0x1
 -- | Sample count 2 supported
-pattern VK_SAMPLE_COUNT_2_BIT = VkSampleCountFlags 0x2
+pattern VK_SAMPLE_COUNT_2_BIT = SampleCountFlags 0x2
 -- | Sample count 4 supported
-pattern VK_SAMPLE_COUNT_4_BIT = VkSampleCountFlags 0x4
+pattern VK_SAMPLE_COUNT_4_BIT = SampleCountFlags 0x4
 -- | Sample count 8 supported
-pattern VK_SAMPLE_COUNT_8_BIT = VkSampleCountFlags 0x8
+pattern VK_SAMPLE_COUNT_8_BIT = SampleCountFlags 0x8
 -- | Sample count 16 supported
-pattern VK_SAMPLE_COUNT_16_BIT = VkSampleCountFlags 0x10
+pattern VK_SAMPLE_COUNT_16_BIT = SampleCountFlags 0x10
 -- | Sample count 32 supported
-pattern VK_SAMPLE_COUNT_32_BIT = VkSampleCountFlags 0x20
+pattern VK_SAMPLE_COUNT_32_BIT = SampleCountFlags 0x20
 -- | Sample count 64 supported
-pattern VK_SAMPLE_COUNT_64_BIT = VkSampleCountFlags 0x40
+pattern VK_SAMPLE_COUNT_64_BIT = SampleCountFlags 0x40
 
 
 -- ** vkDestroySampler

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -25,7 +25,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -202,67 +202,67 @@ newtype Sampler = Sampler Word64
   deriving (Eq, Storable)
 
 
-data VkSamplerCreateInfo =
-  VkSamplerCreateInfo{ sType :: VkStructureType 
-                     , pNext :: Ptr Void 
-                     , flags :: VkSamplerCreateFlags 
-                     , magFilter :: VkFilter 
-                     , minFilter :: VkFilter 
-                     , mipmapMode :: VkSamplerMipmapMode 
-                     , addressModeU :: VkSamplerAddressMode 
-                     , addressModeV :: VkSamplerAddressMode 
-                     , addressModeW :: VkSamplerAddressMode 
-                     , mipLodBias :: CFloat 
-                     , anisotropyEnable :: VkBool32 
-                     , maxAnisotropy :: CFloat 
-                     , compareEnable :: VkBool32 
-                     , compareOp :: VkCompareOp 
-                     , minLod :: CFloat 
-                     , maxLod :: CFloat 
-                     , borderColor :: VkBorderColor 
-                     , unnormalizedCoordinates :: VkBool32 
-                     }
+data SamplerCreateInfo =
+  SamplerCreateInfo{ sType :: VkStructureType 
+                   , pNext :: Ptr Void 
+                   , flags :: VkSamplerCreateFlags 
+                   , magFilter :: VkFilter 
+                   , minFilter :: VkFilter 
+                   , mipmapMode :: VkSamplerMipmapMode 
+                   , addressModeU :: VkSamplerAddressMode 
+                   , addressModeV :: VkSamplerAddressMode 
+                   , addressModeW :: VkSamplerAddressMode 
+                   , mipLodBias :: CFloat 
+                   , anisotropyEnable :: VkBool32 
+                   , maxAnisotropy :: CFloat 
+                   , compareEnable :: VkBool32 
+                   , compareOp :: VkCompareOp 
+                   , minLod :: CFloat 
+                   , maxLod :: CFloat 
+                   , borderColor :: VkBorderColor 
+                   , unnormalizedCoordinates :: VkBool32 
+                   }
   deriving (Eq)
 
-instance Storable VkSamplerCreateInfo where
+instance Storable SamplerCreateInfo where
   sizeOf ~_ = 80
   alignment ~_ = 8
-  peek ptr = VkSamplerCreateInfo <$> peek (ptr `plusPtr` 0)
-                                 <*> peek (ptr `plusPtr` 8)
-                                 <*> peek (ptr `plusPtr` 16)
-                                 <*> peek (ptr `plusPtr` 20)
-                                 <*> peek (ptr `plusPtr` 24)
-                                 <*> peek (ptr `plusPtr` 28)
-                                 <*> peek (ptr `plusPtr` 32)
-                                 <*> peek (ptr `plusPtr` 36)
-                                 <*> peek (ptr `plusPtr` 40)
-                                 <*> peek (ptr `plusPtr` 44)
-                                 <*> peek (ptr `plusPtr` 48)
-                                 <*> peek (ptr `plusPtr` 52)
-                                 <*> peek (ptr `plusPtr` 56)
-                                 <*> peek (ptr `plusPtr` 60)
-                                 <*> peek (ptr `plusPtr` 64)
-                                 <*> peek (ptr `plusPtr` 68)
-                                 <*> peek (ptr `plusPtr` 72)
-                                 <*> peek (ptr `plusPtr` 76)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 20) (magFilter (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 24) (minFilter (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 28) (mipmapMode (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 32) (addressModeU (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 36) (addressModeV (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 40) (addressModeW (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 44) (mipLodBias (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 48) (anisotropyEnable (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 52) (maxAnisotropy (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 56) (compareEnable (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 60) (compareOp (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 64) (minLod (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 68) (maxLod (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 72) (borderColor (poked :: VkSamplerCreateInfo))
-                *> poke (ptr `plusPtr` 76) (unnormalizedCoordinates (poked :: VkSamplerCreateInfo))
+  peek ptr = SamplerCreateInfo <$> peek (ptr `plusPtr` 0)
+                               <*> peek (ptr `plusPtr` 8)
+                               <*> peek (ptr `plusPtr` 16)
+                               <*> peek (ptr `plusPtr` 20)
+                               <*> peek (ptr `plusPtr` 24)
+                               <*> peek (ptr `plusPtr` 28)
+                               <*> peek (ptr `plusPtr` 32)
+                               <*> peek (ptr `plusPtr` 36)
+                               <*> peek (ptr `plusPtr` 40)
+                               <*> peek (ptr `plusPtr` 44)
+                               <*> peek (ptr `plusPtr` 48)
+                               <*> peek (ptr `plusPtr` 52)
+                               <*> peek (ptr `plusPtr` 56)
+                               <*> peek (ptr `plusPtr` 60)
+                               <*> peek (ptr `plusPtr` 64)
+                               <*> peek (ptr `plusPtr` 68)
+                               <*> peek (ptr `plusPtr` 72)
+                               <*> peek (ptr `plusPtr` 76)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 20) (magFilter (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 24) (minFilter (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 28) (mipmapMode (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 32) (addressModeU (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 36) (addressModeV (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 40) (addressModeW (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 44) (mipLodBias (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 48) (anisotropyEnable (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 52) (maxAnisotropy (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 56) (compareEnable (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 60) (compareOp (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 64) (minLod (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 68) (maxLod (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 72) (borderColor (poked :: SamplerCreateInfo))
+                *> poke (ptr `plusPtr` 76) (unnormalizedCoordinates (poked :: SamplerCreateInfo))
 
 
 -- ** VkSamplerCreateFlags
@@ -299,8 +299,8 @@ pattern VK_SAMPLER_MIPMAP_MODE_LINEAR = VkSamplerMipmapMode 1
 -- ** vkCreateSampler
 foreign import ccall "vkCreateSampler" vkCreateSampler ::
   Device ->
-  Ptr VkSamplerCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr Sampler -> IO VkResult
+  Ptr SamplerCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr Sampler -> IO VkResult
 
 -- ** VkSampleCountFlags
 
@@ -352,5 +352,5 @@ pattern VK_SAMPLE_COUNT_64_BIT = VkSampleCountFlags 0x40
 
 -- ** vkDestroySampler
 foreign import ccall "vkDestroySampler" vkDestroySampler ::
-  Device -> Sampler -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> Sampler -> Ptr AllocationCallbacks -> IO ()
 

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -45,7 +45,7 @@ import Foreign.C.Types( CFloat(..)
 -- ** SamplerAddressMode
 
 newtype SamplerAddressMode = SamplerAddressMode Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show SamplerAddressMode where
   showsPrec _ SamplerAddressModeRepeat = showString "SamplerAddressModeRepeat"
@@ -83,7 +83,7 @@ pattern SamplerAddressModeMirrorClampToEdge = SamplerAddressMode 4
 -- ** Filter
 
 newtype Filter = Filter Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show Filter where
   showsPrec _ FilterNearest = showString "FilterNearest"
@@ -109,7 +109,7 @@ pattern FilterLinear = Filter 1
 -- ** BorderColor
 
 newtype BorderColor = BorderColor Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show BorderColor where
   showsPrec _ BorderColorFloatTransparentBlack = showString "BorderColorFloatTransparentBlack"
@@ -151,7 +151,7 @@ pattern BorderColorIntOpaqueWhite = BorderColor 5
 -- ** CompareOp
 
 newtype CompareOp = CompareOp Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show CompareOp where
   showsPrec _ CompareOpNever = showString "CompareOpNever"
@@ -199,7 +199,7 @@ pattern CompareOpGreaterOrEqual = CompareOp 6
 pattern CompareOpAlways = CompareOp 7
 
 newtype Sampler = Sampler Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 
 data SamplerCreateInfo =
@@ -222,7 +222,7 @@ data SamplerCreateInfo =
                    , borderColor :: BorderColor 
                    , unnormalizedCoordinates :: Bool32 
                    }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SamplerCreateInfo where
   sizeOf ~_ = 80
@@ -268,12 +268,12 @@ instance Storable SamplerCreateInfo where
 -- ** SamplerCreateFlags
 -- | Opaque flag
 newtype SamplerCreateFlags = SamplerCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** SamplerMipmapMode
 
 newtype SamplerMipmapMode = SamplerMipmapMode Int32
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 instance Show SamplerMipmapMode where
   showsPrec _ SamplerMipmapModeNearest = showString "SamplerMipmapModeNearest"
@@ -305,7 +305,7 @@ foreign import ccall "vkCreateSampler" createSampler ::
 -- ** SampleCountFlags
 
 newtype SampleCountFlags = SampleCountFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show SampleCountFlags where
   showsPrec _ SampleCount1Bit = showString "SampleCount1Bit"

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -4,16 +4,16 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Sampler where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
+import Data.Word( Word64(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Int( Int32
@@ -23,9 +23,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -34,21 +34,12 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkCompareOp
-                              , VkFilter
-                              , Sampler
-                              , VkSamplerMipmapMode
-                              , VkBorderColor
-                              , VkSamplerAddressMode
-                              , VkSamplerCreateFlags
-                              , VkSamplerCreateInfo
-                              )
-import Graphics.Vulkan.Core( VkResult
-                           , VkBool32
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkBool32(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CFloat
+import Foreign.C.Types( CFloat(..)
                       )
 
 -- ** VkSamplerAddressMode
@@ -313,13 +304,10 @@ foreign import ccall "vkCreateSampler" vkCreateSampler ::
 
 -- ** VkSampleCountFlags
 
-newtype VkSampleCountFlagBits = VkSampleCountFlagBits VkFlags
+newtype VkSampleCountFlags = VkSampleCountFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkSampleCountFlagBits
-type VkSampleCountFlags = VkSampleCountFlagBits
-
-instance Show VkSampleCountFlagBits where
+instance Show VkSampleCountFlags where
   showsPrec _ VK_SAMPLE_COUNT_1_BIT = showString "VK_SAMPLE_COUNT_1_BIT"
   showsPrec _ VK_SAMPLE_COUNT_2_BIT = showString "VK_SAMPLE_COUNT_2_BIT"
   showsPrec _ VK_SAMPLE_COUNT_4_BIT = showString "VK_SAMPLE_COUNT_4_BIT"
@@ -328,9 +316,9 @@ instance Show VkSampleCountFlagBits where
   showsPrec _ VK_SAMPLE_COUNT_32_BIT = showString "VK_SAMPLE_COUNT_32_BIT"
   showsPrec _ VK_SAMPLE_COUNT_64_BIT = showString "VK_SAMPLE_COUNT_64_BIT"
   
-  showsPrec p (VkSampleCountFlagBits x) = showParen (p >= 11) (showString "VkSampleCountFlagBits " . showsPrec 11 x)
+  showsPrec p (VkSampleCountFlags x) = showParen (p >= 11) (showString "VkSampleCountFlags " . showsPrec 11 x)
 
-instance Read VkSampleCountFlagBits where
+instance Read VkSampleCountFlags where
   readPrec = parens ( choose [ ("VK_SAMPLE_COUNT_1_BIT", pure VK_SAMPLE_COUNT_1_BIT)
                              , ("VK_SAMPLE_COUNT_2_BIT", pure VK_SAMPLE_COUNT_2_BIT)
                              , ("VK_SAMPLE_COUNT_4_BIT", pure VK_SAMPLE_COUNT_4_BIT)
@@ -340,26 +328,26 @@ instance Read VkSampleCountFlagBits where
                              , ("VK_SAMPLE_COUNT_64_BIT", pure VK_SAMPLE_COUNT_64_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSampleCountFlagBits")
+                        expectP (Ident "VkSampleCountFlags")
                         v <- step readPrec
-                        pure (VkSampleCountFlagBits v)
+                        pure (VkSampleCountFlags v)
                         )
                     )
 
 -- | Sample count 1 supported
-pattern VK_SAMPLE_COUNT_1_BIT = VkSampleCountFlagBits 0x1
+pattern VK_SAMPLE_COUNT_1_BIT = VkSampleCountFlags 0x1
 -- | Sample count 2 supported
-pattern VK_SAMPLE_COUNT_2_BIT = VkSampleCountFlagBits 0x2
+pattern VK_SAMPLE_COUNT_2_BIT = VkSampleCountFlags 0x2
 -- | Sample count 4 supported
-pattern VK_SAMPLE_COUNT_4_BIT = VkSampleCountFlagBits 0x4
+pattern VK_SAMPLE_COUNT_4_BIT = VkSampleCountFlags 0x4
 -- | Sample count 8 supported
-pattern VK_SAMPLE_COUNT_8_BIT = VkSampleCountFlagBits 0x8
+pattern VK_SAMPLE_COUNT_8_BIT = VkSampleCountFlags 0x8
 -- | Sample count 16 supported
-pattern VK_SAMPLE_COUNT_16_BIT = VkSampleCountFlagBits 0x10
+pattern VK_SAMPLE_COUNT_16_BIT = VkSampleCountFlags 0x10
 -- | Sample count 32 supported
-pattern VK_SAMPLE_COUNT_32_BIT = VkSampleCountFlagBits 0x20
+pattern VK_SAMPLE_COUNT_32_BIT = VkSampleCountFlags 0x20
 -- | Sample count 64 supported
-pattern VK_SAMPLE_COUNT_64_BIT = VkSampleCountFlagBits 0x40
+pattern VK_SAMPLE_COUNT_64_BIT = VkSampleCountFlags 0x40
 
 
 -- ** vkDestroySampler

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -302,7 +302,7 @@ foreign import ccall "vkCreateSampler" createSampler ::
   Ptr SamplerCreateInfo ->
     Ptr AllocationCallbacks -> Ptr Sampler -> IO Result
 
--- ** VkSampleCountFlags
+-- ** SampleCountFlags
 
 newtype SampleCountFlags = SampleCountFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -4,8 +4,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Shader where
 
-import Graphics.Vulkan.Device( Device(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -24,15 +22,6 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
-                             , PFN_vkAllocationFunction
-                             , PFN_vkReallocationFunction
-                             , PFN_vkInternalAllocationNotification
-                             , VkAllocationCallbacks(..)
-                             , VkSystemAllocationScope(..)
-                             , PFN_vkFreeFunction
-                             , PFN_vkInternalFreeNotification
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -40,12 +29,7 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkResult(..)
-                           , VkFlags(..)
-                           , VkStructureType(..)
-                           )
 import Foreign.C.Types( CSize
-                      , CSize(..)
                       )
 
 

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Shader where
 
-import Graphics.Vulkan.Device( VkDevice(..)
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -50,11 +50,11 @@ import Foreign.C.Types( CSize
 
 
 data VkShaderModuleCreateInfo =
-  VkShaderModuleCreateInfo{ vkSType :: VkStructureType 
-                          , vkPNext :: Ptr Void 
-                          , vkFlags :: VkShaderModuleCreateFlags 
-                          , vkCodeSize :: CSize 
-                          , vkPCode :: Ptr Word32 
+  VkShaderModuleCreateInfo{ sType :: VkStructureType 
+                          , pNext :: Ptr Void 
+                          , flags :: VkShaderModuleCreateFlags 
+                          , codeSize :: CSize 
+                          , pCode :: Ptr Word32 
                           }
   deriving (Eq)
 
@@ -66,16 +66,16 @@ instance Storable VkShaderModuleCreateInfo where
                                       <*> peek (ptr `plusPtr` 16)
                                       <*> peek (ptr `plusPtr` 24)
                                       <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 24) (vkCodeSize (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 32) (vkPCode (poked :: VkShaderModuleCreateInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 24) (codeSize (poked :: VkShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pCode (poked :: VkShaderModuleCreateInfo))
 
 
 -- ** vkDestroyShaderModule
 foreign import ccall "vkDestroyShaderModule" vkDestroyShaderModule ::
-  VkDevice -> VkShaderModule -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> ShaderModule -> Ptr VkAllocationCallbacks -> IO ()
 
 -- ** VkShaderModuleCreateFlags
 -- | Opaque flag
@@ -135,12 +135,12 @@ pattern VK_SHADER_STAGE_ALL_GRAPHICS = VkShaderStageFlagBits 0x1f
 
 pattern VK_SHADER_STAGE_ALL = VkShaderStageFlagBits 0x7fffffff
 
-newtype VkShaderModule = VkShaderModule Word64
+newtype ShaderModule = ShaderModule Word64
   deriving (Eq, Storable)
 
 -- ** vkCreateShaderModule
 foreign import ccall "vkCreateShaderModule" vkCreateShaderModule ::
-  VkDevice ->
+  Device ->
   Ptr VkShaderModuleCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr VkShaderModule -> IO VkResult
+    Ptr VkAllocationCallbacks -> Ptr ShaderModule -> IO VkResult
 

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -80,25 +80,25 @@ newtype ShaderStageFlags = ShaderStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ShaderStageFlags where
-  showsPrec _ VK_SHADER_STAGE_VERTEX_BIT = showString "VK_SHADER_STAGE_VERTEX_BIT"
-  showsPrec _ VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = showString "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT"
-  showsPrec _ VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = showString "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT"
-  showsPrec _ VK_SHADER_STAGE_GEOMETRY_BIT = showString "VK_SHADER_STAGE_GEOMETRY_BIT"
-  showsPrec _ VK_SHADER_STAGE_FRAGMENT_BIT = showString "VK_SHADER_STAGE_FRAGMENT_BIT"
-  showsPrec _ VK_SHADER_STAGE_COMPUTE_BIT = showString "VK_SHADER_STAGE_COMPUTE_BIT"
-  showsPrec _ VK_SHADER_STAGE_ALL_GRAPHICS = showString "VK_SHADER_STAGE_ALL_GRAPHICS"
-  showsPrec _ VK_SHADER_STAGE_ALL = showString "VK_SHADER_STAGE_ALL"
+  showsPrec _ ShaderStageVertexBit = showString "ShaderStageVertexBit"
+  showsPrec _ ShaderStageTessellationControlBit = showString "ShaderStageTessellationControlBit"
+  showsPrec _ ShaderStageTessellationEvaluationBit = showString "ShaderStageTessellationEvaluationBit"
+  showsPrec _ ShaderStageGeometryBit = showString "ShaderStageGeometryBit"
+  showsPrec _ ShaderStageFragmentBit = showString "ShaderStageFragmentBit"
+  showsPrec _ ShaderStageComputeBit = showString "ShaderStageComputeBit"
+  showsPrec _ ShaderStageAllGraphics = showString "ShaderStageAllGraphics"
+  showsPrec _ ShaderStageAll = showString "ShaderStageAll"
   showsPrec p (ShaderStageFlags x) = showParen (p >= 11) (showString "ShaderStageFlags " . showsPrec 11 x)
 
 instance Read ShaderStageFlags where
-  readPrec = parens ( choose [ ("VK_SHADER_STAGE_VERTEX_BIT", pure VK_SHADER_STAGE_VERTEX_BIT)
-                             , ("VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT", pure VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
-                             , ("VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT", pure VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
-                             , ("VK_SHADER_STAGE_GEOMETRY_BIT", pure VK_SHADER_STAGE_GEOMETRY_BIT)
-                             , ("VK_SHADER_STAGE_FRAGMENT_BIT", pure VK_SHADER_STAGE_FRAGMENT_BIT)
-                             , ("VK_SHADER_STAGE_COMPUTE_BIT", pure VK_SHADER_STAGE_COMPUTE_BIT)
-                             , ("VK_SHADER_STAGE_ALL_GRAPHICS", pure VK_SHADER_STAGE_ALL_GRAPHICS)
-                             , ("VK_SHADER_STAGE_ALL", pure VK_SHADER_STAGE_ALL)
+  readPrec = parens ( choose [ ("ShaderStageVertexBit", pure ShaderStageVertexBit)
+                             , ("ShaderStageTessellationControlBit", pure ShaderStageTessellationControlBit)
+                             , ("ShaderStageTessellationEvaluationBit", pure ShaderStageTessellationEvaluationBit)
+                             , ("ShaderStageGeometryBit", pure ShaderStageGeometryBit)
+                             , ("ShaderStageFragmentBit", pure ShaderStageFragmentBit)
+                             , ("ShaderStageComputeBit", pure ShaderStageComputeBit)
+                             , ("ShaderStageAllGraphics", pure ShaderStageAllGraphics)
+                             , ("ShaderStageAll", pure ShaderStageAll)
                              ] +++
                       prec 10 (do
                         expectP (Ident "ShaderStageFlags")
@@ -108,21 +108,21 @@ instance Read ShaderStageFlags where
                     )
 
 
-pattern VK_SHADER_STAGE_VERTEX_BIT = ShaderStageFlags 0x1
+pattern ShaderStageVertexBit = ShaderStageFlags 0x1
 
-pattern VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = ShaderStageFlags 0x2
+pattern ShaderStageTessellationControlBit = ShaderStageFlags 0x2
 
-pattern VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = ShaderStageFlags 0x4
+pattern ShaderStageTessellationEvaluationBit = ShaderStageFlags 0x4
 
-pattern VK_SHADER_STAGE_GEOMETRY_BIT = ShaderStageFlags 0x8
+pattern ShaderStageGeometryBit = ShaderStageFlags 0x8
 
-pattern VK_SHADER_STAGE_FRAGMENT_BIT = ShaderStageFlags 0x10
+pattern ShaderStageFragmentBit = ShaderStageFlags 0x10
 
-pattern VK_SHADER_STAGE_COMPUTE_BIT = ShaderStageFlags 0x20
+pattern ShaderStageComputeBit = ShaderStageFlags 0x20
 
-pattern VK_SHADER_STAGE_ALL_GRAPHICS = ShaderStageFlags 0x1f
+pattern ShaderStageAllGraphics = ShaderStageFlags 0x1f
 
-pattern VK_SHADER_STAGE_ALL = ShaderStageFlags 0x7fffffff
+pattern ShaderStageAll = ShaderStageFlags 0x7fffffff
 
 newtype ShaderModule = ShaderModule Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -4,17 +4,17 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Shader where
 
-import Graphics.Vulkan.Device( Device
+import Graphics.Vulkan.Device( Device(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word64(..)
+                , Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
 import Data.Bits( Bits
@@ -22,9 +22,9 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks
+import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -33,15 +33,11 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Shader( VkShaderModuleCreateFlags
-                             , ShaderModule
-                             , VkShaderModuleCreateInfo
-                             )
-import Graphics.Vulkan.Core( VkResult
-                           , VkFlags
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFlags(..)
+                           , VkResult(..)
                            )
-import Foreign.C.Types( CSize
+import Foreign.C.Types( CSize(..)
                       )
 
 
@@ -80,13 +76,10 @@ newtype VkShaderModuleCreateFlags = VkShaderModuleCreateFlags VkFlags
 
 -- ** VkShaderStageFlags
 
-newtype VkShaderStageFlagBits = VkShaderStageFlagBits VkFlags
+newtype VkShaderStageFlags = VkShaderStageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkShaderStageFlagBits
-type VkShaderStageFlags = VkShaderStageFlagBits
-
-instance Show VkShaderStageFlagBits where
+instance Show VkShaderStageFlags where
   showsPrec _ VK_SHADER_STAGE_VERTEX_BIT = showString "VK_SHADER_STAGE_VERTEX_BIT"
   showsPrec _ VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = showString "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT"
   showsPrec _ VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = showString "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT"
@@ -95,9 +88,9 @@ instance Show VkShaderStageFlagBits where
   showsPrec _ VK_SHADER_STAGE_COMPUTE_BIT = showString "VK_SHADER_STAGE_COMPUTE_BIT"
   showsPrec _ VK_SHADER_STAGE_ALL_GRAPHICS = showString "VK_SHADER_STAGE_ALL_GRAPHICS"
   showsPrec _ VK_SHADER_STAGE_ALL = showString "VK_SHADER_STAGE_ALL"
-  showsPrec p (VkShaderStageFlagBits x) = showParen (p >= 11) (showString "VkShaderStageFlagBits " . showsPrec 11 x)
+  showsPrec p (VkShaderStageFlags x) = showParen (p >= 11) (showString "VkShaderStageFlags " . showsPrec 11 x)
 
-instance Read VkShaderStageFlagBits where
+instance Read VkShaderStageFlags where
   readPrec = parens ( choose [ ("VK_SHADER_STAGE_VERTEX_BIT", pure VK_SHADER_STAGE_VERTEX_BIT)
                              , ("VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT", pure VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
                              , ("VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT", pure VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
@@ -108,28 +101,28 @@ instance Read VkShaderStageFlagBits where
                              , ("VK_SHADER_STAGE_ALL", pure VK_SHADER_STAGE_ALL)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkShaderStageFlagBits")
+                        expectP (Ident "VkShaderStageFlags")
                         v <- step readPrec
-                        pure (VkShaderStageFlagBits v)
+                        pure (VkShaderStageFlags v)
                         )
                     )
 
 
-pattern VK_SHADER_STAGE_VERTEX_BIT = VkShaderStageFlagBits 0x1
+pattern VK_SHADER_STAGE_VERTEX_BIT = VkShaderStageFlags 0x1
 
-pattern VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = VkShaderStageFlagBits 0x2
+pattern VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = VkShaderStageFlags 0x2
 
-pattern VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = VkShaderStageFlagBits 0x4
+pattern VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = VkShaderStageFlags 0x4
 
-pattern VK_SHADER_STAGE_GEOMETRY_BIT = VkShaderStageFlagBits 0x8
+pattern VK_SHADER_STAGE_GEOMETRY_BIT = VkShaderStageFlags 0x8
 
-pattern VK_SHADER_STAGE_FRAGMENT_BIT = VkShaderStageFlagBits 0x10
+pattern VK_SHADER_STAGE_FRAGMENT_BIT = VkShaderStageFlags 0x10
 
-pattern VK_SHADER_STAGE_COMPUTE_BIT = VkShaderStageFlagBits 0x20
+pattern VK_SHADER_STAGE_COMPUTE_BIT = VkShaderStageFlags 0x20
 
-pattern VK_SHADER_STAGE_ALL_GRAPHICS = VkShaderStageFlagBits 0x1f
+pattern VK_SHADER_STAGE_ALL_GRAPHICS = VkShaderStageFlags 0x1f
 
-pattern VK_SHADER_STAGE_ALL = VkShaderStageFlagBits 0x7fffffff
+pattern VK_SHADER_STAGE_ALL = VkShaderStageFlags 0x7fffffff
 
 newtype ShaderModule = ShaderModule Word64
   deriving (Eq, Storable)

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -74,7 +74,7 @@ foreign import ccall "vkDestroyShaderModule" destroyShaderModule ::
 newtype ShaderModuleCreateFlags = ShaderModuleCreateFlags Flags
   deriving (Eq, Storable)
 
--- ** VkShaderStageFlags
+-- ** ShaderStageFlags
 
 newtype ShaderStageFlags = ShaderStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.Shader where
 
+import Graphics.Vulkan.Device( Device
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -22,6 +24,8 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( VkAllocationCallbacks
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -29,6 +33,14 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Shader( VkShaderModuleCreateFlags
+                             , ShaderModule
+                             , VkShaderModuleCreateInfo
+                             )
+import Graphics.Vulkan.Core( VkResult
+                           , VkFlags
+                           , VkStructureType
+                           )
 import Foreign.C.Types( CSize
                       )
 

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -65,8 +65,8 @@ instance Storable ShaderModuleCreateInfo where
                 *> poke (ptr `plusPtr` 32) (pCode (poked :: ShaderModuleCreateInfo))
 
 
--- ** vkDestroyShaderModule
-foreign import ccall "vkDestroyShaderModule" vkDestroyShaderModule ::
+-- ** destroyShaderModule
+foreign import ccall "vkDestroyShaderModule" destroyShaderModule ::
   Device -> ShaderModule -> Ptr AllocationCallbacks -> IO ()
 
 -- ** ShaderModuleCreateFlags
@@ -127,8 +127,8 @@ pattern VK_SHADER_STAGE_ALL = ShaderStageFlags 0x7fffffff
 newtype ShaderModule = ShaderModule Word64
   deriving (Eq, Storable)
 
--- ** vkCreateShaderModule
-foreign import ccall "vkCreateShaderModule" vkCreateShaderModule ::
+-- ** createShaderModule
+foreign import ccall "vkCreateShaderModule" createShaderModule ::
   Device ->
   Ptr ShaderModuleCreateInfo ->
     Ptr AllocationCallbacks -> Ptr ShaderModule -> IO Result

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -48,7 +48,7 @@ data ShaderModuleCreateInfo =
                         , codeSize :: CSize 
                         , pCode :: Ptr Word32 
                         }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable ShaderModuleCreateInfo where
   sizeOf ~_ = 40
@@ -72,12 +72,12 @@ foreign import ccall "vkDestroyShaderModule" destroyShaderModule ::
 -- ** ShaderModuleCreateFlags
 -- | Opaque flag
 newtype ShaderModuleCreateFlags = ShaderModuleCreateFlags Flags
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** ShaderStageFlags
 
 newtype ShaderStageFlags = ShaderStageFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show ShaderStageFlags where
   showsPrec _ ShaderStageVertexBit = showString "ShaderStageVertexBit"
@@ -125,7 +125,7 @@ pattern ShaderStageAllGraphics = ShaderStageFlags 0x1f
 pattern ShaderStageAll = ShaderStageFlags 0x7fffffff
 
 newtype ShaderModule = ShaderModule Word64
-  deriving (Eq, Storable)
+  deriving (Eq, Ord, Storable)
 
 -- ** createShaderModule
 foreign import ccall "vkCreateShaderModule" createShaderModule ::

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -33,9 +33,9 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkFlags(..)
-                           , StructureType(..)
+import Graphics.Vulkan.Core( StructureType(..)
                            , Result(..)
+                           , Flags(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
@@ -71,12 +71,12 @@ foreign import ccall "vkDestroyShaderModule" vkDestroyShaderModule ::
 
 -- ** ShaderModuleCreateFlags
 -- | Opaque flag
-newtype ShaderModuleCreateFlags = ShaderModuleCreateFlags VkFlags
+newtype ShaderModuleCreateFlags = ShaderModuleCreateFlags Flags
   deriving (Eq, Storable)
 
 -- ** VkShaderStageFlags
 
-newtype ShaderStageFlags = ShaderStageFlags VkFlags
+newtype ShaderStageFlags = ShaderStageFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show ShaderStageFlags where

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -33,18 +33,18 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFlags(..)
-                           , VkResult(..)
+import Graphics.Vulkan.Core( VkFlags(..)
+                           , StructureType(..)
+                           , Result(..)
                            )
 import Foreign.C.Types( CSize(..)
                       )
 
 
 data ShaderModuleCreateInfo =
-  ShaderModuleCreateInfo{ sType :: VkStructureType 
+  ShaderModuleCreateInfo{ sType :: StructureType 
                         , pNext :: Ptr Void 
-                        , flags :: VkShaderModuleCreateFlags 
+                        , flags :: ShaderModuleCreateFlags 
                         , codeSize :: CSize 
                         , pCode :: Ptr Word32 
                         }
@@ -69,17 +69,17 @@ instance Storable ShaderModuleCreateInfo where
 foreign import ccall "vkDestroyShaderModule" vkDestroyShaderModule ::
   Device -> ShaderModule -> Ptr AllocationCallbacks -> IO ()
 
--- ** VkShaderModuleCreateFlags
+-- ** ShaderModuleCreateFlags
 -- | Opaque flag
-newtype VkShaderModuleCreateFlags = VkShaderModuleCreateFlags VkFlags
+newtype ShaderModuleCreateFlags = ShaderModuleCreateFlags VkFlags
   deriving (Eq, Storable)
 
 -- ** VkShaderStageFlags
 
-newtype VkShaderStageFlags = VkShaderStageFlags VkFlags
+newtype ShaderStageFlags = ShaderStageFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkShaderStageFlags where
+instance Show ShaderStageFlags where
   showsPrec _ VK_SHADER_STAGE_VERTEX_BIT = showString "VK_SHADER_STAGE_VERTEX_BIT"
   showsPrec _ VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = showString "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT"
   showsPrec _ VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = showString "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT"
@@ -88,9 +88,9 @@ instance Show VkShaderStageFlags where
   showsPrec _ VK_SHADER_STAGE_COMPUTE_BIT = showString "VK_SHADER_STAGE_COMPUTE_BIT"
   showsPrec _ VK_SHADER_STAGE_ALL_GRAPHICS = showString "VK_SHADER_STAGE_ALL_GRAPHICS"
   showsPrec _ VK_SHADER_STAGE_ALL = showString "VK_SHADER_STAGE_ALL"
-  showsPrec p (VkShaderStageFlags x) = showParen (p >= 11) (showString "VkShaderStageFlags " . showsPrec 11 x)
+  showsPrec p (ShaderStageFlags x) = showParen (p >= 11) (showString "ShaderStageFlags " . showsPrec 11 x)
 
-instance Read VkShaderStageFlags where
+instance Read ShaderStageFlags where
   readPrec = parens ( choose [ ("VK_SHADER_STAGE_VERTEX_BIT", pure VK_SHADER_STAGE_VERTEX_BIT)
                              , ("VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT", pure VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT)
                              , ("VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT", pure VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
@@ -101,28 +101,28 @@ instance Read VkShaderStageFlags where
                              , ("VK_SHADER_STAGE_ALL", pure VK_SHADER_STAGE_ALL)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkShaderStageFlags")
+                        expectP (Ident "ShaderStageFlags")
                         v <- step readPrec
-                        pure (VkShaderStageFlags v)
+                        pure (ShaderStageFlags v)
                         )
                     )
 
 
-pattern VK_SHADER_STAGE_VERTEX_BIT = VkShaderStageFlags 0x1
+pattern VK_SHADER_STAGE_VERTEX_BIT = ShaderStageFlags 0x1
 
-pattern VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = VkShaderStageFlags 0x2
+pattern VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT = ShaderStageFlags 0x2
 
-pattern VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = VkShaderStageFlags 0x4
+pattern VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT = ShaderStageFlags 0x4
 
-pattern VK_SHADER_STAGE_GEOMETRY_BIT = VkShaderStageFlags 0x8
+pattern VK_SHADER_STAGE_GEOMETRY_BIT = ShaderStageFlags 0x8
 
-pattern VK_SHADER_STAGE_FRAGMENT_BIT = VkShaderStageFlags 0x10
+pattern VK_SHADER_STAGE_FRAGMENT_BIT = ShaderStageFlags 0x10
 
-pattern VK_SHADER_STAGE_COMPUTE_BIT = VkShaderStageFlags 0x20
+pattern VK_SHADER_STAGE_COMPUTE_BIT = ShaderStageFlags 0x20
 
-pattern VK_SHADER_STAGE_ALL_GRAPHICS = VkShaderStageFlags 0x1f
+pattern VK_SHADER_STAGE_ALL_GRAPHICS = ShaderStageFlags 0x1f
 
-pattern VK_SHADER_STAGE_ALL = VkShaderStageFlags 0x7fffffff
+pattern VK_SHADER_STAGE_ALL = ShaderStageFlags 0x7fffffff
 
 newtype ShaderModule = ShaderModule Word64
   deriving (Eq, Storable)
@@ -131,5 +131,5 @@ newtype ShaderModule = ShaderModule Word64
 foreign import ccall "vkCreateShaderModule" vkCreateShaderModule ::
   Device ->
   Ptr ShaderModuleCreateInfo ->
-    Ptr AllocationCallbacks -> Ptr ShaderModule -> IO VkResult
+    Ptr AllocationCallbacks -> Ptr ShaderModule -> IO Result
 

--- a/src/Graphics/Vulkan/Shader.hs
+++ b/src/Graphics/Vulkan/Shader.hs
@@ -24,7 +24,7 @@ import Foreign.Storable( Storable(..)
                        )
 import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( VkAllocationCallbacks(..)
+import Graphics.Vulkan.Memory( AllocationCallbacks(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -41,33 +41,33 @@ import Foreign.C.Types( CSize(..)
                       )
 
 
-data VkShaderModuleCreateInfo =
-  VkShaderModuleCreateInfo{ sType :: VkStructureType 
-                          , pNext :: Ptr Void 
-                          , flags :: VkShaderModuleCreateFlags 
-                          , codeSize :: CSize 
-                          , pCode :: Ptr Word32 
-                          }
+data ShaderModuleCreateInfo =
+  ShaderModuleCreateInfo{ sType :: VkStructureType 
+                        , pNext :: Ptr Void 
+                        , flags :: VkShaderModuleCreateFlags 
+                        , codeSize :: CSize 
+                        , pCode :: Ptr Word32 
+                        }
   deriving (Eq)
 
-instance Storable VkShaderModuleCreateInfo where
+instance Storable ShaderModuleCreateInfo where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkShaderModuleCreateInfo <$> peek (ptr `plusPtr` 0)
-                                      <*> peek (ptr `plusPtr` 8)
-                                      <*> peek (ptr `plusPtr` 16)
-                                      <*> peek (ptr `plusPtr` 24)
-                                      <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 24) (codeSize (poked :: VkShaderModuleCreateInfo))
-                *> poke (ptr `plusPtr` 32) (pCode (poked :: VkShaderModuleCreateInfo))
+  peek ptr = ShaderModuleCreateInfo <$> peek (ptr `plusPtr` 0)
+                                    <*> peek (ptr `plusPtr` 8)
+                                    <*> peek (ptr `plusPtr` 16)
+                                    <*> peek (ptr `plusPtr` 24)
+                                    <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: ShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: ShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: ShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 24) (codeSize (poked :: ShaderModuleCreateInfo))
+                *> poke (ptr `plusPtr` 32) (pCode (poked :: ShaderModuleCreateInfo))
 
 
 -- ** vkDestroyShaderModule
 foreign import ccall "vkDestroyShaderModule" vkDestroyShaderModule ::
-  Device -> ShaderModule -> Ptr VkAllocationCallbacks -> IO ()
+  Device -> ShaderModule -> Ptr AllocationCallbacks -> IO ()
 
 -- ** VkShaderModuleCreateFlags
 -- | Opaque flag
@@ -130,6 +130,6 @@ newtype ShaderModule = ShaderModule Word64
 -- ** vkCreateShaderModule
 foreign import ccall "vkCreateShaderModule" vkCreateShaderModule ::
   Device ->
-  Ptr VkShaderModuleCreateInfo ->
-    Ptr VkAllocationCallbacks -> Ptr ShaderModule -> IO VkResult
+  Ptr ShaderModuleCreateInfo ->
+    Ptr AllocationCallbacks -> Ptr ShaderModule -> IO VkResult
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.SparseResourceMemoryManagement where
 
-import Graphics.Vulkan.Device( VkPhysicalDevice(..)
-                             , VkDevice(..)
+import Graphics.Vulkan.Device( PhysicalDevice(..)
+                             , Device(..)
                              )
-import Graphics.Vulkan.Buffer( VkBuffer(..)
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
@@ -20,7 +20,7 @@ import Data.Word( Word64
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.Queue( VkQueue(..)
+import Graphics.Vulkan.Queue( Queue(..)
                             )
 import Data.Int( Int32
                )
@@ -29,11 +29,11 @@ import Data.Bits( Bits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( VkFence(..)
+import Graphics.Vulkan.Fence( Fence(..)
                             )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( VkDeviceMemory(..)
+import Graphics.Vulkan.Memory( DeviceMemory(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -45,7 +45,7 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
                               )
 import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , VkImage(..)
+                            , Image(..)
                             , VkImageSubresource(..)
                             , VkImageType(..)
                             , VkImageAspectFlagBits(..)
@@ -53,7 +53,7 @@ import Graphics.Vulkan.Image( VkImageUsageFlags(..)
                             , VkImageTiling(..)
                             , VkImageAspectFlags(..)
                             )
-import Graphics.Vulkan.QueueSemaphore( VkSemaphore(..)
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
 import Graphics.Vulkan.Core( VkExtent3D(..)
                            , VkResult(..)
@@ -66,11 +66,11 @@ import Graphics.Vulkan.Core( VkExtent3D(..)
 
 
 data VkSparseImageMemoryRequirements =
-  VkSparseImageMemoryRequirements{ vkFormatProperties :: VkSparseImageFormatProperties 
-                                 , vkImageMipTailFirstLod :: Word32 
-                                 , vkImageMipTailSize :: VkDeviceSize 
-                                 , vkImageMipTailOffset :: VkDeviceSize 
-                                 , vkImageMipTailStride :: VkDeviceSize 
+  VkSparseImageMemoryRequirements{ formatProperties :: VkSparseImageFormatProperties 
+                                 , imageMipTailFirstLod :: Word32 
+                                 , imageMipTailSize :: VkDeviceSize 
+                                 , imageMipTailOffset :: VkDeviceSize 
+                                 , imageMipTailStride :: VkDeviceSize 
                                  }
   deriving (Eq)
 
@@ -82,20 +82,20 @@ instance Storable VkSparseImageMemoryRequirements where
                                              <*> peek (ptr `plusPtr` 24)
                                              <*> peek (ptr `plusPtr` 32)
                                              <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkFormatProperties (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 20) (vkImageMipTailFirstLod (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 24) (vkImageMipTailSize (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 32) (vkImageMipTailOffset (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 40) (vkImageMipTailStride (poked :: VkSparseImageMemoryRequirements))
+  poke ptr poked = poke (ptr `plusPtr` 0) (formatProperties (poked :: VkSparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 20) (imageMipTailFirstLod (poked :: VkSparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 24) (imageMipTailSize (poked :: VkSparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 32) (imageMipTailOffset (poked :: VkSparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 40) (imageMipTailStride (poked :: VkSparseImageMemoryRequirements))
 
 
 
 data VkSparseMemoryBind =
-  VkSparseMemoryBind{ vkResourceOffset :: VkDeviceSize 
-                    , vkSize :: VkDeviceSize 
-                    , vkMemory :: VkDeviceMemory 
-                    , vkMemoryOffset :: VkDeviceSize 
-                    , vkFlags :: VkSparseMemoryBindFlags 
+  VkSparseMemoryBind{ resourceOffset :: VkDeviceSize 
+                    , size :: VkDeviceSize 
+                    , memory :: DeviceMemory 
+                    , memoryOffset :: VkDeviceSize 
+                    , flags :: VkSparseMemoryBindFlags 
                     }
   deriving (Eq)
 
@@ -107,21 +107,21 @@ instance Storable VkSparseMemoryBind where
                                 <*> peek (ptr `plusPtr` 16)
                                 <*> peek (ptr `plusPtr` 24)
                                 <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkResourceOffset (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 8) (vkSize (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 16) (vkMemory (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 24) (vkMemoryOffset (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 32) (vkFlags (poked :: VkSparseMemoryBind))
+  poke ptr poked = poke (ptr `plusPtr` 0) (resourceOffset (poked :: VkSparseMemoryBind))
+                *> poke (ptr `plusPtr` 8) (size (poked :: VkSparseMemoryBind))
+                *> poke (ptr `plusPtr` 16) (memory (poked :: VkSparseMemoryBind))
+                *> poke (ptr `plusPtr` 24) (memoryOffset (poked :: VkSparseMemoryBind))
+                *> poke (ptr `plusPtr` 32) (flags (poked :: VkSparseMemoryBind))
 
 
 
 data VkSparseImageMemoryBind =
-  VkSparseImageMemoryBind{ vkSubresource :: VkImageSubresource 
-                         , vkOffset :: VkOffset3D 
-                         , vkExtent :: VkExtent3D 
-                         , vkMemory :: VkDeviceMemory 
-                         , vkMemoryOffset :: VkDeviceSize 
-                         , vkFlags :: VkSparseMemoryBindFlags 
+  VkSparseImageMemoryBind{ subresource :: VkImageSubresource 
+                         , offset :: VkOffset3D 
+                         , extent :: VkExtent3D 
+                         , memory :: DeviceMemory 
+                         , memoryOffset :: VkDeviceSize 
+                         , flags :: VkSparseMemoryBindFlags 
                          }
   deriving (Eq)
 
@@ -134,19 +134,19 @@ instance Storable VkSparseImageMemoryBind where
                                      <*> peek (ptr `plusPtr` 40)
                                      <*> peek (ptr `plusPtr` 48)
                                      <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSubresource (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 12) (vkOffset (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 24) (vkExtent (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 40) (vkMemory (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 48) (vkMemoryOffset (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 56) (vkFlags (poked :: VkSparseImageMemoryBind))
+  poke ptr poked = poke (ptr `plusPtr` 0) (subresource (poked :: VkSparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 12) (offset (poked :: VkSparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 24) (extent (poked :: VkSparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 40) (memory (poked :: VkSparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 48) (memoryOffset (poked :: VkSparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 56) (flags (poked :: VkSparseImageMemoryBind))
 
 
 
 data VkSparseImageMemoryBindInfo =
-  VkSparseImageMemoryBindInfo{ vkImage :: VkImage 
-                             , vkBindCount :: Word32 
-                             , vkPBinds :: Ptr VkSparseImageMemoryBind 
+  VkSparseImageMemoryBindInfo{ image :: Image 
+                             , bindCount :: Word32 
+                             , pBinds :: Ptr VkSparseImageMemoryBind 
                              }
   deriving (Eq)
 
@@ -156,35 +156,34 @@ instance Storable VkSparseImageMemoryBindInfo where
   peek ptr = VkSparseImageMemoryBindInfo <$> peek (ptr `plusPtr` 0)
                                          <*> peek (ptr `plusPtr` 8)
                                          <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkImage (poked :: VkSparseImageMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (vkBindCount (poked :: VkSparseImageMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (vkPBinds (poked :: VkSparseImageMemoryBindInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: VkSparseImageMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseImageMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseImageMemoryBindInfo))
 
 
 -- ** vkGetImageSparseMemoryRequirements
 foreign import ccall "vkGetImageSparseMemoryRequirements" vkGetImageSparseMemoryRequirements ::
-  VkDevice ->
-  VkImage ->
-    Ptr Word32 -> Ptr VkSparseImageMemoryRequirements -> IO ()
+  Device ->
+  Image -> Ptr Word32 -> Ptr VkSparseImageMemoryRequirements -> IO ()
 
 -- ** vkQueueBindSparse
 foreign import ccall "vkQueueBindSparse" vkQueueBindSparse ::
-  VkQueue -> Word32 -> Ptr VkBindSparseInfo -> VkFence -> IO VkResult
+  Queue -> Word32 -> Ptr VkBindSparseInfo -> Fence -> IO VkResult
 
 
 data VkBindSparseInfo =
-  VkBindSparseInfo{ vkSType :: VkStructureType 
-                  , vkPNext :: Ptr Void 
-                  , vkWaitSemaphoreCount :: Word32 
-                  , vkPWaitSemaphores :: Ptr VkSemaphore 
-                  , vkBufferBindCount :: Word32 
-                  , vkPBufferBinds :: Ptr VkSparseBufferMemoryBindInfo 
-                  , vkImageOpaqueBindCount :: Word32 
-                  , vkPImageOpaqueBinds :: Ptr VkSparseImageOpaqueMemoryBindInfo 
-                  , vkImageBindCount :: Word32 
-                  , vkPImageBinds :: Ptr VkSparseImageMemoryBindInfo 
-                  , vkSignalSemaphoreCount :: Word32 
-                  , vkPSignalSemaphores :: Ptr VkSemaphore 
+  VkBindSparseInfo{ sType :: VkStructureType 
+                  , pNext :: Ptr Void 
+                  , waitSemaphoreCount :: Word32 
+                  , pWaitSemaphores :: Ptr Semaphore 
+                  , bufferBindCount :: Word32 
+                  , pBufferBinds :: Ptr VkSparseBufferMemoryBindInfo 
+                  , imageOpaqueBindCount :: Word32 
+                  , pImageOpaqueBinds :: Ptr VkSparseImageOpaqueMemoryBindInfo 
+                  , imageBindCount :: Word32 
+                  , pImageBinds :: Ptr VkSparseImageMemoryBindInfo 
+                  , signalSemaphoreCount :: Word32 
+                  , pSignalSemaphores :: Ptr Semaphore 
                   }
   deriving (Eq)
 
@@ -203,25 +202,25 @@ instance Storable VkBindSparseInfo where
                               <*> peek (ptr `plusPtr` 72)
                               <*> peek (ptr `plusPtr` 80)
                               <*> peek (ptr `plusPtr` 88)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 16) (vkWaitSemaphoreCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 24) (vkPWaitSemaphores (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 32) (vkBufferBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 40) (vkPBufferBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 48) (vkImageOpaqueBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 56) (vkPImageOpaqueBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 64) (vkImageBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 72) (vkPImageBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 80) (vkSignalSemaphoreCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 88) (vkPSignalSemaphores (poked :: VkBindSparseInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 32) (bufferBindCount (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 40) (pBufferBinds (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 48) (imageOpaqueBindCount (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 56) (pImageOpaqueBinds (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 64) (imageBindCount (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 72) (pImageBinds (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 80) (signalSemaphoreCount (poked :: VkBindSparseInfo))
+                *> poke (ptr `plusPtr` 88) (pSignalSemaphores (poked :: VkBindSparseInfo))
 
 
 
 data VkSparseBufferMemoryBindInfo =
-  VkSparseBufferMemoryBindInfo{ vkBuffer :: VkBuffer 
-                              , vkBindCount :: Word32 
-                              , vkPBinds :: Ptr VkSparseMemoryBind 
+  VkSparseBufferMemoryBindInfo{ buffer :: Buffer 
+                              , bindCount :: Word32 
+                              , pBinds :: Ptr VkSparseMemoryBind 
                               }
   deriving (Eq)
 
@@ -231,9 +230,9 @@ instance Storable VkSparseBufferMemoryBindInfo where
   peek ptr = VkSparseBufferMemoryBindInfo <$> peek (ptr `plusPtr` 0)
                                           <*> peek (ptr `plusPtr` 8)
                                           <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkBuffer (poked :: VkSparseBufferMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (vkBindCount (poked :: VkSparseBufferMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (vkPBinds (poked :: VkSparseBufferMemoryBindInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: VkSparseBufferMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseBufferMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseBufferMemoryBindInfo))
 
 
 -- ** VkSparseImageFormatFlags
@@ -273,7 +272,7 @@ pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = VkSparseImageFormatF
 
 -- ** vkGetPhysicalDeviceSparseImageFormatProperties
 foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysicalDeviceSparseImageFormatProperties ::
-  VkPhysicalDevice ->
+  PhysicalDevice ->
   VkFormat ->
     VkImageType ->
       VkSampleCountFlagBits ->
@@ -310,9 +309,9 @@ pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = VkSparseMemoryBindFlagBits 0x1
 
 
 data VkSparseImageOpaqueMemoryBindInfo =
-  VkSparseImageOpaqueMemoryBindInfo{ vkImage :: VkImage 
-                                   , vkBindCount :: Word32 
-                                   , vkPBinds :: Ptr VkSparseMemoryBind 
+  VkSparseImageOpaqueMemoryBindInfo{ image :: Image 
+                                   , bindCount :: Word32 
+                                   , pBinds :: Ptr VkSparseMemoryBind 
                                    }
   deriving (Eq)
 
@@ -322,16 +321,16 @@ instance Storable VkSparseImageOpaqueMemoryBindInfo where
   peek ptr = VkSparseImageOpaqueMemoryBindInfo <$> peek (ptr `plusPtr` 0)
                                                <*> peek (ptr `plusPtr` 8)
                                                <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkImage (poked :: VkSparseImageOpaqueMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (vkBindCount (poked :: VkSparseImageOpaqueMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (vkPBinds (poked :: VkSparseImageOpaqueMemoryBindInfo))
+  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: VkSparseImageOpaqueMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseImageOpaqueMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseImageOpaqueMemoryBindInfo))
 
 
 
 data VkSparseImageFormatProperties =
-  VkSparseImageFormatProperties{ vkAspectMask :: VkImageAspectFlags 
-                               , vkImageGranularity :: VkExtent3D 
-                               , vkFlags :: VkSparseImageFormatFlags 
+  VkSparseImageFormatProperties{ aspectMask :: VkImageAspectFlags 
+                               , imageGranularity :: VkExtent3D 
+                               , flags :: VkSparseImageFormatFlags 
                                }
   deriving (Eq)
 
@@ -341,8 +340,8 @@ instance Storable VkSparseImageFormatProperties where
   peek ptr = VkSparseImageFormatProperties <$> peek (ptr `plusPtr` 0)
                                            <*> peek (ptr `plusPtr` 4)
                                            <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (vkAspectMask (poked :: VkSparseImageFormatProperties))
-                *> poke (ptr `plusPtr` 4) (vkImageGranularity (poked :: VkSparseImageFormatProperties))
-                *> poke (ptr `plusPtr` 16) (vkFlags (poked :: VkSparseImageFormatProperties))
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkSparseImageFormatProperties))
+                *> poke (ptr `plusPtr` 4) (imageGranularity (poked :: VkSparseImageFormatProperties))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSparseImageFormatProperties))
 
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -4,37 +4,23 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.SparseResourceMemoryManagement where
 
-import Graphics.Vulkan.Device( PhysicalDevice(..)
-                             , Device(..)
-                             )
-import Graphics.Vulkan.Buffer( Buffer(..)
-                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word64
-                , Word32
+import Data.Word( Word32
                 )
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
-import Graphics.Vulkan.Queue( Queue(..)
-                            )
-import Data.Int( Int32
-               )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence(..)
-                            )
 import Data.Void( Void
                 )
-import Graphics.Vulkan.Memory( DeviceMemory(..)
-                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -42,27 +28,6 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits(..)
-                              )
-import Graphics.Vulkan.Image( VkImageUsageFlags(..)
-                            , Image(..)
-                            , VkImageSubresource(..)
-                            , VkImageType(..)
-                            , VkImageAspectFlagBits(..)
-                            , VkImageUsageFlagBits(..)
-                            , VkImageTiling(..)
-                            , VkImageAspectFlags(..)
-                            )
-import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
-                                     )
-import Graphics.Vulkan.Core( VkExtent3D(..)
-                           , VkResult(..)
-                           , VkDeviceSize(..)
-                           , VkFlags(..)
-                           , VkFormat(..)
-                           , VkOffset3D(..)
-                           , VkStructureType(..)
-                           )
 
 
 data VkSparseImageMemoryRequirements =

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -230,7 +230,7 @@ instance Storable SparseBufferMemoryBindInfo where
                 *> poke (ptr `plusPtr` 16) (pBinds (poked :: SparseBufferMemoryBindInfo))
 
 
--- ** VkSparseImageFormatFlags
+-- ** SparseImageFormatFlags
 
 newtype SparseImageFormatFlags = SparseImageFormatFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
@@ -272,7 +272,7 @@ foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" getPhysica
           ImageTiling ->
             Ptr Word32 -> Ptr SparseImageFormatProperties -> IO ()
 
--- ** VkSparseMemoryBindFlags
+-- ** SparseMemoryBindFlags
 
 newtype SparseMemoryBindFlags = SparseMemoryBindFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -51,21 +51,21 @@ import Graphics.Vulkan.Image( ImageAspectFlags(..)
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
 import Graphics.Vulkan.Core( Offset3D(..)
-                           , VkFlags(..)
                            , StructureType(..)
                            , Format(..)
                            , Extent3D(..)
                            , Result(..)
-                           , VkDeviceSize(..)
+                           , DeviceSize(..)
+                           , Flags(..)
                            )
 
 
 data SparseImageMemoryRequirements =
   SparseImageMemoryRequirements{ formatProperties :: SparseImageFormatProperties 
                                , imageMipTailFirstLod :: Word32 
-                               , imageMipTailSize :: VkDeviceSize 
-                               , imageMipTailOffset :: VkDeviceSize 
-                               , imageMipTailStride :: VkDeviceSize 
+                               , imageMipTailSize :: DeviceSize 
+                               , imageMipTailOffset :: DeviceSize 
+                               , imageMipTailStride :: DeviceSize 
                                }
   deriving (Eq)
 
@@ -86,10 +86,10 @@ instance Storable SparseImageMemoryRequirements where
 
 
 data SparseMemoryBind =
-  SparseMemoryBind{ resourceOffset :: VkDeviceSize 
-                  , size :: VkDeviceSize 
+  SparseMemoryBind{ resourceOffset :: DeviceSize 
+                  , size :: DeviceSize 
                   , memory :: DeviceMemory 
-                  , memoryOffset :: VkDeviceSize 
+                  , memoryOffset :: DeviceSize 
                   , flags :: SparseMemoryBindFlags 
                   }
   deriving (Eq)
@@ -115,7 +115,7 @@ data SparseImageMemoryBind =
                        , offset :: Offset3D 
                        , extent :: Extent3D 
                        , memory :: DeviceMemory 
-                       , memoryOffset :: VkDeviceSize 
+                       , memoryOffset :: DeviceSize 
                        , flags :: SparseMemoryBindFlags 
                        }
   deriving (Eq)
@@ -232,7 +232,7 @@ instance Storable SparseBufferMemoryBindInfo where
 
 -- ** VkSparseImageFormatFlags
 
-newtype SparseImageFormatFlags = SparseImageFormatFlags VkFlags
+newtype SparseImageFormatFlags = SparseImageFormatFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SparseImageFormatFlags where
@@ -274,7 +274,7 @@ foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysi
 
 -- ** VkSparseMemoryBindFlags
 
-newtype SparseMemoryBindFlags = SparseMemoryBindFlags VkFlags
+newtype SparseMemoryBindFlags = SparseMemoryBindFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SparseMemoryBindFlags where

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -39,23 +39,23 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
+import Graphics.Vulkan.Sampler( SampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( Image(..)
-                            , VkImageType(..)
-                            , VkImageUsageFlags(..)
-                            , VkImageAspectFlags(..)
-                            , VkImageTiling(..)
+import Graphics.Vulkan.Image( ImageAspectFlags(..)
+                            , Image(..)
+                            , ImageUsageFlags(..)
+                            , ImageTiling(..)
+                            , ImageType(..)
                             , ImageSubresource(..)
                             )
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.Core( VkStructureType(..)
-                           , VkFormat(..)
-                           , Offset3D(..)
+import Graphics.Vulkan.Core( Offset3D(..)
                            , VkFlags(..)
+                           , StructureType(..)
+                           , Format(..)
                            , Extent3D(..)
-                           , VkResult(..)
+                           , Result(..)
                            , VkDeviceSize(..)
                            )
 
@@ -90,7 +90,7 @@ data SparseMemoryBind =
                   , size :: VkDeviceSize 
                   , memory :: DeviceMemory 
                   , memoryOffset :: VkDeviceSize 
-                  , flags :: VkSparseMemoryBindFlags 
+                  , flags :: SparseMemoryBindFlags 
                   }
   deriving (Eq)
 
@@ -116,7 +116,7 @@ data SparseImageMemoryBind =
                        , extent :: Extent3D 
                        , memory :: DeviceMemory 
                        , memoryOffset :: VkDeviceSize 
-                       , flags :: VkSparseMemoryBindFlags 
+                       , flags :: SparseMemoryBindFlags 
                        }
   deriving (Eq)
 
@@ -163,11 +163,11 @@ foreign import ccall "vkGetImageSparseMemoryRequirements" vkGetImageSparseMemory
 
 -- ** vkQueueBindSparse
 foreign import ccall "vkQueueBindSparse" vkQueueBindSparse ::
-  Queue -> Word32 -> Ptr BindSparseInfo -> Fence -> IO VkResult
+  Queue -> Word32 -> Ptr BindSparseInfo -> Fence -> IO Result
 
 
 data BindSparseInfo =
-  BindSparseInfo{ sType :: VkStructureType 
+  BindSparseInfo{ sType :: StructureType 
                 , pNext :: Ptr Void 
                 , waitSemaphoreCount :: Word32 
                 , pWaitSemaphores :: Ptr Semaphore 
@@ -232,68 +232,68 @@ instance Storable SparseBufferMemoryBindInfo where
 
 -- ** VkSparseImageFormatFlags
 
-newtype VkSparseImageFormatFlags = VkSparseImageFormatFlags VkFlags
+newtype SparseImageFormatFlags = SparseImageFormatFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkSparseImageFormatFlags where
+instance Show SparseImageFormatFlags where
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = showString "VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT"
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT"
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT"
   
-  showsPrec p (VkSparseImageFormatFlags x) = showParen (p >= 11) (showString "VkSparseImageFormatFlags " . showsPrec 11 x)
+  showsPrec p (SparseImageFormatFlags x) = showParen (p >= 11) (showString "SparseImageFormatFlags " . showsPrec 11 x)
 
-instance Read VkSparseImageFormatFlags where
+instance Read SparseImageFormatFlags where
   readPrec = parens ( choose [ ("VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT", pure VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT)
                              , ("VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT)
                              , ("VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSparseImageFormatFlags")
+                        expectP (Ident "SparseImageFormatFlags")
                         v <- step readPrec
-                        pure (VkSparseImageFormatFlags v)
+                        pure (SparseImageFormatFlags v)
                         )
                     )
 
 -- | Image uses a single miptail region for all array layers
-pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = VkSparseImageFormatFlags 0x1
+pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = SparseImageFormatFlags 0x1
 -- | Image requires mip levels to be an exact multiple of the sparse image block size for non-miptail levels.
-pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = VkSparseImageFormatFlags 0x2
+pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = SparseImageFormatFlags 0x2
 -- | Image uses a non-standard sparse block size
-pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = VkSparseImageFormatFlags 0x4
+pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = SparseImageFormatFlags 0x4
 
 
 -- ** vkGetPhysicalDeviceSparseImageFormatProperties
 foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysicalDeviceSparseImageFormatProperties ::
   PhysicalDevice ->
-  VkFormat ->
-    VkImageType ->
-      VkSampleCountFlags ->
-        VkImageUsageFlags ->
-          VkImageTiling ->
+  Format ->
+    ImageType ->
+      SampleCountFlags ->
+        ImageUsageFlags ->
+          ImageTiling ->
             Ptr Word32 -> Ptr SparseImageFormatProperties -> IO ()
 
 -- ** VkSparseMemoryBindFlags
 
-newtype VkSparseMemoryBindFlags = VkSparseMemoryBindFlags VkFlags
+newtype SparseMemoryBindFlags = SparseMemoryBindFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
-instance Show VkSparseMemoryBindFlags where
+instance Show SparseMemoryBindFlags where
   showsPrec _ VK_SPARSE_MEMORY_BIND_METADATA_BIT = showString "VK_SPARSE_MEMORY_BIND_METADATA_BIT"
   
-  showsPrec p (VkSparseMemoryBindFlags x) = showParen (p >= 11) (showString "VkSparseMemoryBindFlags " . showsPrec 11 x)
+  showsPrec p (SparseMemoryBindFlags x) = showParen (p >= 11) (showString "SparseMemoryBindFlags " . showsPrec 11 x)
 
-instance Read VkSparseMemoryBindFlags where
+instance Read SparseMemoryBindFlags where
   readPrec = parens ( choose [ ("VK_SPARSE_MEMORY_BIND_METADATA_BIT", pure VK_SPARSE_MEMORY_BIND_METADATA_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSparseMemoryBindFlags")
+                        expectP (Ident "SparseMemoryBindFlags")
                         v <- step readPrec
-                        pure (VkSparseMemoryBindFlags v)
+                        pure (SparseMemoryBindFlags v)
                         )
                     )
 
 -- | Operation binds resource metadata to memory
-pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = VkSparseMemoryBindFlags 0x1
+pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = SparseMemoryBindFlags 0x1
 
 
 
@@ -317,9 +317,9 @@ instance Storable SparseImageOpaqueMemoryBindInfo where
 
 
 data SparseImageFormatProperties =
-  SparseImageFormatProperties{ aspectMask :: VkImageAspectFlags 
+  SparseImageFormatProperties{ aspectMask :: ImageAspectFlags 
                              , imageGranularity :: Extent3D 
-                             , flags :: VkSparseImageFormatFlags 
+                             , flags :: SparseImageFormatFlags 
                              }
   deriving (Eq)
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -4,33 +4,33 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.SparseResourceMemoryManagement where
 
-import Graphics.Vulkan.Device( Device
-                             , PhysicalDevice
+import Graphics.Vulkan.Device( Device(..)
+                             , PhysicalDevice(..)
                              )
-import Graphics.Vulkan.Buffer( Buffer
+import Graphics.Vulkan.Buffer( Buffer(..)
                              )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
                , choose
                )
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
-import Foreign.Ptr( Ptr
+import Foreign.Ptr( Ptr(..)
                   , plusPtr
                   )
-import Graphics.Vulkan.Queue( Queue
+import Graphics.Vulkan.Queue( Queue(..)
                             )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
-import Graphics.Vulkan.Fence( Fence
+import Graphics.Vulkan.Fence( Fence(..)
                             )
-import Data.Void( Void
+import Data.Void( Void(..)
                 )
-import Graphics.Vulkan.Memory( DeviceMemory
+import Graphics.Vulkan.Memory( DeviceMemory(..)
                              )
 import Text.Read( Read(..)
                 , parens
@@ -39,35 +39,24 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
-import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
                               )
-import Graphics.Vulkan.Image( VkImageType
-                            , VkImageAspectFlags
-                            , VkImageTiling
-                            , VkImageSubresource
-                            , Image
-                            , VkImageUsageFlags
+import Graphics.Vulkan.Image( Image(..)
+                            , VkImageType(..)
+                            , VkImageUsageFlags(..)
+                            , VkImageSubresource(..)
+                            , VkImageAspectFlags(..)
+                            , VkImageTiling(..)
                             )
-import Graphics.Vulkan.QueueSemaphore( Semaphore
+import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
-import Graphics.Vulkan.SparseResourceMemoryManagement( VkSparseImageFormatProperties
-                                                     , VkSparseMemoryBindFlags
-                                                     , VkBindSparseInfo
-                                                     , VkSparseImageFormatFlags
-                                                     , VkSparseMemoryBind
-                                                     , VkSparseImageMemoryRequirements
-                                                     , VkSparseImageMemoryBindInfo
-                                                     , VkSparseBufferMemoryBindInfo
-                                                     , VkSparseImageMemoryBind
-                                                     , VkSparseImageOpaqueMemoryBindInfo
-                                                     )
-import Graphics.Vulkan.Core( VkResult
-                           , VkExtent3D
-                           , VkDeviceSize
-                           , VkFlags
-                           , VkFormat
-                           , VkOffset3D
-                           , VkStructureType
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           , VkFormat(..)
+                           , VkFlags(..)
+                           , VkOffset3D(..)
+                           , VkResult(..)
+                           , VkDeviceSize(..)
+                           , VkExtent3D(..)
                            )
 
 
@@ -243,37 +232,34 @@ instance Storable VkSparseBufferMemoryBindInfo where
 
 -- ** VkSparseImageFormatFlags
 
-newtype VkSparseImageFormatFlagBits = VkSparseImageFormatFlagBits VkFlags
+newtype VkSparseImageFormatFlags = VkSparseImageFormatFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkSparseImageFormatFlagBits
-type VkSparseImageFormatFlags = VkSparseImageFormatFlagBits
-
-instance Show VkSparseImageFormatFlagBits where
+instance Show VkSparseImageFormatFlags where
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = showString "VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT"
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT"
   showsPrec _ VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT"
   
-  showsPrec p (VkSparseImageFormatFlagBits x) = showParen (p >= 11) (showString "VkSparseImageFormatFlagBits " . showsPrec 11 x)
+  showsPrec p (VkSparseImageFormatFlags x) = showParen (p >= 11) (showString "VkSparseImageFormatFlags " . showsPrec 11 x)
 
-instance Read VkSparseImageFormatFlagBits where
+instance Read VkSparseImageFormatFlags where
   readPrec = parens ( choose [ ("VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT", pure VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT)
                              , ("VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT)
                              , ("VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSparseImageFormatFlagBits")
+                        expectP (Ident "VkSparseImageFormatFlags")
                         v <- step readPrec
-                        pure (VkSparseImageFormatFlagBits v)
+                        pure (VkSparseImageFormatFlags v)
                         )
                     )
 
 -- | Image uses a single miptail region for all array layers
-pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = VkSparseImageFormatFlagBits 0x1
+pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = VkSparseImageFormatFlags 0x1
 -- | Image requires mip levels to be an exact multiple of the sparse image block size for non-miptail levels.
-pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = VkSparseImageFormatFlagBits 0x2
+pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = VkSparseImageFormatFlags 0x2
 -- | Image uses a non-standard sparse block size
-pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = VkSparseImageFormatFlagBits 0x4
+pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = VkSparseImageFormatFlags 0x4
 
 
 -- ** vkGetPhysicalDeviceSparseImageFormatProperties
@@ -281,36 +267,33 @@ foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysi
   PhysicalDevice ->
   VkFormat ->
     VkImageType ->
-      VkSampleCountFlagBits ->
+      VkSampleCountFlags ->
         VkImageUsageFlags ->
           VkImageTiling ->
             Ptr Word32 -> Ptr VkSparseImageFormatProperties -> IO ()
 
 -- ** VkSparseMemoryBindFlags
 
-newtype VkSparseMemoryBindFlagBits = VkSparseMemoryBindFlagBits VkFlags
+newtype VkSparseMemoryBindFlags = VkSparseMemoryBindFlags VkFlags
   deriving (Eq, Storable, Bits, FiniteBits)
 
--- | Alias for VkSparseMemoryBindFlagBits
-type VkSparseMemoryBindFlags = VkSparseMemoryBindFlagBits
-
-instance Show VkSparseMemoryBindFlagBits where
+instance Show VkSparseMemoryBindFlags where
   showsPrec _ VK_SPARSE_MEMORY_BIND_METADATA_BIT = showString "VK_SPARSE_MEMORY_BIND_METADATA_BIT"
   
-  showsPrec p (VkSparseMemoryBindFlagBits x) = showParen (p >= 11) (showString "VkSparseMemoryBindFlagBits " . showsPrec 11 x)
+  showsPrec p (VkSparseMemoryBindFlags x) = showParen (p >= 11) (showString "VkSparseMemoryBindFlags " . showsPrec 11 x)
 
-instance Read VkSparseMemoryBindFlagBits where
+instance Read VkSparseMemoryBindFlags where
   readPrec = parens ( choose [ ("VK_SPARSE_MEMORY_BIND_METADATA_BIT", pure VK_SPARSE_MEMORY_BIND_METADATA_BIT)
                              ] +++
                       prec 10 (do
-                        expectP (Ident "VkSparseMemoryBindFlagBits")
+                        expectP (Ident "VkSparseMemoryBindFlags")
                         v <- step readPrec
-                        pure (VkSparseMemoryBindFlagBits v)
+                        pure (VkSparseMemoryBindFlags v)
                         )
                     )
 
 -- | Operation binds resource metadata to memory
-pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = VkSparseMemoryBindFlagBits 0x1
+pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = VkSparseMemoryBindFlags 0x1
 
 
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -156,13 +156,13 @@ instance Storable SparseImageMemoryBindInfo where
                 *> poke (ptr `plusPtr` 16) (pBinds (poked :: SparseImageMemoryBindInfo))
 
 
--- ** vkGetImageSparseMemoryRequirements
-foreign import ccall "vkGetImageSparseMemoryRequirements" vkGetImageSparseMemoryRequirements ::
+-- ** getImageSparseMemoryRequirements
+foreign import ccall "vkGetImageSparseMemoryRequirements" getImageSparseMemoryRequirements ::
   Device ->
   Image -> Ptr Word32 -> Ptr SparseImageMemoryRequirements -> IO ()
 
--- ** vkQueueBindSparse
-foreign import ccall "vkQueueBindSparse" vkQueueBindSparse ::
+-- ** queueBindSparse
+foreign import ccall "vkQueueBindSparse" queueBindSparse ::
   Queue -> Word32 -> Ptr BindSparseInfo -> Fence -> IO Result
 
 
@@ -262,8 +262,8 @@ pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = SparseImageFormatFlags 0x2
 pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = SparseImageFormatFlags 0x4
 
 
--- ** vkGetPhysicalDeviceSparseImageFormatProperties
-foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysicalDeviceSparseImageFormatProperties ::
+-- ** getPhysicalDeviceSparseImageFormatProperties
+foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" getPhysicalDeviceSparseImageFormatProperties ::
   PhysicalDevice ->
   Format ->
     ImageType ->

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -4,6 +4,11 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.SparseResourceMemoryManagement where
 
+import Graphics.Vulkan.Device( Device
+                             , PhysicalDevice
+                             )
+import Graphics.Vulkan.Buffer( Buffer
+                             )
 import Text.Read.Lex( Lexeme(Ident)
                     )
 import GHC.Read( expectP
@@ -14,13 +19,19 @@ import Data.Word( Word32
 import Foreign.Ptr( Ptr
                   , plusPtr
                   )
+import Graphics.Vulkan.Queue( Queue
+                            )
 import Data.Bits( Bits
                 , FiniteBits
                 )
 import Foreign.Storable( Storable(..)
                        )
+import Graphics.Vulkan.Fence( Fence
+                            )
 import Data.Void( Void
                 )
+import Graphics.Vulkan.Memory( DeviceMemory
+                             )
 import Text.Read( Read(..)
                 , parens
                 )
@@ -28,6 +39,36 @@ import Text.ParserCombinators.ReadPrec( prec
                                       , (+++)
                                       , step
                                       )
+import Graphics.Vulkan.Sampler( VkSampleCountFlagBits
+                              )
+import Graphics.Vulkan.Image( VkImageType
+                            , VkImageAspectFlags
+                            , VkImageTiling
+                            , VkImageSubresource
+                            , Image
+                            , VkImageUsageFlags
+                            )
+import Graphics.Vulkan.QueueSemaphore( Semaphore
+                                     )
+import Graphics.Vulkan.SparseResourceMemoryManagement( VkSparseImageFormatProperties
+                                                     , VkSparseMemoryBindFlags
+                                                     , VkBindSparseInfo
+                                                     , VkSparseImageFormatFlags
+                                                     , VkSparseMemoryBind
+                                                     , VkSparseImageMemoryRequirements
+                                                     , VkSparseImageMemoryBindInfo
+                                                     , VkSparseBufferMemoryBindInfo
+                                                     , VkSparseImageMemoryBind
+                                                     , VkSparseImageOpaqueMemoryBindInfo
+                                                     )
+import Graphics.Vulkan.Core( VkResult
+                           , VkExtent3D
+                           , VkDeviceSize
+                           , VkFlags
+                           , VkFormat
+                           , VkOffset3D
+                           , VkStructureType
+                           )
 
 
 data VkSparseImageMemoryRequirements =

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -44,190 +44,190 @@ import Graphics.Vulkan.Sampler( VkSampleCountFlags(..)
 import Graphics.Vulkan.Image( Image(..)
                             , VkImageType(..)
                             , VkImageUsageFlags(..)
-                            , VkImageSubresource(..)
                             , VkImageAspectFlags(..)
                             , VkImageTiling(..)
+                            , ImageSubresource(..)
                             )
 import Graphics.Vulkan.QueueSemaphore( Semaphore(..)
                                      )
 import Graphics.Vulkan.Core( VkStructureType(..)
                            , VkFormat(..)
+                           , Offset3D(..)
                            , VkFlags(..)
-                           , VkOffset3D(..)
+                           , Extent3D(..)
                            , VkResult(..)
                            , VkDeviceSize(..)
-                           , VkExtent3D(..)
                            )
 
 
-data VkSparseImageMemoryRequirements =
-  VkSparseImageMemoryRequirements{ formatProperties :: VkSparseImageFormatProperties 
-                                 , imageMipTailFirstLod :: Word32 
-                                 , imageMipTailSize :: VkDeviceSize 
-                                 , imageMipTailOffset :: VkDeviceSize 
-                                 , imageMipTailStride :: VkDeviceSize 
-                                 }
+data SparseImageMemoryRequirements =
+  SparseImageMemoryRequirements{ formatProperties :: SparseImageFormatProperties 
+                               , imageMipTailFirstLod :: Word32 
+                               , imageMipTailSize :: VkDeviceSize 
+                               , imageMipTailOffset :: VkDeviceSize 
+                               , imageMipTailStride :: VkDeviceSize 
+                               }
   deriving (Eq)
 
-instance Storable VkSparseImageMemoryRequirements where
+instance Storable SparseImageMemoryRequirements where
   sizeOf ~_ = 48
   alignment ~_ = 8
-  peek ptr = VkSparseImageMemoryRequirements <$> peek (ptr `plusPtr` 0)
-                                             <*> peek (ptr `plusPtr` 20)
-                                             <*> peek (ptr `plusPtr` 24)
-                                             <*> peek (ptr `plusPtr` 32)
-                                             <*> peek (ptr `plusPtr` 40)
-  poke ptr poked = poke (ptr `plusPtr` 0) (formatProperties (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 20) (imageMipTailFirstLod (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 24) (imageMipTailSize (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 32) (imageMipTailOffset (poked :: VkSparseImageMemoryRequirements))
-                *> poke (ptr `plusPtr` 40) (imageMipTailStride (poked :: VkSparseImageMemoryRequirements))
+  peek ptr = SparseImageMemoryRequirements <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 20)
+                                           <*> peek (ptr `plusPtr` 24)
+                                           <*> peek (ptr `plusPtr` 32)
+                                           <*> peek (ptr `plusPtr` 40)
+  poke ptr poked = poke (ptr `plusPtr` 0) (formatProperties (poked :: SparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 20) (imageMipTailFirstLod (poked :: SparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 24) (imageMipTailSize (poked :: SparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 32) (imageMipTailOffset (poked :: SparseImageMemoryRequirements))
+                *> poke (ptr `plusPtr` 40) (imageMipTailStride (poked :: SparseImageMemoryRequirements))
 
 
 
-data VkSparseMemoryBind =
-  VkSparseMemoryBind{ resourceOffset :: VkDeviceSize 
-                    , size :: VkDeviceSize 
-                    , memory :: DeviceMemory 
-                    , memoryOffset :: VkDeviceSize 
-                    , flags :: VkSparseMemoryBindFlags 
-                    }
+data SparseMemoryBind =
+  SparseMemoryBind{ resourceOffset :: VkDeviceSize 
+                  , size :: VkDeviceSize 
+                  , memory :: DeviceMemory 
+                  , memoryOffset :: VkDeviceSize 
+                  , flags :: VkSparseMemoryBindFlags 
+                  }
   deriving (Eq)
 
-instance Storable VkSparseMemoryBind where
+instance Storable SparseMemoryBind where
   sizeOf ~_ = 40
   alignment ~_ = 8
-  peek ptr = VkSparseMemoryBind <$> peek (ptr `plusPtr` 0)
-                                <*> peek (ptr `plusPtr` 8)
-                                <*> peek (ptr `plusPtr` 16)
-                                <*> peek (ptr `plusPtr` 24)
-                                <*> peek (ptr `plusPtr` 32)
-  poke ptr poked = poke (ptr `plusPtr` 0) (resourceOffset (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 8) (size (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 16) (memory (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 24) (memoryOffset (poked :: VkSparseMemoryBind))
-                *> poke (ptr `plusPtr` 32) (flags (poked :: VkSparseMemoryBind))
+  peek ptr = SparseMemoryBind <$> peek (ptr `plusPtr` 0)
+                              <*> peek (ptr `plusPtr` 8)
+                              <*> peek (ptr `plusPtr` 16)
+                              <*> peek (ptr `plusPtr` 24)
+                              <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (resourceOffset (poked :: SparseMemoryBind))
+                *> poke (ptr `plusPtr` 8) (size (poked :: SparseMemoryBind))
+                *> poke (ptr `plusPtr` 16) (memory (poked :: SparseMemoryBind))
+                *> poke (ptr `plusPtr` 24) (memoryOffset (poked :: SparseMemoryBind))
+                *> poke (ptr `plusPtr` 32) (flags (poked :: SparseMemoryBind))
 
 
 
-data VkSparseImageMemoryBind =
-  VkSparseImageMemoryBind{ subresource :: VkImageSubresource 
-                         , offset :: VkOffset3D 
-                         , extent :: VkExtent3D 
-                         , memory :: DeviceMemory 
-                         , memoryOffset :: VkDeviceSize 
-                         , flags :: VkSparseMemoryBindFlags 
-                         }
+data SparseImageMemoryBind =
+  SparseImageMemoryBind{ subresource :: ImageSubresource 
+                       , offset :: Offset3D 
+                       , extent :: Extent3D 
+                       , memory :: DeviceMemory 
+                       , memoryOffset :: VkDeviceSize 
+                       , flags :: VkSparseMemoryBindFlags 
+                       }
   deriving (Eq)
 
-instance Storable VkSparseImageMemoryBind where
+instance Storable SparseImageMemoryBind where
   sizeOf ~_ = 64
   alignment ~_ = 8
-  peek ptr = VkSparseImageMemoryBind <$> peek (ptr `plusPtr` 0)
-                                     <*> peek (ptr `plusPtr` 12)
-                                     <*> peek (ptr `plusPtr` 24)
-                                     <*> peek (ptr `plusPtr` 40)
-                                     <*> peek (ptr `plusPtr` 48)
-                                     <*> peek (ptr `plusPtr` 56)
-  poke ptr poked = poke (ptr `plusPtr` 0) (subresource (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 12) (offset (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 24) (extent (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 40) (memory (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 48) (memoryOffset (poked :: VkSparseImageMemoryBind))
-                *> poke (ptr `plusPtr` 56) (flags (poked :: VkSparseImageMemoryBind))
+  peek ptr = SparseImageMemoryBind <$> peek (ptr `plusPtr` 0)
+                                   <*> peek (ptr `plusPtr` 12)
+                                   <*> peek (ptr `plusPtr` 24)
+                                   <*> peek (ptr `plusPtr` 40)
+                                   <*> peek (ptr `plusPtr` 48)
+                                   <*> peek (ptr `plusPtr` 56)
+  poke ptr poked = poke (ptr `plusPtr` 0) (subresource (poked :: SparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 12) (offset (poked :: SparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 24) (extent (poked :: SparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 40) (memory (poked :: SparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 48) (memoryOffset (poked :: SparseImageMemoryBind))
+                *> poke (ptr `plusPtr` 56) (flags (poked :: SparseImageMemoryBind))
 
 
 
-data VkSparseImageMemoryBindInfo =
-  VkSparseImageMemoryBindInfo{ image :: Image 
-                             , bindCount :: Word32 
-                             , pBinds :: Ptr VkSparseImageMemoryBind 
-                             }
+data SparseImageMemoryBindInfo =
+  SparseImageMemoryBindInfo{ image :: Image 
+                           , bindCount :: Word32 
+                           , pBinds :: Ptr SparseImageMemoryBind 
+                           }
   deriving (Eq)
 
-instance Storable VkSparseImageMemoryBindInfo where
+instance Storable SparseImageMemoryBindInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkSparseImageMemoryBindInfo <$> peek (ptr `plusPtr` 0)
-                                         <*> peek (ptr `plusPtr` 8)
-                                         <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: VkSparseImageMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseImageMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseImageMemoryBindInfo))
+  peek ptr = SparseImageMemoryBindInfo <$> peek (ptr `plusPtr` 0)
+                                       <*> peek (ptr `plusPtr` 8)
+                                       <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: SparseImageMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: SparseImageMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: SparseImageMemoryBindInfo))
 
 
 -- ** vkGetImageSparseMemoryRequirements
 foreign import ccall "vkGetImageSparseMemoryRequirements" vkGetImageSparseMemoryRequirements ::
   Device ->
-  Image -> Ptr Word32 -> Ptr VkSparseImageMemoryRequirements -> IO ()
+  Image -> Ptr Word32 -> Ptr SparseImageMemoryRequirements -> IO ()
 
 -- ** vkQueueBindSparse
 foreign import ccall "vkQueueBindSparse" vkQueueBindSparse ::
-  Queue -> Word32 -> Ptr VkBindSparseInfo -> Fence -> IO VkResult
+  Queue -> Word32 -> Ptr BindSparseInfo -> Fence -> IO VkResult
 
 
-data VkBindSparseInfo =
-  VkBindSparseInfo{ sType :: VkStructureType 
-                  , pNext :: Ptr Void 
-                  , waitSemaphoreCount :: Word32 
-                  , pWaitSemaphores :: Ptr Semaphore 
-                  , bufferBindCount :: Word32 
-                  , pBufferBinds :: Ptr VkSparseBufferMemoryBindInfo 
-                  , imageOpaqueBindCount :: Word32 
-                  , pImageOpaqueBinds :: Ptr VkSparseImageOpaqueMemoryBindInfo 
-                  , imageBindCount :: Word32 
-                  , pImageBinds :: Ptr VkSparseImageMemoryBindInfo 
-                  , signalSemaphoreCount :: Word32 
-                  , pSignalSemaphores :: Ptr Semaphore 
-                  }
+data BindSparseInfo =
+  BindSparseInfo{ sType :: VkStructureType 
+                , pNext :: Ptr Void 
+                , waitSemaphoreCount :: Word32 
+                , pWaitSemaphores :: Ptr Semaphore 
+                , bufferBindCount :: Word32 
+                , pBufferBinds :: Ptr SparseBufferMemoryBindInfo 
+                , imageOpaqueBindCount :: Word32 
+                , pImageOpaqueBinds :: Ptr SparseImageOpaqueMemoryBindInfo 
+                , imageBindCount :: Word32 
+                , pImageBinds :: Ptr SparseImageMemoryBindInfo 
+                , signalSemaphoreCount :: Word32 
+                , pSignalSemaphores :: Ptr Semaphore 
+                }
   deriving (Eq)
 
-instance Storable VkBindSparseInfo where
+instance Storable BindSparseInfo where
   sizeOf ~_ = 96
   alignment ~_ = 8
-  peek ptr = VkBindSparseInfo <$> peek (ptr `plusPtr` 0)
-                              <*> peek (ptr `plusPtr` 8)
-                              <*> peek (ptr `plusPtr` 16)
-                              <*> peek (ptr `plusPtr` 24)
-                              <*> peek (ptr `plusPtr` 32)
-                              <*> peek (ptr `plusPtr` 40)
-                              <*> peek (ptr `plusPtr` 48)
-                              <*> peek (ptr `plusPtr` 56)
-                              <*> peek (ptr `plusPtr` 64)
-                              <*> peek (ptr `plusPtr` 72)
-                              <*> peek (ptr `plusPtr` 80)
-                              <*> peek (ptr `plusPtr` 88)
-  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 8) (pNext (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 32) (bufferBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 40) (pBufferBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 48) (imageOpaqueBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 56) (pImageOpaqueBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 64) (imageBindCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 72) (pImageBinds (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 80) (signalSemaphoreCount (poked :: VkBindSparseInfo))
-                *> poke (ptr `plusPtr` 88) (pSignalSemaphores (poked :: VkBindSparseInfo))
+  peek ptr = BindSparseInfo <$> peek (ptr `plusPtr` 0)
+                            <*> peek (ptr `plusPtr` 8)
+                            <*> peek (ptr `plusPtr` 16)
+                            <*> peek (ptr `plusPtr` 24)
+                            <*> peek (ptr `plusPtr` 32)
+                            <*> peek (ptr `plusPtr` 40)
+                            <*> peek (ptr `plusPtr` 48)
+                            <*> peek (ptr `plusPtr` 56)
+                            <*> peek (ptr `plusPtr` 64)
+                            <*> peek (ptr `plusPtr` 72)
+                            <*> peek (ptr `plusPtr` 80)
+                            <*> peek (ptr `plusPtr` 88)
+  poke ptr poked = poke (ptr `plusPtr` 0) (sType (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 8) (pNext (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 16) (waitSemaphoreCount (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 24) (pWaitSemaphores (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 32) (bufferBindCount (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 40) (pBufferBinds (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 48) (imageOpaqueBindCount (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 56) (pImageOpaqueBinds (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 64) (imageBindCount (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 72) (pImageBinds (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 80) (signalSemaphoreCount (poked :: BindSparseInfo))
+                *> poke (ptr `plusPtr` 88) (pSignalSemaphores (poked :: BindSparseInfo))
 
 
 
-data VkSparseBufferMemoryBindInfo =
-  VkSparseBufferMemoryBindInfo{ buffer :: Buffer 
-                              , bindCount :: Word32 
-                              , pBinds :: Ptr VkSparseMemoryBind 
-                              }
+data SparseBufferMemoryBindInfo =
+  SparseBufferMemoryBindInfo{ buffer :: Buffer 
+                            , bindCount :: Word32 
+                            , pBinds :: Ptr SparseMemoryBind 
+                            }
   deriving (Eq)
 
-instance Storable VkSparseBufferMemoryBindInfo where
+instance Storable SparseBufferMemoryBindInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkSparseBufferMemoryBindInfo <$> peek (ptr `plusPtr` 0)
-                                          <*> peek (ptr `plusPtr` 8)
-                                          <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: VkSparseBufferMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseBufferMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseBufferMemoryBindInfo))
+  peek ptr = SparseBufferMemoryBindInfo <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (buffer (poked :: SparseBufferMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: SparseBufferMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: SparseBufferMemoryBindInfo))
 
 
 -- ** VkSparseImageFormatFlags
@@ -270,7 +270,7 @@ foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" vkGetPhysi
       VkSampleCountFlags ->
         VkImageUsageFlags ->
           VkImageTiling ->
-            Ptr Word32 -> Ptr VkSparseImageFormatProperties -> IO ()
+            Ptr Word32 -> Ptr SparseImageFormatProperties -> IO ()
 
 -- ** VkSparseMemoryBindFlags
 
@@ -297,40 +297,40 @@ pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = VkSparseMemoryBindFlags 0x1
 
 
 
-data VkSparseImageOpaqueMemoryBindInfo =
-  VkSparseImageOpaqueMemoryBindInfo{ image :: Image 
-                                   , bindCount :: Word32 
-                                   , pBinds :: Ptr VkSparseMemoryBind 
-                                   }
+data SparseImageOpaqueMemoryBindInfo =
+  SparseImageOpaqueMemoryBindInfo{ image :: Image 
+                                 , bindCount :: Word32 
+                                 , pBinds :: Ptr SparseMemoryBind 
+                                 }
   deriving (Eq)
 
-instance Storable VkSparseImageOpaqueMemoryBindInfo where
+instance Storable SparseImageOpaqueMemoryBindInfo where
   sizeOf ~_ = 24
   alignment ~_ = 8
-  peek ptr = VkSparseImageOpaqueMemoryBindInfo <$> peek (ptr `plusPtr` 0)
-                                               <*> peek (ptr `plusPtr` 8)
-                                               <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: VkSparseImageOpaqueMemoryBindInfo))
-                *> poke (ptr `plusPtr` 8) (bindCount (poked :: VkSparseImageOpaqueMemoryBindInfo))
-                *> poke (ptr `plusPtr` 16) (pBinds (poked :: VkSparseImageOpaqueMemoryBindInfo))
+  peek ptr = SparseImageOpaqueMemoryBindInfo <$> peek (ptr `plusPtr` 0)
+                                             <*> peek (ptr `plusPtr` 8)
+                                             <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (image (poked :: SparseImageOpaqueMemoryBindInfo))
+                *> poke (ptr `plusPtr` 8) (bindCount (poked :: SparseImageOpaqueMemoryBindInfo))
+                *> poke (ptr `plusPtr` 16) (pBinds (poked :: SparseImageOpaqueMemoryBindInfo))
 
 
 
-data VkSparseImageFormatProperties =
-  VkSparseImageFormatProperties{ aspectMask :: VkImageAspectFlags 
-                               , imageGranularity :: VkExtent3D 
-                               , flags :: VkSparseImageFormatFlags 
-                               }
+data SparseImageFormatProperties =
+  SparseImageFormatProperties{ aspectMask :: VkImageAspectFlags 
+                             , imageGranularity :: Extent3D 
+                             , flags :: VkSparseImageFormatFlags 
+                             }
   deriving (Eq)
 
-instance Storable VkSparseImageFormatProperties where
+instance Storable SparseImageFormatProperties where
   sizeOf ~_ = 20
   alignment ~_ = 4
-  peek ptr = VkSparseImageFormatProperties <$> peek (ptr `plusPtr` 0)
-                                           <*> peek (ptr `plusPtr` 4)
-                                           <*> peek (ptr `plusPtr` 16)
-  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: VkSparseImageFormatProperties))
-                *> poke (ptr `plusPtr` 4) (imageGranularity (poked :: VkSparseImageFormatProperties))
-                *> poke (ptr `plusPtr` 16) (flags (poked :: VkSparseImageFormatProperties))
+  peek ptr = SparseImageFormatProperties <$> peek (ptr `plusPtr` 0)
+                                         <*> peek (ptr `plusPtr` 4)
+                                         <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (aspectMask (poked :: SparseImageFormatProperties))
+                *> poke (ptr `plusPtr` 4) (imageGranularity (poked :: SparseImageFormatProperties))
+                *> poke (ptr `plusPtr` 16) (flags (poked :: SparseImageFormatProperties))
 
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -67,7 +67,7 @@ data SparseImageMemoryRequirements =
                                , imageMipTailOffset :: DeviceSize 
                                , imageMipTailStride :: DeviceSize 
                                }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseImageMemoryRequirements where
   sizeOf ~_ = 48
@@ -92,7 +92,7 @@ data SparseMemoryBind =
                   , memoryOffset :: DeviceSize 
                   , flags :: SparseMemoryBindFlags 
                   }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseMemoryBind where
   sizeOf ~_ = 40
@@ -118,7 +118,7 @@ data SparseImageMemoryBind =
                        , memoryOffset :: DeviceSize 
                        , flags :: SparseMemoryBindFlags 
                        }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseImageMemoryBind where
   sizeOf ~_ = 64
@@ -143,7 +143,7 @@ data SparseImageMemoryBindInfo =
                            , bindCount :: Word32 
                            , pBinds :: Ptr SparseImageMemoryBind 
                            }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseImageMemoryBindInfo where
   sizeOf ~_ = 24
@@ -180,7 +180,7 @@ data BindSparseInfo =
                 , signalSemaphoreCount :: Word32 
                 , pSignalSemaphores :: Ptr Semaphore 
                 }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable BindSparseInfo where
   sizeOf ~_ = 96
@@ -217,7 +217,7 @@ data SparseBufferMemoryBindInfo =
                             , bindCount :: Word32 
                             , pBinds :: Ptr SparseMemoryBind 
                             }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseBufferMemoryBindInfo where
   sizeOf ~_ = 24
@@ -233,7 +233,7 @@ instance Storable SparseBufferMemoryBindInfo where
 -- ** SparseImageFormatFlags
 
 newtype SparseImageFormatFlags = SparseImageFormatFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show SparseImageFormatFlags where
   showsPrec _ SparseImageFormatSingleMiptailBit = showString "SparseImageFormatSingleMiptailBit"
@@ -275,7 +275,7 @@ foreign import ccall "vkGetPhysicalDeviceSparseImageFormatProperties" getPhysica
 -- ** SparseMemoryBindFlags
 
 newtype SparseMemoryBindFlags = SparseMemoryBindFlags Flags
-  deriving (Eq, Storable, Bits, FiniteBits)
+  deriving (Eq, Ord, Storable, Bits, FiniteBits)
 
 instance Show SparseMemoryBindFlags where
   showsPrec _ SparseMemoryBindMetadataBit = showString "SparseMemoryBindMetadataBit"
@@ -302,7 +302,7 @@ data SparseImageOpaqueMemoryBindInfo =
                                  , bindCount :: Word32 
                                  , pBinds :: Ptr SparseMemoryBind 
                                  }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseImageOpaqueMemoryBindInfo where
   sizeOf ~_ = 24
@@ -321,7 +321,7 @@ data SparseImageFormatProperties =
                              , imageGranularity :: Extent3D 
                              , flags :: SparseImageFormatFlags 
                              }
-  deriving (Eq)
+  deriving (Eq, Ord)
 
 instance Storable SparseImageFormatProperties where
   sizeOf ~_ = 20

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -236,16 +236,16 @@ newtype SparseImageFormatFlags = SparseImageFormatFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SparseImageFormatFlags where
-  showsPrec _ VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = showString "VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT"
-  showsPrec _ VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT"
-  showsPrec _ VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = showString "VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT"
+  showsPrec _ SparseImageFormatSingleMiptailBit = showString "SparseImageFormatSingleMiptailBit"
+  showsPrec _ SparseImageFormatAlignedMipSizeBit = showString "SparseImageFormatAlignedMipSizeBit"
+  showsPrec _ SparseImageFormatNonstandardBlockSizeBit = showString "SparseImageFormatNonstandardBlockSizeBit"
   
   showsPrec p (SparseImageFormatFlags x) = showParen (p >= 11) (showString "SparseImageFormatFlags " . showsPrec 11 x)
 
 instance Read SparseImageFormatFlags where
-  readPrec = parens ( choose [ ("VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT", pure VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT)
-                             , ("VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT)
-                             , ("VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT", pure VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT)
+  readPrec = parens ( choose [ ("SparseImageFormatSingleMiptailBit", pure SparseImageFormatSingleMiptailBit)
+                             , ("SparseImageFormatAlignedMipSizeBit", pure SparseImageFormatAlignedMipSizeBit)
+                             , ("SparseImageFormatNonstandardBlockSizeBit", pure SparseImageFormatNonstandardBlockSizeBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SparseImageFormatFlags")
@@ -255,11 +255,11 @@ instance Read SparseImageFormatFlags where
                     )
 
 -- | Image uses a single miptail region for all array layers
-pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = SparseImageFormatFlags 0x1
+pattern SparseImageFormatSingleMiptailBit = SparseImageFormatFlags 0x1
 -- | Image requires mip levels to be an exact multiple of the sparse image block size for non-miptail levels.
-pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = SparseImageFormatFlags 0x2
+pattern SparseImageFormatAlignedMipSizeBit = SparseImageFormatFlags 0x2
 -- | Image uses a non-standard sparse block size
-pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = SparseImageFormatFlags 0x4
+pattern SparseImageFormatNonstandardBlockSizeBit = SparseImageFormatFlags 0x4
 
 
 -- ** getPhysicalDeviceSparseImageFormatProperties
@@ -278,12 +278,12 @@ newtype SparseMemoryBindFlags = SparseMemoryBindFlags Flags
   deriving (Eq, Storable, Bits, FiniteBits)
 
 instance Show SparseMemoryBindFlags where
-  showsPrec _ VK_SPARSE_MEMORY_BIND_METADATA_BIT = showString "VK_SPARSE_MEMORY_BIND_METADATA_BIT"
+  showsPrec _ SparseMemoryBindMetadataBit = showString "SparseMemoryBindMetadataBit"
   
   showsPrec p (SparseMemoryBindFlags x) = showParen (p >= 11) (showString "SparseMemoryBindFlags " . showsPrec 11 x)
 
 instance Read SparseMemoryBindFlags where
-  readPrec = parens ( choose [ ("VK_SPARSE_MEMORY_BIND_METADATA_BIT", pure VK_SPARSE_MEMORY_BIND_METADATA_BIT)
+  readPrec = parens ( choose [ ("SparseMemoryBindMetadataBit", pure SparseMemoryBindMetadataBit)
                              ] +++
                       prec 10 (do
                         expectP (Ident "SparseMemoryBindFlags")
@@ -293,7 +293,7 @@ instance Read SparseMemoryBindFlags where
                     )
 
 -- | Operation binds resource metadata to memory
-pattern VK_SPARSE_MEMORY_BIND_METADATA_BIT = SparseMemoryBindFlags 0x1
+pattern SparseMemoryBindMetadataBit = SparseMemoryBindFlags 0x1
 
 
 

--- a/src/Graphics/Vulkan/Version.hs
+++ b/src/Graphics/Vulkan/Version.hs
@@ -1,7 +1,7 @@
 
 module Graphics.Vulkan.Version where
 
-import Data.Word( Word32
+import Data.Word( Word32(..)
                 )
 import Data.Bits( shiftR
                 , shiftL

--- a/src/Graphics/Vulkan/Version.hs
+++ b/src/Graphics/Vulkan/Version.hs
@@ -9,18 +9,18 @@ import Data.Bits( shiftR
                 , (.&.)
                 )
 
-vkApiVersion :: Word32
-vkApiVersion  = vkMakeVersion 1 0 3
+apiVersion :: Word32
+apiVersion  = makeVersion 1 0 3
 
-vkVersionMinor :: Word32 -> Word32
-vkVersionMinor version = (.&.) (shiftR version 12) 1023
+versionMinor :: Word32 -> Word32
+versionMinor version = (.&.) (shiftR version 12) 1023
 
-vkVersionPatch :: Word32 -> Word32
-vkVersionPatch version = (.&.) version 4095
+versionPatch :: Word32 -> Word32
+versionPatch version = (.&.) version 4095
 
-vkMakeVersion :: Word32 -> Word32 -> Word32 -> Word32
-vkMakeVersion major minor patch = (.|.) ((.|.) (shiftL major 22) (shiftL minor 12)) patch
+makeVersion :: Word32 -> Word32 -> Word32 -> Word32
+makeVersion major minor patch = (.|.) ((.|.) (shiftL major 22) (shiftL minor 12)) patch
 
-vkVersionMajor :: Word32 -> Word32
-vkVersionMajor version = shiftR version 22
+versionMajor :: Word32 -> Word32
+versionMajor version = shiftR version 22
 


### PR DESCRIPTION
This still needs a bunch of cleanup, but it's the result of me trying to get more haskelly (and less redundant) names.  There are also a few unrelated changes in here that I don't intend to be merged.

I ended up getting rid of the separate FlagBits types because it simplified import generation.  I'm not sure if that's a good idea, but it seems to work for the existing spec.

I think it would make sense to combine the renaming with the partitioning system, but this was easier for me to prototype without fully understanding that stuff.

I originally wanted to have separate types for the parsed spec and the haskell spec, with the renaming/partitioning done in Spec -> HsSpec, but that got really complicated with the way C expressions are handled, etc.  So I took it back a step and just added haskell names to the spec.

There are still some things that don't come out quite right, like: Unorm (should be UNorm), R8g8b8, etc.  Those can be easily fixed with special cases.

Do you think this is worth continuing?  Any other thoughts?