### PR TITLE
Vulkan sdk fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ install:
   - pushd ~/.vulkan
   - curl https://vulkan.lunarg.com/pub/sdks/linux/latest -L -o vulkan.run
   - chmod +x vulkan.run
-  - sudo ./vulkan.run
+  - ./vulkan.run
+  - export VULKAN_SDK=$(pwd)/VulkanSDK/*/x86_64
   - popd
   - export STACK_NAME=stack-$STACK_VER-linux-x86_64
   - mkdir -p ~/.stack-bin
@@ -42,5 +43,5 @@ install:
 script:
   - find generate/src -name "*.hs" | xargs stylish-haskell -i
   - 'if [ -n "$(git status --porcelain)" ]; then echo Error: changes found after stylish-haskell; git status; exit 1; fi'
-  - ./build.sh
+  - ./build.sh --extra-lib-dirs $VULKAN_SDK/lib
   - 'if [ -n "$(git status --porcelain)" ]; then echo Error: changes found after generate; git status; exit 1; fi'

--- a/build.sh
+++ b/build.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -e
 pushd generate
-stack build
+stack build $*
 rm -rf out
 cat ./Vulkan-Docs/src/spec/vk.xml | stack exec generate
 popd
 rm -rf src
 mv generate/out src
-stack build
+stack build $*


### PR DESCRIPTION
Recent versions of the Vulkan SDK no longer install to the system, so you need to set up include/lib paths.  This change gets builds working again.