### PR TITLE
WIP: Extension enums

### DIFF
--- a/generate/src/Parse/Extension.hs
+++ b/generate/src/Parse/Extension.hs
@@ -30,8 +30,8 @@ parseExtension = extractFields "Extension"
           eContact <- optionalAttrValue "contact" -< extension
           require <- oneRequired "require"
                        (hasName "require" <<< getChildren) -< extension
-          eEnumExtensions <-
-            listA (parseEnumExtension <<< getChildren) -< require
+          eEnums <-
+            listA (parseExtensionEnum <<< getChildren) -< require
           eConstants <-
             listA (parseExtensionConstant <<< getChildren) -< require
           eCommandNames <-
@@ -40,19 +40,19 @@ parseExtension = extractFields "Extension"
             listA (parseTypeName <<< getChildren) -< require
           returnA -< Extension{..}
 
-parseEnumExtension :: IOStateArrow s XmlTree EnumExtension
-parseEnumExtension = extractFields "enum extension"
+parseExtensionEnum :: IOStateArrow s XmlTree ExtensionEnum
+parseExtensionEnum = extractFields "enum extension"
                                    (hasName "enum" >>> hasAttr "extends")
                                    extract
-  where extract = proc enumExtension -> do
-          eeName <- requiredAttrValue "name" -< enumExtension
-          eeExtends <- requiredAttrValue "extends" -< enumExtension
+  where extract = proc extensionEnum -> do
+          eeName <- requiredAttrValue "name" -< extensionEnum
+          eeExtends <- requiredAttrValue "extends" -< extensionEnum
           eeOffset <- requiredRead <<<
-                      requiredAttrValue "offset" -< enumExtension
+                      requiredAttrValue "offset" -< extensionEnum
           eeDirection <- fromMaybe Positive ^<<
                          traverseMaybeA parseDirection <<<
-                         optionalAttrValue "dir" -< enumExtension
-          returnA -< EnumExtension{..}
+                         optionalAttrValue "dir" -< extensionEnum
+          returnA -< ExtensionEnum{..}
 
 parseDirection :: IOStateArrow s String Direction
 parseDirection = arrF p `orElse`

--- a/generate/src/Spec/Extension.hs
+++ b/generate/src/Spec/Extension.hs
@@ -2,16 +2,16 @@ module Spec.Extension where
 
 import           Data.Int (Int32)
 
-data Extension = Extension{ eName           :: String
-                          , eNumber         :: Int
-                          , eSupported      :: String
-                          , eProtect        :: Maybe String
-                          , eAuthor         :: Maybe String
-                          , eContact        :: Maybe String
-                          , eEnumExtensions :: [EnumExtension]
-                          , eConstants      :: [ExtensionConstant]
-                          , eCommandNames   :: [String]
-                          , eTypeNames      :: [String]
+data Extension = Extension{ eName         :: String
+                          , eNumber       :: Int
+                          , eSupported    :: String
+                          , eProtect      :: Maybe String
+                          , eAuthor       :: Maybe String
+                          , eContact      :: Maybe String
+                          , eEnums        :: [ExtensionEnum]
+                          , eConstants    :: [ExtensionConstant]
+                          , eCommandNames :: [String]
+                          , eTypeNames    :: [String]
                           }
   deriving(Show)
 
@@ -19,7 +19,7 @@ data Direction = Negative
                | Positive
   deriving(Show)
 
-data EnumExtension = EnumExtension{ eeName      :: String
+data ExtensionEnum = ExtensionEnum{ eeName      :: String
                                   , eeExtends   :: String
                                   , eeOffset    :: Int32
                                   , eeDirection :: Direction
@@ -34,7 +34,7 @@ data ExtensionConstant = ExtensionConstant{ ecName  :: String
 allExtensionNames :: Extension -> [String]
 allExtensionNames e =
   -- TODO: Uncomment
-  -- eeName <$> eEnumExtensions e ++
+  -- eeName <$> eExtensionEnums e ++
   -- evName <$> eConstants e ++
   eCommandNames e ++
   eTypeNames e

--- a/generate/src/Spec/Extension.hs
+++ b/generate/src/Spec/Extension.hs
@@ -32,7 +32,7 @@ data ExtensionConstant = ExtensionConstant{ ecName    :: String
   deriving(Show)
 
 data ExtensionBitmask = ExtensionBitmask{ ebmName    :: String
-                                        , ebmBitpos  :: Integer
+                                        , ebmBitpos  :: Int
                                         , ebmExtends :: Maybe String
                                         }
   deriving(Show)
@@ -40,6 +40,7 @@ data ExtensionBitmask = ExtensionBitmask{ ebmName    :: String
 allExtensionNames :: Extension -> [String]
 allExtensionNames e =
   (eeName <$> eEnums e) ++
-  -- evName <$> eConstants e ++
+  (ecName <$> eConstants e) ++
+  (ebmName <$> eBitmasks e) ++
   eCommandNames e ++
   eTypeNames e

--- a/generate/src/Spec/Extension.hs
+++ b/generate/src/Spec/Extension.hs
@@ -1,7 +1,5 @@
 module Spec.Extension where
 
-import           Data.Int (Int32)
-
 data Extension = Extension{ eName         :: String
                           , eNumber       :: Int
                           , eSupported    :: String
@@ -22,7 +20,7 @@ data Direction = Negative
 
 data ExtensionEnum = ExtensionEnum{ eeName      :: String
                                   , eeExtends   :: String
-                                  , eeOffset    :: Int32
+                                  , eeOffset    :: Int
                                   , eeDirection :: Direction
                                   }
   deriving(Show)
@@ -41,8 +39,7 @@ data ExtensionBitmask = ExtensionBitmask{ ebmName    :: String
 
 allExtensionNames :: Extension -> [String]
 allExtensionNames e =
-  -- TODO: Uncomment
-  -- eeName <$> eExtensionEnums e ++
+  (eeName <$> eEnums e) ++
   -- evName <$> eConstants e ++
   eCommandNames e ++
   eTypeNames e

--- a/generate/src/Spec/Extension.hs
+++ b/generate/src/Spec/Extension.hs
@@ -10,6 +10,7 @@ data Extension = Extension{ eName         :: String
                           , eContact      :: Maybe String
                           , eEnums        :: [ExtensionEnum]
                           , eConstants    :: [ExtensionConstant]
+                          , eBitmasks     :: [ExtensionBitmask]
                           , eCommandNames :: [String]
                           , eTypeNames    :: [String]
                           }
@@ -26,9 +27,16 @@ data ExtensionEnum = ExtensionEnum{ eeName      :: String
                                   }
   deriving(Show)
 
-data ExtensionConstant = ExtensionConstant{ ecName  :: String
-                                          , ecValue :: Either String Integer
+data ExtensionConstant = ExtensionConstant{ ecName    :: String
+                                          , ecValue   :: Either String Integer
+                                          , ecExtends :: Maybe String
                                           }
+  deriving(Show)
+
+data ExtensionBitmask = ExtensionBitmask{ ebmName    :: String
+                                        , ebmBitpos  :: Integer
+                                        , ebmExtends :: Maybe String
+                                        }
   deriving(Show)
 
 allExtensionNames :: Extension -> [String]

--- a/generate/src/Spec/Graph.hs
+++ b/generate/src/Spec/Graph.hs
@@ -30,6 +30,7 @@ data Vertex = Vertex{ vName         :: String
                     , vDependencies :: [Vertex]
                     , vSourceEntity :: SourceEntity
                     }
+  deriving (Show)
 
 data SourceEntity = AnInclude Include
                   | ADefine Define

--- a/generate/src/Spec/Partition.hs
+++ b/generate/src/Spec/Partition.hs
@@ -142,6 +142,10 @@ bespokeModuleExports = M.fromList
                  , "VK_UUID_SIZE"
                  ]
     )
+  , ( ModuleName ("Graphics.Vulkan.DeviceInitialization")
+    , S.fromList [ "VkFormatFeatureFlags"
+                 ]
+    )
   , ( ModuleName "Graphics.Vulkan.Memory"
     , S.fromList [ "VkDeviceMemory"
                  , "VkSystemAllocationScope"
@@ -183,6 +187,7 @@ bespokeModuleExports = M.fromList
     , S.fromList [ "VkFilter"
                  , "VkCompareOp"
                  , "VkSampleCountFlagBits"
+                 , "VkSamplerAddressMode"
                  ]
     )
   , ( ModuleName "Graphics.Vulkan.Image"

--- a/generate/src/Write/Constant.hs
+++ b/generate/src/Write/Constant.hs
@@ -3,10 +3,12 @@
 
 module Write.Constant
   ( writeConstant
+  , writeExtensionConstant
   ) where
 
 import           Data.Maybe                    (fromMaybe)
 import           Spec.Constant
+import           Spec.Extension
 import           Text.InterpolatedString.Perl6
 import           Text.PrettyPrint.Leijen.Text  hiding ((<$>))
 import           Write.Utils
@@ -45,3 +47,9 @@ type {cName c} = {i}|]
   | otherwise
   = pure Nothing
 
+writeExtensionConstant :: ExtensionConstant -> Write Doc
+writeExtensionConstant ec = do
+  tellExtension "PatternSynonyms"
+  pure [qc|pattern {ecName ec} = {fromMaybe "" $ ecExtends ec} {value}|]
+  where value = case ecValue ec of Left sv -> sv
+                                   Right iv -> showHex' iv

--- a/generate/src/Write/Enum.hs
+++ b/generate/src/Write/Enum.hs
@@ -3,11 +3,13 @@
 
 module Write.Enum
   ( writeEnum
+  , writeExtensionEnum
   ) where
 
 import           Data.Maybe                    (fromMaybe)
 import           Prelude                       hiding (Enum)
 import           Spec.Enum
+import qualified Spec.Extension                as Ex
 import           Text.InterpolatedString.Perl6
 import           Text.PrettyPrint.Leijen.Text  hiding ((<$>))
 import           Write.Utils
@@ -55,6 +57,16 @@ instance Read {eName e} where
 
 {vcat $ writeElement e <$> eElements e}
 |]
+
+writeExtensionEnum :: Ex.ExtensionEnum -> Int -> Write Doc
+writeExtensionEnum ee extnumber = do
+  tellExtension "PatternSynonyms"
+  pure [qc|pattern {Ex.eeName ee} = {Ex.eeExtends ee} {showsPrec 10 (value) ""}|]
+  where extBase = 1000000000
+        extBlockSize = 1000
+        value = dir * (extBase + (extnumber - 1) * extBlockSize + Ex.eeOffset ee)
+        dir = case Ex.eeDirection ee of Ex.Negative -> -1
+                                        Ex.Positive -> 1
 
 writeElement :: Enum -> EnumElement -> Doc
 writeElement e el =

--- a/generate/src/Write/Type/Bitmask.hs
+++ b/generate/src/Write/Type/Bitmask.hs
@@ -3,12 +3,14 @@
 
 module Write.Type.Bitmask
   ( writeBitmaskType
+  , writeExtensionBitmask
   ) where
 
 import           Data.Bits                     (shiftL)
 import           Data.Maybe                    (fromMaybe)
 import           Data.Word                     (Word32)
 import           Spec.Bitmask
+import           Spec.Extension
 import           Spec.Type
 import           Text.InterpolatedString.Perl6
 import           Text.PrettyPrint.Leijen.Text  hiding ((<$>))
@@ -109,3 +111,9 @@ writeBitPositionReadTuple bp = [qc|("{bmbpName bp}", pure {bmbpName bp})|]
 
 writeValueReadTuple :: BitmaskValue -> Doc
 writeValueReadTuple v = [qc|("{bmvName v}", pure {bmvName v})|]
+
+writeExtensionBitmask :: ExtensionBitmask -> Write Doc
+writeExtensionBitmask bm = do
+  tellExtension "PatternSynonyms"
+  tellExtension "ScopedTypeVariables"
+  pure [qc|pattern {ebmName bm} = {fromMaybe "" $ ebmExtends bm} {showHex' $ (1 `shiftL` ebmBitpos bm :: Word32)}|]

--- a/generate/src/Write/Vertex.hs
+++ b/generate/src/Write/Vertex.hs
@@ -33,3 +33,6 @@ writeVertex v =
     AnEnum enum -> writeEnum enum
     ABitmask _ -> pure empty -- Handled by bitmasktype
     AConstant constant -> writeConstant constant
+    AnExtensionEnum enum extnumber -> writeExtensionEnum enum extnumber
+    AnExtensionConstant _ -> pure empty --writeExtensionConstant constant
+    AnExtensionBitmask _ -> pure empty --writeExtensionBitmask bitmask

--- a/generate/src/Write/Vertex.hs
+++ b/generate/src/Write/Vertex.hs
@@ -34,5 +34,5 @@ writeVertex v =
     ABitmask _ -> pure empty -- Handled by bitmasktype
     AConstant constant -> writeConstant constant
     AnExtensionEnum enum extnumber -> writeExtensionEnum enum extnumber
-    AnExtensionConstant _ -> pure empty --writeExtensionConstant constant
-    AnExtensionBitmask _ -> pure empty --writeExtensionBitmask bitmask
+    AnExtensionConstant constant -> writeExtensionConstant constant
+    AnExtensionBitmask bitmask -> writeExtensionBitmask bitmask

--- a/src/Graphics/Vulkan.hs
+++ b/src/Graphics/Vulkan.hs
@@ -1,5 +1,9 @@
 module Graphics.Vulkan
-  ( module Graphics.Vulkan.Buffer
+  ( module Graphics.Vulkan.AMD.GcnShader
+  , module Graphics.Vulkan.AMD.RasterizationOrder
+  , module Graphics.Vulkan.AMD.ShaderExplicitVertexParameter
+  , module Graphics.Vulkan.AMD.ShaderTrinaryMinmax
+  , module Graphics.Vulkan.Buffer
   , module Graphics.Vulkan.BufferView
   , module Graphics.Vulkan.CommandBuffer
   , module Graphics.Vulkan.CommandBufferBuilding
@@ -9,19 +13,23 @@ module Graphics.Vulkan
   , module Graphics.Vulkan.DescriptorSet
   , module Graphics.Vulkan.Device
   , module Graphics.Vulkan.DeviceInitialization
+  , module Graphics.Vulkan.EXT.DebugMarker
   , module Graphics.Vulkan.EXT.DebugReport
   , module Graphics.Vulkan.Event
   , module Graphics.Vulkan.ExtensionDiscovery
   , module Graphics.Vulkan.Fence
+  , module Graphics.Vulkan.IMG.FilterCubic
   , module Graphics.Vulkan.Image
   , module Graphics.Vulkan.ImageView
   , module Graphics.Vulkan.KHR.Display
   , module Graphics.Vulkan.KHR.DisplaySwapchain
+  , module Graphics.Vulkan.KHR.SamplerMirrorClampToEdge
   , module Graphics.Vulkan.KHR.Surface
   , module Graphics.Vulkan.KHR.Swapchain
   , module Graphics.Vulkan.LayerDiscovery
   , module Graphics.Vulkan.Memory
   , module Graphics.Vulkan.MemoryManagement
+  , module Graphics.Vulkan.NV.GlslShader
   , module Graphics.Vulkan.OtherTypes
   , module Graphics.Vulkan.Pass
   , module Graphics.Vulkan.Pipeline
@@ -36,6 +44,10 @@ module Graphics.Vulkan
   , module Graphics.Vulkan.Version
   ) where
 
+import Graphics.Vulkan.AMD.GcnShader
+import Graphics.Vulkan.AMD.RasterizationOrder
+import Graphics.Vulkan.AMD.ShaderExplicitVertexParameter
+import Graphics.Vulkan.AMD.ShaderTrinaryMinmax
 import Graphics.Vulkan.Buffer
 import Graphics.Vulkan.BufferView
 import Graphics.Vulkan.CommandBuffer
@@ -46,19 +58,23 @@ import Graphics.Vulkan.Core
 import Graphics.Vulkan.DescriptorSet
 import Graphics.Vulkan.Device
 import Graphics.Vulkan.DeviceInitialization
+import Graphics.Vulkan.EXT.DebugMarker
 import Graphics.Vulkan.EXT.DebugReport
 import Graphics.Vulkan.Event
 import Graphics.Vulkan.ExtensionDiscovery
 import Graphics.Vulkan.Fence
+import Graphics.Vulkan.IMG.FilterCubic
 import Graphics.Vulkan.Image
 import Graphics.Vulkan.ImageView
 import Graphics.Vulkan.KHR.Display
 import Graphics.Vulkan.KHR.DisplaySwapchain
+import Graphics.Vulkan.KHR.SamplerMirrorClampToEdge
 import Graphics.Vulkan.KHR.Surface
 import Graphics.Vulkan.KHR.Swapchain
 import Graphics.Vulkan.LayerDiscovery
 import Graphics.Vulkan.Memory
 import Graphics.Vulkan.MemoryManagement
+import Graphics.Vulkan.NV.GlslShader
 import Graphics.Vulkan.OtherTypes
 import Graphics.Vulkan.Pass
 import Graphics.Vulkan.Pipeline

--- a/src/Graphics/Vulkan/AMD/GcnShader.hs
+++ b/src/Graphics/Vulkan/AMD/GcnShader.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.AMD.GcnShader where
+
+
+
+

--- a/src/Graphics/Vulkan/AMD/GcnShader.hs
+++ b/src/Graphics/Vulkan/AMD/GcnShader.hs
@@ -1,6 +1,7 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.AMD.GcnShader where
 
 
 
-
+pattern VK_AMD_GCN_SHADER_EXTENSION_NAME =  "VK_AMD_gcn_shader"
+pattern VK_AMD_GCN_SHADER_SPEC_VERSION =  0x1

--- a/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
+++ b/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Graphics.Vulkan.AMD.RasterizationOrder where
+
+import Text.Read.Lex( Lexeme(Ident)
+                    )
+import GHC.Read( expectP
+               , choose
+               )
+import Foreign.Ptr( Ptr
+                  , plusPtr
+                  )
+import Data.Int( Int32
+               )
+import Foreign.Storable( Storable(..)
+                       )
+import Data.Void( Void
+                )
+import Text.Read( Read(..)
+                , parens
+                )
+import Text.ParserCombinators.ReadPrec( prec
+                                      , (+++)
+                                      , step
+                                      )
+import Graphics.Vulkan.Core( VkStructureType(..)
+                           )
+
+-- ** VkRasterizationOrderAMD
+
+newtype VkRasterizationOrderAMD = VkRasterizationOrderAMD Int32
+  deriving (Eq, Ord, Storable)
+
+instance Show VkRasterizationOrderAMD where
+  showsPrec _ VK_RASTERIZATION_ORDER_STRICT_AMD = showString "VK_RASTERIZATION_ORDER_STRICT_AMD"
+  showsPrec _ VK_RASTERIZATION_ORDER_RELAXED_AMD = showString "VK_RASTERIZATION_ORDER_RELAXED_AMD"
+  showsPrec p (VkRasterizationOrderAMD x) = showParen (p >= 11) (showString "VkRasterizationOrderAMD " . showsPrec 11 x)
+
+instance Read VkRasterizationOrderAMD where
+  readPrec = parens ( choose [ ("VK_RASTERIZATION_ORDER_STRICT_AMD", pure VK_RASTERIZATION_ORDER_STRICT_AMD)
+                             , ("VK_RASTERIZATION_ORDER_RELAXED_AMD", pure VK_RASTERIZATION_ORDER_RELAXED_AMD)
+                             ] +++
+                      prec 10 (do
+                        expectP (Ident "VkRasterizationOrderAMD")
+                        v <- step readPrec
+                        pure (VkRasterizationOrderAMD v)
+                        )
+                    )
+
+
+pattern VK_RASTERIZATION_ORDER_STRICT_AMD = VkRasterizationOrderAMD 0
+
+pattern VK_RASTERIZATION_ORDER_RELAXED_AMD = VkRasterizationOrderAMD 1
+
+
+data VkPipelineRasterizationStateRasterizationOrderAMD =
+  VkPipelineRasterizationStateRasterizationOrderAMD{ vkSType :: VkStructureType 
+                                                   , vkPNext :: Ptr Void 
+                                                   , vkRasterizationOrder :: VkRasterizationOrderAMD 
+                                                   }
+  deriving (Eq, Ord, Show)
+
+instance Storable VkPipelineRasterizationStateRasterizationOrderAMD where
+  sizeOf ~_ = 24
+  alignment ~_ = 8
+  peek ptr = VkPipelineRasterizationStateRasterizationOrderAMD <$> peek (ptr `plusPtr` 0)
+                                                               <*> peek (ptr `plusPtr` 8)
+                                                               <*> peek (ptr `plusPtr` 16)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkPipelineRasterizationStateRasterizationOrderAMD))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkPipelineRasterizationStateRasterizationOrderAMD))
+                *> poke (ptr `plusPtr` 16) (vkRasterizationOrder (poked :: VkPipelineRasterizationStateRasterizationOrderAMD))
+
+

--- a/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
+++ b/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
@@ -54,6 +54,7 @@ pattern VK_RASTERIZATION_ORDER_STRICT_AMD = VkRasterizationOrderAMD 0
 
 pattern VK_RASTERIZATION_ORDER_RELAXED_AMD = VkRasterizationOrderAMD 1
 
+pattern VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD = VkStructureType 1000018000
 
 data VkPipelineRasterizationStateRasterizationOrderAMD =
   VkPipelineRasterizationStateRasterizationOrderAMD{ vkSType :: VkStructureType 

--- a/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
+++ b/src/Graphics/Vulkan/AMD/RasterizationOrder.hs
@@ -28,6 +28,7 @@ import Text.ParserCombinators.ReadPrec( prec
 import Graphics.Vulkan.Core( VkStructureType(..)
                            )
 
+pattern VK_AMD_RASTERIZATION_ORDER_EXTENSION_NAME =  "VK_AMD_rasterization_order"
 -- ** VkRasterizationOrderAMD
 
 newtype VkRasterizationOrderAMD = VkRasterizationOrderAMD Int32
@@ -55,6 +56,7 @@ pattern VK_RASTERIZATION_ORDER_STRICT_AMD = VkRasterizationOrderAMD 0
 pattern VK_RASTERIZATION_ORDER_RELAXED_AMD = VkRasterizationOrderAMD 1
 
 pattern VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD = VkStructureType 1000018000
+pattern VK_AMD_RASTERIZATION_ORDER_SPEC_VERSION =  0x1
 
 data VkPipelineRasterizationStateRasterizationOrderAMD =
   VkPipelineRasterizationStateRasterizationOrderAMD{ vkSType :: VkStructureType 

--- a/src/Graphics/Vulkan/AMD/ShaderExplicitVertexParameter.hs
+++ b/src/Graphics/Vulkan/AMD/ShaderExplicitVertexParameter.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.AMD.ShaderExplicitVertexParameter where
+
+
+
+

--- a/src/Graphics/Vulkan/AMD/ShaderExplicitVertexParameter.hs
+++ b/src/Graphics/Vulkan/AMD/ShaderExplicitVertexParameter.hs
@@ -1,6 +1,7 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.AMD.ShaderExplicitVertexParameter where
 
 
 
-
+pattern VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_EXTENSION_NAME =  "VK_AMD_shader_explicit_vertex_parameter"
+pattern VK_AMD_SHADER_EXPLICIT_VERTEX_PARAMETER_SPEC_VERSION =  0x1

--- a/src/Graphics/Vulkan/AMD/ShaderTrinaryMinmax.hs
+++ b/src/Graphics/Vulkan/AMD/ShaderTrinaryMinmax.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.AMD.ShaderTrinaryMinmax where
+
+
+
+

--- a/src/Graphics/Vulkan/AMD/ShaderTrinaryMinmax.hs
+++ b/src/Graphics/Vulkan/AMD/ShaderTrinaryMinmax.hs
@@ -1,6 +1,7 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.AMD.ShaderTrinaryMinmax where
 
 
 
-
+pattern VK_AMD_SHADER_TRINARY_MINMAX_SPEC_VERSION =  0x1
+pattern VK_AMD_SHADER_TRINARY_MINMAX_EXTENSION_NAME =  "VK_AMD_shader_trinary_minmax"

--- a/src/Graphics/Vulkan/Buffer.hs
+++ b/src/Graphics/Vulkan/Buffer.hs
@@ -87,7 +87,7 @@ instance Read VkBufferCreateFlagBits where
 pattern VK_BUFFER_CREATE_SPARSE_BINDING_BIT = VkBufferCreateFlagBits 0x1
 -- | Buffer should support sparse backing with partial residency
 pattern VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT = VkBufferCreateFlagBits 0x2
--- | Buffer should support constent data access to physical memory blocks mapped into multiple locations of sparse buffers
+-- | Buffer should support constent data access to physical memory ranges mapped into multiple locations of sparse buffers
 pattern VK_BUFFER_CREATE_SPARSE_ALIASED_BIT = VkBufferCreateFlagBits 0x4
 
 

--- a/src/Graphics/Vulkan/Core.hs
+++ b/src/Graphics/Vulkan/Core.hs
@@ -1180,17 +1180,17 @@ pattern VK_NOT_READY = VkResult 1
 pattern VK_TIMEOUT = VkResult 2
 -- | An event is signaled
 pattern VK_EVENT_SET = VkResult 3
--- | An event is unsignalled
+-- | An event is unsignaled
 pattern VK_EVENT_RESET = VkResult 4
--- | A return array was too small for the resul
+-- | A return array was too small for the result
 pattern VK_INCOMPLETE = VkResult 5
 -- | A host memory allocation has failed
 pattern VK_ERROR_OUT_OF_HOST_MEMORY = VkResult (-1)
 -- | A device memory allocation has failed
 pattern VK_ERROR_OUT_OF_DEVICE_MEMORY = VkResult (-2)
--- | The logical device has been lost. See <<devsandqueues-lost-device>>
-pattern VK_ERROR_INITIALIZATION_FAILED = VkResult (-3)
 -- | Initialization of a object has failed
+pattern VK_ERROR_INITIALIZATION_FAILED = VkResult (-3)
+-- | The logical device has been lost. See <<devsandqueues-lost-device>>
 pattern VK_ERROR_DEVICE_LOST = VkResult (-4)
 -- | Mapping of a memory object has failed
 pattern VK_ERROR_MEMORY_MAP_FAILED = VkResult (-5)

--- a/src/Graphics/Vulkan/EXT/DebugMarker.hs
+++ b/src/Graphics/Vulkan/EXT/DebugMarker.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE Strict #-}
+module Graphics.Vulkan.EXT.DebugMarker where
+
+import Data.Vector.Storable.Sized( Vector
+                                 )
+import Graphics.Vulkan.Device( VkDevice(..)
+                             )
+import Data.Word( Word64
+                )
+import Foreign.Ptr( Ptr
+                  , plusPtr
+                  )
+import Graphics.Vulkan.CommandBuffer( VkCommandBuffer(..)
+                                    )
+import Graphics.Vulkan.EXT.DebugReport( VkDebugReportObjectTypeEXT(..)
+                                      )
+import Foreign.Storable( Storable(..)
+                       )
+import Data.Void( Void
+                )
+import Graphics.Vulkan.Core( VkResult(..)
+                           , VkStructureType(..)
+                           )
+import Foreign.C.Types( CSize
+                      , CFloat
+                      , CFloat(..)
+                      , CChar
+                      , CSize(..)
+                      )
+
+
+data VkDebugMarkerObjectNameInfoEXT =
+  VkDebugMarkerObjectNameInfoEXT{ vkSType :: VkStructureType 
+                                , vkPNext :: Ptr Void 
+                                , vkObjectType :: VkDebugReportObjectTypeEXT 
+                                , vkObject :: Word64 
+                                , vkPObjectName :: Ptr CChar 
+                                }
+  deriving (Eq, Ord, Show)
+
+instance Storable VkDebugMarkerObjectNameInfoEXT where
+  sizeOf ~_ = 40
+  alignment ~_ = 8
+  peek ptr = VkDebugMarkerObjectNameInfoEXT <$> peek (ptr `plusPtr` 0)
+                                            <*> peek (ptr `plusPtr` 8)
+                                            <*> peek (ptr `plusPtr` 16)
+                                            <*> peek (ptr `plusPtr` 24)
+                                            <*> peek (ptr `plusPtr` 32)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDebugMarkerObjectNameInfoEXT))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDebugMarkerObjectNameInfoEXT))
+                *> poke (ptr `plusPtr` 16) (vkObjectType (poked :: VkDebugMarkerObjectNameInfoEXT))
+                *> poke (ptr `plusPtr` 24) (vkObject (poked :: VkDebugMarkerObjectNameInfoEXT))
+                *> poke (ptr `plusPtr` 32) (vkPObjectName (poked :: VkDebugMarkerObjectNameInfoEXT))
+
+
+
+data VkDebugMarkerMarkerInfoEXT =
+  VkDebugMarkerMarkerInfoEXT{ vkSType :: VkStructureType 
+                            , vkPNext :: Ptr Void 
+                            , vkPMarkerName :: Ptr CChar 
+                            , vkColor :: Vector 4 CFloat 
+                            }
+  deriving (Eq, Ord, Show)
+
+instance Storable VkDebugMarkerMarkerInfoEXT where
+  sizeOf ~_ = 40
+  alignment ~_ = 8
+  peek ptr = VkDebugMarkerMarkerInfoEXT <$> peek (ptr `plusPtr` 0)
+                                        <*> peek (ptr `plusPtr` 8)
+                                        <*> peek (ptr `plusPtr` 16)
+                                        <*> peek (ptr `plusPtr` 24)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDebugMarkerMarkerInfoEXT))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDebugMarkerMarkerInfoEXT))
+                *> poke (ptr `plusPtr` 16) (vkPMarkerName (poked :: VkDebugMarkerMarkerInfoEXT))
+                *> poke (ptr `plusPtr` 24) (vkColor (poked :: VkDebugMarkerMarkerInfoEXT))
+
+
+-- ** vkCmdDebugMarkerInsertEXT
+foreign import ccall "vkCmdDebugMarkerInsertEXT" vkCmdDebugMarkerInsertEXT ::
+  VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
+
+-- ** vkCmdDebugMarkerBeginEXT
+foreign import ccall "vkCmdDebugMarkerBeginEXT" vkCmdDebugMarkerBeginEXT ::
+  VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
+
+-- ** vkDebugMarkerSetObjectTagEXT
+foreign import ccall "vkDebugMarkerSetObjectTagEXT" vkDebugMarkerSetObjectTagEXT ::
+  VkDevice -> Ptr VkDebugMarkerObjectTagInfoEXT -> IO VkResult
+
+-- ** vkCmdDebugMarkerEndEXT
+foreign import ccall "vkCmdDebugMarkerEndEXT" vkCmdDebugMarkerEndEXT ::
+  VkCommandBuffer -> IO ()
+
+
+data VkDebugMarkerObjectTagInfoEXT =
+  VkDebugMarkerObjectTagInfoEXT{ vkSType :: VkStructureType 
+                               , vkPNext :: Ptr Void 
+                               , vkObjectType :: VkDebugReportObjectTypeEXT 
+                               , vkObject :: Word64 
+                               , vkTagName :: Word64 
+                               , vkTagSize :: CSize 
+                               , vkPTag :: Ptr Void 
+                               }
+  deriving (Eq, Ord, Show)
+
+instance Storable VkDebugMarkerObjectTagInfoEXT where
+  sizeOf ~_ = 56
+  alignment ~_ = 8
+  peek ptr = VkDebugMarkerObjectTagInfoEXT <$> peek (ptr `plusPtr` 0)
+                                           <*> peek (ptr `plusPtr` 8)
+                                           <*> peek (ptr `plusPtr` 16)
+                                           <*> peek (ptr `plusPtr` 24)
+                                           <*> peek (ptr `plusPtr` 32)
+                                           <*> peek (ptr `plusPtr` 40)
+                                           <*> peek (ptr `plusPtr` 48)
+  poke ptr poked = poke (ptr `plusPtr` 0) (vkSType (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 8) (vkPNext (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 16) (vkObjectType (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 24) (vkObject (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 32) (vkTagName (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 40) (vkTagSize (poked :: VkDebugMarkerObjectTagInfoEXT))
+                *> poke (ptr `plusPtr` 48) (vkPTag (poked :: VkDebugMarkerObjectTagInfoEXT))
+
+
+-- ** vkDebugMarkerSetObjectNameEXT
+foreign import ccall "vkDebugMarkerSetObjectNameEXT" vkDebugMarkerSetObjectNameEXT ::
+  VkDevice -> Ptr VkDebugMarkerObjectNameInfoEXT -> IO VkResult
+

--- a/src/Graphics/Vulkan/EXT/DebugMarker.hs
+++ b/src/Graphics/Vulkan/EXT/DebugMarker.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.EXT.DebugMarker where
 
 import Data.Vector.Storable.Sized( Vector
@@ -55,6 +56,7 @@ instance Storable VkDebugMarkerObjectNameInfoEXT where
                 *> poke (ptr `plusPtr` 32) (vkPObjectName (poked :: VkDebugMarkerObjectNameInfoEXT))
 
 
+pattern VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT = VkStructureType 1000022000
 
 data VkDebugMarkerMarkerInfoEXT =
   VkDebugMarkerMarkerInfoEXT{ vkSType :: VkStructureType 
@@ -81,6 +83,7 @@ instance Storable VkDebugMarkerMarkerInfoEXT where
 foreign import ccall "vkCmdDebugMarkerInsertEXT" vkCmdDebugMarkerInsertEXT ::
   VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
 
+pattern VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT = VkStructureType 1000022001
 -- ** vkCmdDebugMarkerBeginEXT
 foreign import ccall "vkCmdDebugMarkerBeginEXT" vkCmdDebugMarkerBeginEXT ::
   VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
@@ -128,3 +131,4 @@ instance Storable VkDebugMarkerObjectTagInfoEXT where
 foreign import ccall "vkDebugMarkerSetObjectNameEXT" vkDebugMarkerSetObjectNameEXT ::
   VkDevice -> Ptr VkDebugMarkerObjectNameInfoEXT -> IO VkResult
 
+pattern VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT = VkStructureType 1000022002

--- a/src/Graphics/Vulkan/EXT/DebugMarker.hs
+++ b/src/Graphics/Vulkan/EXT/DebugMarker.hs
@@ -83,11 +83,13 @@ instance Storable VkDebugMarkerMarkerInfoEXT where
 foreign import ccall "vkCmdDebugMarkerInsertEXT" vkCmdDebugMarkerInsertEXT ::
   VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
 
+pattern VK_EXT_DEBUG_MARKER_EXTENSION_NAME =  "VK_EXT_debug_marker"
 pattern VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT = VkStructureType 1000022001
 -- ** vkCmdDebugMarkerBeginEXT
 foreign import ccall "vkCmdDebugMarkerBeginEXT" vkCmdDebugMarkerBeginEXT ::
   VkCommandBuffer -> Ptr VkDebugMarkerMarkerInfoEXT -> IO ()
 
+pattern VK_EXT_DEBUG_MARKER_SPEC_VERSION =  0x3
 -- ** vkDebugMarkerSetObjectTagEXT
 foreign import ccall "vkDebugMarkerSetObjectTagEXT" vkDebugMarkerSetObjectTagEXT ::
   VkDevice -> Ptr VkDebugMarkerObjectTagInfoEXT -> IO VkResult

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -54,6 +54,7 @@ import Foreign.C.Types( CSize
                       , CSize(..)
                       )
 
+pattern VK_EXT_DEBUG_REPORT_EXTENSION_NAME =  "VK_EXT_debug_report"
 -- ** vkDebugReportMessageEXT
 foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
   VkInstance ->
@@ -64,6 +65,7 @@ foreign import ccall "vkDebugReportMessageEXT" vkDebugReportMessageEXT ::
 newtype VkDebugReportCallbackEXT = VkDebugReportCallbackEXT Word64
   deriving (Eq, Ord, Storable, Show)
 
+pattern VK_EXT_DEBUG_REPORT_SPEC_VERSION =  0x2
 -- ** VkDebugReportObjectTypeEXT
 
 newtype VkDebugReportObjectTypeEXT = VkDebugReportObjectTypeEXT Int32
@@ -249,6 +251,7 @@ instance Storable VkDebugReportCallbackCreateInfoEXT where
                 *> poke (ptr `plusPtr` 32) (vkPUserData (poked :: VkDebugReportCallbackCreateInfoEXT))
 
 
+pattern VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT =  VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT
 -- ** vkDestroyDebugReportCallbackEXT
 foreign import ccall "vkDestroyDebugReportCallbackEXT" vkDestroyDebugReportCallbackEXT ::
   VkInstance ->

--- a/src/Graphics/Vulkan/EXT/DebugReport.hs
+++ b/src/Graphics/Vulkan/EXT/DebugReport.hs
@@ -304,6 +304,8 @@ type PFN_vkDebugReportCallbackEXT = FunPtr
          CSize ->
            Int32 -> Ptr CChar -> Ptr CChar -> Ptr Void -> IO VkBool32)
 
+pattern VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT = VkStructureType 1000011000
+pattern VK_ERROR_VALIDATION_FAILED_EXT = VkResult (-1000011001)
 -- ** vkCreateDebugReportCallbackEXT
 foreign import ccall "vkCreateDebugReportCallbackEXT" vkCreateDebugReportCallbackEXT ::
   VkInstance ->

--- a/src/Graphics/Vulkan/IMG/FilterCubic.hs
+++ b/src/Graphics/Vulkan/IMG/FilterCubic.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.IMG.FilterCubic where
+
+
+
+

--- a/src/Graphics/Vulkan/IMG/FilterCubic.hs
+++ b/src/Graphics/Vulkan/IMG/FilterCubic.hs
@@ -1,6 +1,7 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.IMG.FilterCubic where
 
+import Graphics.Vulkan.Sampler( VkFilter(..)
+                              )
 
-
-
+pattern VK_FILTER_CUBIC_IMG = VkFilter 1000015000

--- a/src/Graphics/Vulkan/IMG/FilterCubic.hs
+++ b/src/Graphics/Vulkan/IMG/FilterCubic.hs
@@ -1,7 +1,13 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.IMG.FilterCubic where
 
 import Graphics.Vulkan.Sampler( VkFilter(..)
                               )
+import Graphics.Vulkan.DeviceInitialization( VkFormatFeatureFlagBits(..)
+                                           )
 
+pattern VK_IMG_FILTER_CUBIC_SPEC_VERSION =  0x1
+pattern VK_IMG_FILTER_CUBIC_EXTENSION_NAME =  "VK_IMG_filter_cubic"
+pattern VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG = VkFormatFeatureFlagBits 0x2000
 pattern VK_FILTER_CUBIC_IMG = VkFilter 1000015000

--- a/src/Graphics/Vulkan/Image.hs
+++ b/src/Graphics/Vulkan/Image.hs
@@ -97,7 +97,7 @@ instance Read VkImageCreateFlagBits where
 pattern VK_IMAGE_CREATE_SPARSE_BINDING_BIT = VkImageCreateFlagBits 0x1
 -- | Image should support sparse backing with partial residency
 pattern VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT = VkImageCreateFlagBits 0x2
--- | Image should support constent data access to physical memory blocks mapped into multiple locations of sparse images
+-- | Image should support constent data access to physical memory ranges mapped into multiple locations of sparse images
 pattern VK_IMAGE_CREATE_SPARSE_ALIASED_BIT = VkImageCreateFlagBits 0x4
 -- | Allows image views to have different format than the base image
 pattern VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT = VkImageCreateFlagBits 0x8

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -140,6 +140,7 @@ instance Storable VkDisplayPlaneCapabilitiesKHR where
                 *> poke (ptr `plusPtr` 60) (vkMaxDstExtent (poked :: VkDisplayPlaneCapabilitiesKHR))
 
 
+pattern VK_KHR_DISPLAY_EXTENSION_NAME =  "VK_KHR_display"
 -- ** vkGetDisplayModePropertiesKHR
 foreign import ccall "vkGetDisplayModePropertiesKHR" vkGetDisplayModePropertiesKHR ::
   VkPhysicalDevice ->
@@ -182,6 +183,7 @@ foreign import ccall "vkGetDisplayPlaneSupportedDisplaysKHR" vkGetDisplayPlaneSu
   VkPhysicalDevice ->
   Word32 -> Ptr Word32 -> Ptr VkDisplayKHR -> IO VkResult
 
+pattern VK_KHR_DISPLAY_SPEC_VERSION =  0x15
 -- ** vkCreateDisplayModeKHR
 foreign import ccall "vkCreateDisplayModeKHR" vkCreateDisplayModeKHR ::
   VkPhysicalDevice ->

--- a/src/Graphics/Vulkan/KHR/Display.hs
+++ b/src/Graphics/Vulkan/KHR/Display.hs
@@ -102,6 +102,7 @@ instance Storable VkDisplaySurfaceCreateInfoKHR where
                 *> poke (ptr `plusPtr` 52) (vkImageExtent (poked :: VkDisplaySurfaceCreateInfoKHR))
 
 
+pattern VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR = VkStructureType 1000002001
 
 data VkDisplayPlaneCapabilitiesKHR =
   VkDisplayPlaneCapabilitiesKHR{ vkSupportedAlpha :: VkDisplayPlaneAlphaFlagsKHR 
@@ -226,6 +227,7 @@ instance Storable VkDisplayModePropertiesKHR where
                 *> poke (ptr `plusPtr` 8) (vkParameters (poked :: VkDisplayModePropertiesKHR))
 
 
+pattern VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR = VkStructureType 1000002000
 -- ** VkDisplayPlaneAlphaFlagsKHR
 
 newtype VkDisplayPlaneAlphaFlagBitsKHR = VkDisplayPlaneAlphaFlagBitsKHR VkFlags

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -84,5 +84,7 @@ foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR :
     Ptr VkSwapchainCreateInfoKHR ->
       Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
 
+pattern VK_KHR_DISPLAY_SWAPCHAIN_SPEC_VERSION =  0x9
+pattern VK_KHR_DISPLAY_SWAPCHAIN_EXTENSION_NAME =  "VK_KHR_display_swapchain"
 pattern VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR = VkStructureType 1000003000
 pattern VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = VkResult (-1000003001)

--- a/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
+++ b/src/Graphics/Vulkan/KHR/DisplaySwapchain.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.KHR.DisplaySwapchain where
 
 import Graphics.Vulkan.Device( VkDevice(..)
@@ -83,3 +84,5 @@ foreign import ccall "vkCreateSharedSwapchainsKHR" vkCreateSharedSwapchainsKHR :
     Ptr VkSwapchainCreateInfoKHR ->
       Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
 
+pattern VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR = VkStructureType 1000003000
+pattern VK_ERROR_INCOMPATIBLE_DISPLAY_KHR = VkResult (-1000003001)

--- a/src/Graphics/Vulkan/KHR/SamplerMirrorClampToEdge.hs
+++ b/src/Graphics/Vulkan/KHR/SamplerMirrorClampToEdge.hs
@@ -1,6 +1,9 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.KHR.SamplerMirrorClampToEdge where
 
+import Graphics.Vulkan.Sampler( VkSamplerAddressMode(..)
+                              )
 
-
-
+pattern VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME =  "VK_KHR_sampler_mirror_clamp_to_edge"
+pattern VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_SPEC_VERSION =  0x1
+pattern VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = VkSamplerAddressMode 0x4

--- a/src/Graphics/Vulkan/KHR/SamplerMirrorClampToEdge.hs
+++ b/src/Graphics/Vulkan/KHR/SamplerMirrorClampToEdge.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.KHR.SamplerMirrorClampToEdge where
+
+
+
+

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -174,11 +174,11 @@ newtype VkColorSpaceKHR = VkColorSpaceKHR Int32
   deriving (Eq, Ord, Storable)
 
 instance Show VkColorSpaceKHR where
-  showsPrec _ VK_COLORSPACE_SRGB_NONLINEAR_KHR = showString "VK_COLORSPACE_SRGB_NONLINEAR_KHR"
+  showsPrec _ VK_COLOR_SPACE_SRGB_NONLINEAR_KHR = showString "VK_COLOR_SPACE_SRGB_NONLINEAR_KHR"
   showsPrec p (VkColorSpaceKHR x) = showParen (p >= 11) (showString "VkColorSpaceKHR " . showsPrec 11 x)
 
 instance Read VkColorSpaceKHR where
-  readPrec = parens ( choose [ ("VK_COLORSPACE_SRGB_NONLINEAR_KHR", pure VK_COLORSPACE_SRGB_NONLINEAR_KHR)
+  readPrec = parens ( choose [ ("VK_COLOR_SPACE_SRGB_NONLINEAR_KHR", pure VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
                              ] +++
                       prec 10 (do
                         expectP (Ident "VkColorSpaceKHR")
@@ -188,7 +188,7 @@ instance Read VkColorSpaceKHR where
                     )
 
 
-pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR = VkColorSpaceKHR 0
+pattern VK_COLOR_SPACE_SRGB_NONLINEAR_KHR = VkColorSpaceKHR 0
 
 -- ** vkGetPhysicalDeviceSurfacePresentModesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfacePresentModesKHR" vkGetPhysicalDeviceSurfacePresentModesKHR ::

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -57,11 +57,14 @@ import Graphics.Vulkan.Core( VkResult(..)
 import Foreign.C.Types( CSize(..)
                       )
 
+pattern VK_KHR_SURFACE_EXTENSION_NAME =  "VK_KHR_surface"
+pattern VK_COLORSPACE_SRGB_NONLINEAR_KHR =  VK_COLOR_SPACE_SRGB_NONLINEAR_KHR
 -- ** vkGetPhysicalDeviceSurfaceFormatsKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceFormatsKHR" vkGetPhysicalDeviceSurfaceFormatsKHR ::
   VkPhysicalDevice ->
   VkSurfaceKHR -> Ptr Word32 -> Ptr VkSurfaceFormatKHR -> IO VkResult
 
+pattern VK_KHR_SURFACE_SPEC_VERSION =  0x19
 -- ** vkGetPhysicalDeviceSurfaceCapabilitiesKHR
 foreign import ccall "vkGetPhysicalDeviceSurfaceCapabilitiesKHR" vkGetPhysicalDeviceSurfaceCapabilitiesKHR ::
   VkPhysicalDevice ->

--- a/src/Graphics/Vulkan/KHR/Surface.hs
+++ b/src/Graphics/Vulkan/KHR/Surface.hs
@@ -140,6 +140,7 @@ pattern VK_PRESENT_MODE_FIFO_KHR = VkPresentModeKHR 2
 
 pattern VK_PRESENT_MODE_FIFO_RELAXED_KHR = VkPresentModeKHR 3
 
+pattern VK_ERROR_NATIVE_WINDOW_IN_USE_KHR = VkResult (-1000000001)
 newtype VkSurfaceKHR = VkSurfaceKHR Word64
   deriving (Eq, Ord, Storable, Show)
 
@@ -148,6 +149,7 @@ foreign import ccall "vkGetPhysicalDeviceSurfaceSupportKHR" vkGetPhysicalDeviceS
   VkPhysicalDevice ->
   Word32 -> VkSurfaceKHR -> Ptr VkBool32 -> IO VkResult
 
+pattern VK_ERROR_SURFACE_LOST_KHR = VkResult (-1000000000)
 
 data VkSurfaceFormatKHR =
   VkSurfaceFormatKHR{ vkFormat :: VkFormat 

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -142,6 +142,7 @@ pattern VK_SUBOPTIMAL_KHR = VkResult 1000001003
 newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
   deriving (Eq, Ord, Storable, Bits, FiniteBits, Show)
 
+pattern VK_KHR_SWAPCHAIN_SPEC_VERSION =  0x44
 -- ** vkCreateSwapchainKHR
 foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
   VkDevice ->
@@ -192,3 +193,4 @@ instance Storable VkPresentInfoKHR where
 newtype VkSwapchainKHR = VkSwapchainKHR Word64
   deriving (Eq, Ord, Storable, Show)
 
+pattern VK_KHR_SWAPCHAIN_EXTENSION_NAME =  "VK_KHR_swapchain"

--- a/src/Graphics/Vulkan/KHR/Swapchain.hs
+++ b/src/Graphics/Vulkan/KHR/Swapchain.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE Strict #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Graphics.Vulkan.KHR.Swapchain where
 
@@ -39,6 +40,7 @@ import Graphics.Vulkan.Memory( VkInternalAllocationType(..)
                              )
 import Graphics.Vulkan.Image( VkImageUsageFlags(..)
                             , VkImage(..)
+                            , VkImageLayout(..)
                             , VkImageUsageFlagBits(..)
                             )
 import Graphics.Vulkan.QueueSemaphore( VkSemaphore(..)
@@ -54,6 +56,7 @@ import Graphics.Vulkan.Core( VkResult(..)
 import Foreign.C.Types( CSize(..)
                       )
 
+pattern VK_ERROR_OUT_OF_DATE_KHR = VkResult (-1000001004)
 
 data VkSwapchainCreateInfoKHR =
   VkSwapchainCreateInfoKHR{ vkSType :: VkStructureType 
@@ -118,6 +121,7 @@ instance Storable VkSwapchainCreateInfoKHR where
                 *> poke (ptr `plusPtr` 96) (vkOldSwapchain (poked :: VkSwapchainCreateInfoKHR))
 
 
+pattern VK_IMAGE_LAYOUT_PRESENT_SRC_KHR = VkImageLayout 1000001002
 -- ** vkGetSwapchainImagesKHR
 foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
   VkDevice ->
@@ -127,10 +131,12 @@ foreign import ccall "vkGetSwapchainImagesKHR" vkGetSwapchainImagesKHR ::
 foreign import ccall "vkDestroySwapchainKHR" vkDestroySwapchainKHR ::
   VkDevice -> VkSwapchainKHR -> Ptr VkAllocationCallbacks -> IO ()
 
+pattern VK_STRUCTURE_TYPE_PRESENT_INFO_KHR = VkStructureType 1000001001
 -- ** vkQueuePresentKHR
 foreign import ccall "vkQueuePresentKHR" vkQueuePresentKHR ::
   VkQueue -> Ptr VkPresentInfoKHR -> IO VkResult
 
+pattern VK_SUBOPTIMAL_KHR = VkResult 1000001003
 -- ** VkSwapchainCreateFlagsKHR
 -- | Opaque flag
 newtype VkSwapchainCreateFlagsKHR = VkSwapchainCreateFlagsKHR VkFlags
@@ -142,6 +148,7 @@ foreign import ccall "vkCreateSwapchainKHR" vkCreateSwapchainKHR ::
   Ptr VkSwapchainCreateInfoKHR ->
     Ptr VkAllocationCallbacks -> Ptr VkSwapchainKHR -> IO VkResult
 
+pattern VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR = VkStructureType 1000001000
 -- ** vkAcquireNextImageKHR
 foreign import ccall "vkAcquireNextImageKHR" vkAcquireNextImageKHR ::
   VkDevice ->

--- a/src/Graphics/Vulkan/NV/GlslShader.hs
+++ b/src/Graphics/Vulkan/NV/GlslShader.hs
@@ -1,0 +1,6 @@
+
+module Graphics.Vulkan.NV.GlslShader where
+
+
+
+

--- a/src/Graphics/Vulkan/NV/GlslShader.hs
+++ b/src/Graphics/Vulkan/NV/GlslShader.hs
@@ -5,3 +5,5 @@ import Graphics.Vulkan.Core( VkResult(..)
                            )
 
 pattern VK_ERROR_INVALID_SHADER_NV = VkResult (-1000012000)
+pattern VK_NV_GLSL_SHADER_SPEC_VERSION =  0x1
+pattern VK_NV_GLSL_SHADER_EXTENSION_NAME =  "VK_NV_glsl_shader"

--- a/src/Graphics/Vulkan/NV/GlslShader.hs
+++ b/src/Graphics/Vulkan/NV/GlslShader.hs
@@ -1,6 +1,7 @@
-
+{-# LANGUAGE PatternSynonyms #-}
 module Graphics.Vulkan.NV.GlslShader where
 
+import Graphics.Vulkan.Core( VkResult(..)
+                           )
 
-
-
+pattern VK_ERROR_INVALID_SHADER_NV = VkResult (-1000012000)

--- a/src/Graphics/Vulkan/Sampler.hs
+++ b/src/Graphics/Vulkan/Sampler.hs
@@ -63,7 +63,6 @@ instance Show VkSamplerAddressMode where
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = showString "VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE"
   showsPrec _ VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = showString "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER"
-  showsPrec _ VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = showString "VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE"
   showsPrec p (VkSamplerAddressMode x) = showParen (p >= 11) (showString "VkSamplerAddressMode " . showsPrec 11 x)
 
 instance Read VkSamplerAddressMode where
@@ -71,7 +70,6 @@ instance Read VkSamplerAddressMode where
                              , ("VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT", pure VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT)
                              , ("VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
                              , ("VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER", pure VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)
-                             , ("VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE", pure VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE)
                              ] +++
                       prec 10 (do
                         expectP (Ident "VkSamplerAddressMode")
@@ -88,8 +86,6 @@ pattern VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT = VkSamplerAddressMode 1
 pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE = VkSamplerAddressMode 2
 
 pattern VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER = VkSamplerAddressMode 3
-
-pattern VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE = VkSamplerAddressMode 4
 
 -- ** VkFilter
 

--- a/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
+++ b/src/Graphics/Vulkan/SparseResourceMemoryManagement.hs
@@ -266,9 +266,9 @@ instance Read VkSparseImageFormatFlagBits where
 
 -- | Image uses a single miptail region for all array layers
 pattern VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT = VkSparseImageFormatFlagBits 0x1
--- | Image requires mip levels to be an exact multiple of the sparse image block size for non-miptail levels.
+-- | Image requires mip level dimensions to be an integer multiple of the sparse image block dimensions for non-miptail levels.
 pattern VK_SPARSE_IMAGE_FORMAT_ALIGNED_MIP_SIZE_BIT = VkSparseImageFormatFlagBits 0x2
--- | Image uses a non-standard sparse block size
+-- | Image uses a non-standard sparse image block dimensions
 pattern VK_SPARSE_IMAGE_FORMAT_NONSTANDARD_BLOCK_SIZE_BIT = VkSparseImageFormatFlagBits 0x4
 
 

--- a/src/Graphics/Vulkan/Version.hs
+++ b/src/Graphics/Vulkan/Version.hs
@@ -9,14 +9,17 @@ import Data.Bits( shiftR
                 , (.&.)
                 )
 
-vkApiVersion :: Word32
-vkApiVersion  = vkMakeVersion 1 0 3
-
 vkVersionMinor :: Word32 -> Word32
 vkVersionMinor version = (.&.) (shiftR version 12) 1023
 
+vkHeaderVersion :: Word32
+vkHeaderVersion  = 16
+
 vkVersionPatch :: Word32 -> Word32
 vkVersionPatch version = (.&.) version 4095
+
+vkApiVersion10 :: Word32
+vkApiVersion10  = vkMakeVersion 1 0 0
 
 vkMakeVersion :: Word32 -> Word32 -> Word32 -> Word32
 vkMakeVersion major minor patch = (.|.) ((.|.) (shiftL major 22) (shiftL minor 12)) patch

--- a/vulkan.cabal
+++ b/vulkan.cabal
@@ -17,6 +17,10 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Graphics.Vulkan
+                     , Graphics.Vulkan.AMD.GcnShader
+                     , Graphics.Vulkan.AMD.RasterizationOrder
+                     , Graphics.Vulkan.AMD.ShaderExplicitVertexParameter
+                     , Graphics.Vulkan.AMD.ShaderTrinaryMinmax
                      , Graphics.Vulkan.Buffer
                      , Graphics.Vulkan.BufferView
                      , Graphics.Vulkan.CommandBuffer
@@ -27,19 +31,23 @@ library
                      , Graphics.Vulkan.DescriptorSet
                      , Graphics.Vulkan.Device
                      , Graphics.Vulkan.DeviceInitialization
+                     , Graphics.Vulkan.EXT.DebugMarker
                      , Graphics.Vulkan.EXT.DebugReport
                      , Graphics.Vulkan.Event
                      , Graphics.Vulkan.ExtensionDiscovery
                      , Graphics.Vulkan.Fence
+                     , Graphics.Vulkan.IMG.FilterCubic
                      , Graphics.Vulkan.Image
                      , Graphics.Vulkan.ImageView
                      , Graphics.Vulkan.KHR.Display
                      , Graphics.Vulkan.KHR.DisplaySwapchain
+                     , Graphics.Vulkan.KHR.SamplerMirrorClampToEdge
                      , Graphics.Vulkan.KHR.Surface
                      , Graphics.Vulkan.KHR.Swapchain
                      , Graphics.Vulkan.LayerDiscovery
                      , Graphics.Vulkan.Memory
                      , Graphics.Vulkan.MemoryManagement
+                     , Graphics.Vulkan.NV.GlslShader
                      , Graphics.Vulkan.OtherTypes
                      , Graphics.Vulkan.Pass
                      , Graphics.Vulkan.Pipeline


### PR DESCRIPTION
This is built on #22.

This exports all extension/enum types currently used in the spec.

I'm not thrilled with having 6 types to represent the `enum` type from the registry.

I had to add a couple of newly ambiguous things to the bespoke export list.
