### PR TITLE
Add fatal debug callback

### DIFF
--- a/utils/cbits/DebugCallback.c
+++ b/utils/cbits/DebugCallback.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <vulkan/vulkan.h>
 
 VKAPI_ATTR VkBool32 VKAPI_CALL
@@ -7,5 +8,22 @@ debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
               const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
               void *pUserData) {
   fprintf(stderr, "Validation: %s\n", pCallbackData->pMessage);
+  return VK_FALSE;
+}
+
+VKAPI_ATTR VkBool32 VKAPI_CALL
+debugCallbackFatal(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
+                   VkDebugUtilsMessageTypeFlagsEXT messageType,
+                   const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData,
+                   void *pUserData) {
+  int errorBitSet = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT & messageSeverity;
+  int isError = VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT == errorBitSet;
+
+  fprintf(stderr, "Validation: %s\n", pCallbackData->pMessage);
+
+  if (isError) {
+    fprintf(stderr, "Aborting on validation error.\n");
+    abort();
+  }
   return VK_FALSE;
 }

--- a/utils/src/Vulkan/Utils/Debug.hs
+++ b/utils/src/Vulkan/Utils/Debug.hs
@@ -1,5 +1,6 @@
 module Vulkan.Utils.Debug
   ( debugCallbackPtr
+  , debugCallbackFatalPtr
   , nameObject
   ) where
 
@@ -13,6 +14,9 @@ import           Vulkan.Extensions.VK_EXT_debug_utils
 -- stderr.
 foreign import ccall unsafe "DebugCallback.c &debugCallback"
   debugCallbackPtr :: PFN_vkDebugUtilsMessengerCallbackEXT
+
+foreign import ccall unsafe "DebugCallback.c &debugCallbackFatal"
+  debugCallbackFatalPtr :: PFN_vkDebugUtilsMessengerCallbackEXT
 
 -- | Assign a name to a handle using 'setDebugUtilsObjectNameEXT', note that
 -- the @VK_EXT_debug_utils@ extension must be enabled.


### PR DESCRIPTION
Alternative callback that calls `abort()` after receiving a message with ERROR severity set.