### PR TITLE
Enable macOS platform builds for cabal and stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ghc: ['8.10.1', '8.8.2', '8.6.5']
         cabal: ['3.0']
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macOS-latest]
       fail-fast: false
 
     steps:
@@ -41,7 +41,7 @@ jobs:
         path: dist-newstyle
         key: ${{ runner.os }}-${{ matrix.ghc }}-dist-newstyle
 
-    - name: Install system dependencies
+    - name: Install system dependencies Linux
       if: matrix.os == 'ubuntu-latest'
       run: |
         wget -qO - http://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo apt-key add -
@@ -49,14 +49,22 @@ jobs:
         sudo apt-get update
         sudo apt-get install libvulkan-dev glslang-tools libsdl2-dev
 
+    - name: Install system dependencies macOS
+      if: matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        brew install pkg-config sdl2
+        brew tap apenngrace/homebrew-vulkan 
+        brew cask install vulkan-sdk
+
     - name: Remove examples for 8.6.5
       run: |
-        sed -i '/examples/d' cabal.project
+        sed -ibak '/examples/d' cabal.project
       if: matrix.ghc == '8.6.5'
 
     - name: Remove generator for all but 8.8.2
       run: |
-        sed -i '/generate-new/d' cabal.project
+        sed -ibak '/generate-new/d' cabal.project
       if: matrix.ghc != '8.8.2'
 
     - run: cabal update
@@ -85,7 +93,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macOS-latest]
         # Use windows with 8.10.2+ https://gitlab.haskell.org/ghc/ghc/issues/17926
         # os: [ubuntu-latest, windows-latest]
         stack-args: ['--system-ghc --flag vulkan:generic-instances --flag VulkanMemoryAllocator:generic-instances']
@@ -137,15 +145,23 @@ jobs:
       env:
         ARGS: ${{ matrix.args }}
 
+    - name: Install system dependencies macOS
+      if: matrix.os == 'macOS-latest'
+      shell: bash
+      run: |
+        brew install pkg-config sdl2
+        brew tap apenngrace/homebrew-vulkan 
+        brew cask install vulkan-sdk
+
     - name: Install dependencies
       run: stack build --test --bench --only-dependencies $ARGS
       env:
-        ARGS: ${{ matrix.args }}
+        ARGS: ${{ matrix.stack-args }}
 
     - name: Build
       run: stack build $ARGS
       env:
-        ARGS: ${{ matrix.args }}
+        ARGS: ${{ matrix.stack-args }}
 
   nix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
         ghc: ['8.10.1', '8.8.2', '8.6.5']
         cabal: ['3.0']
         os: [ubuntu-latest, macOS-latest]
+        exclude:
+          - ghc: 8.10.1
+            os: macOS-latest
       fail-fast: false
 
     steps:

--- a/VulkanMemoryAllocator/VulkanMemoryAllocator.cabal
+++ b/VulkanMemoryAllocator/VulkanMemoryAllocator.cabal
@@ -1,10 +1,10 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.33.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d63790e67481a6422f7936270c7caa8f6245825d2a71741d5e26ea30e9ba5df1
+-- hash: fe08a174d6251038a043c4acdfec378ecdba621388ec2b5f1bd4a15daa61cdd8
 
 name:           VulkanMemoryAllocator
 version:        0.3.1
@@ -52,6 +52,7 @@ library
       src
   default-extensions: AllowAmbiguousTypes CPP DataKinds DefaultSignatures DeriveAnyClass DeriveGeneric DerivingStrategies DuplicateRecordFields FlexibleContexts FlexibleInstances GADTs GeneralizedNewtypeDeriving InstanceSigs LambdaCase MagicHash NoMonomorphismRestriction OverloadedStrings PartialTypeSignatures PatternSynonyms PolyKinds QuantifiedConstraints RankNTypes RecordWildCards RoleAnnotations ScopedTypeVariables StandaloneDeriving Strict TypeApplications TypeFamilyDependencies TypeOperators TypeSynonymInstances UndecidableInstances ViewPatterns
   ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-missing-pattern-synonym-signatures -Wno-unused-imports -Wno-missing-signatures -Wno-partial-type-signatures
+  cxx-options: -std=c++11
   include-dirs:
       VulkanMemoryAllocator/src
   cxx-sources:

--- a/VulkanMemoryAllocator/package.yaml
+++ b/VulkanMemoryAllocator/package.yaml
@@ -39,6 +39,8 @@ library:
     - -Wno-unused-imports
     - -Wno-missing-signatures
     - -Wno-partial-type-signatures
+  cxx-options:
+    - -std=c++11
   verbatim:
     other-modules:
 

--- a/VulkanMemoryAllocator/src/lib.cpp
+++ b/VulkanMemoryAllocator/src/lib.cpp
@@ -1,3 +1,13 @@
 #define VMA_IMPLEMENTATION
 #define VMA_STATIC_VULKAN_FUNCTIONS 0
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnullability-completeness"
+#endif
+
 #include <vk_mem_alloc.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Thanks for your great work on this project. Here's a suggested CI configuration which should hopefully add macOS support to the stack and cabal builds.

- Use Homebrew for macOS dependencies.
- Add `cxx-options: -std=c++11` to VMA, otherwise the macOS clang build fails.
- Ignore the `-Wnullability-completeness` C++ option, which otherwise produces many warnings. The use of pragmas for this was taken from the VMA example here:
    https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator/blob/facf05ee6389910fc4f6bd27ba9daf27bb0a312a/src/VmaUsage.h#L87
- Add a backup extension for `sed -i` (required on macOS by BSD sed)