### PR TITLE
Make resize example work on macOS

### DIFF
--- a/examples/resize/Main.hs
+++ b/examples/resize/Main.hs
@@ -22,9 +22,6 @@ import           Linear.Metric                  ( norm )
 import           Linear.V2
 import qualified SDL
 import           Say
-import           UnliftIO.Async                 ( wait
-                                                , withAsyncBound
-                                                )
 import           UnliftIO.Exception             ( displayException
                                                 , throwString
                                                 )
@@ -64,7 +61,7 @@ import           Window
 -- It's bound to an OS thread so SDL.pumpEvents can work properly.
 ----------------------------------------------------------------
 main :: IO ()
-main = (`withAsyncBound` wait) . prettyError . runResourceT $ do
+main = prettyError . runResourceT $ do
   -- Start SDL
   _ <- allocate_ (SDL.initialize @[] [SDL.InitEvents]) SDL.quit
 


### PR DESCRIPTION
- Just remove `withAsyncBound`

<img width="1392" alt="Screen Shot 2020-05-27 at 8 37 42 pm" src="https://user-images.githubusercontent.com/356739/83009588-51e9d080-a05a-11ea-972c-9c5693b58d82.png">
