### PR TITLE
Refine GLSL validator messages

### DIFF
--- a/utils/package.yaml
+++ b/utils/package.yaml
@@ -15,6 +15,7 @@ library:
     - bytestring
     - extra
     - file-embed
+    - filepath
     - template-haskell
     - temporary
     - typed-process

--- a/utils/src/Vulkan/Utils/ShaderQQ.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ.hs
@@ -20,6 +20,7 @@ import           Data.List.Extra
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote
 import           System.Exit
+import           System.FilePath
 import           System.IO.Temp
 import           System.Process.Typed
 
@@ -117,7 +118,9 @@ processValidatorMessages = foldr grep [] . filter (not . null) . lines . BSL.unp
       | "ERROR: "   `isPrefixOf` line = cut line : acc
       | otherwise                     = acc
 
-    cut = drop 1 . dropWhile (/= '/')
+    cut line = takeFileName path <> msg
+      where
+        (path, msg) = break (== ':') . drop 1 $ dropWhile (/= ' ') line
 
 -- If possible, insert a #line directive after the #version directive (as well
 -- as the extension which allows filenames in line directives.

--- a/utils/vulkan-utils.cabal
+++ b/utils/vulkan-utils.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4932fa53ef89839352ab8a611016196cf2d6f06cae0690fd721ef21efe0c73f9
+-- hash: bf2abe816ee07e2c6d5e207a4ec2c4a44910f18d6be88017d73e851879ad5078
 
 name:           vulkan-utils
 version:        0.1.1.0
@@ -39,6 +39,7 @@ library
     , bytestring
     , extra
     , file-embed
+    , filepath
     , template-haskell
     , temporary
     , typed-process


### PR DESCRIPTION
After fiddling for a while I settled on some light preprocessing. I tried to make make file locations real and clickable, but it adds too much noise and kinda redundant. Too bad TH has no function to report message at exact location.

The big multiline messages now look like this:

    /home/user/src/os/vulkan/examples/resize/Julia.hs:108:24: error:
        • glslangValidator:
            Julia.hs:141: 'cx' : no such field in structure 
            Julia.hs:141: '+' :  wrong operand types: no operation '+' exists that takes a left-hand operand of type ' global highp 2-component vector of float' and a right operand of type 'layout( column_major std430 push_constant) uniform block{layout( column_major std430 offset=0) uniform highp 2-component vector of float scale, layout( column_major std430 offset=8) uniform highp 2-component vector of float offset, layout( column_major std430 offset=16) uniform highp 2-component vector of float c, layout( column_major std430 offset=24) uniform highp float escapeRadius}' (or there is no acceptable conversion)
            Julia.hs:141: '' : compilation terminated 
            
            
        • In the quasi-quotation:
            [comp|
            #version 450
            #extension GL_ARB_separate_shader_objects : enable

            const int workgroup_x = 8;

And the smaller (the error/warning distinction is removed):

    /home/user/src/os/vulkan/examples/sdl-triangle/Main.hs:164:24: error:
        • glslangValidator:
            Main.hs:167: '#define' : missing space after macro name 
            Main.hs:168: '#define' : missing space after macro name 
            Main.hs:175: 'fragColor' : undeclared identifier 
            Main.hs:175: '' : compilation terminated 
            
        • In the quasi-quotation:
            [frag|
            #version 450

Single-line warnings are almost cute:

    /home/user/src/os/vulkan/examples/sdl-triangle/Main.hs:164:24: warning:
        Main.hs:167: '#define' : missing space after macro name 
        |
    164 |   let fragCode = [frag|
        |                        ^...
