### PR TITLE
fix #231

### DIFF
--- a/examples/resize/Main.hs
+++ b/examples/resize/Main.hs
@@ -394,9 +394,9 @@ draw = do
 ----------------------------------------------------------------
 
 -- | Consumes all events in the queue and reports if any of them instruct the
--- application to quit.
+-- application to quit. Waits for at least one event to arrive.
 shouldQuit :: MonadIO m => m Bool
-shouldQuit = any isQuitEvent <$> SDL.pollEvents
+shouldQuit = any isQuitEvent <$> awaitSDLEvents
  where
   isQuitEvent :: SDL.Event -> Bool
   isQuitEvent = \case
@@ -405,6 +405,10 @@ shouldQuit = any isQuitEvent <$> SDL.pollEvents
       | code == SDL.KeycodeQ || code == SDL.KeycodeEscape
       -> True
     _ -> False
+
+-- | Wait for the next SDL event and slurp in others that have become available
+awaitSDLEvents :: MonadIO m => m [SDL.Event]
+awaitSDLEvents = (:) <$> SDL.waitEvent <*> SDL.pollEvents
 
 ----------------------------------------------------------------
 -- Utils

--- a/examples/sdl-triangle/Main.hs
+++ b/examples/sdl-triangle/Main.hs
@@ -74,12 +74,16 @@ main = runManaged $ do
 
 mainLoop :: IO () -> IO ()
 mainLoop draw = whileM $ do
-  quit <- Prelude.any isQuitEvent <$> SDL.pollEvents
+  quit <- Prelude.any isQuitEvent <$> awaitSDLEvents
   if quit
     then pure False
     else do
       draw
       pure True
+
+-- wait for the next SDL event and slurp in others that have become available
+awaitSDLEvents :: IO [SDL.Event]
+awaitSDLEvents = (:) <$> SDL.waitEvent <*> SDL.pollEvents
 
 drawFrame
   :: Device


### PR DESCRIPTION
Before this patch, `sdl-triangle`'s main loop would redraw continuously
in a tight loop, consuming 100% CPU on my system and rendering X11
unresponsive. The solution is to wait for an event instead.