### PR TITLE
Use pkgconfig-depends to find libvulkan on Linux

### DIFF
--- a/vulkan.cabal
+++ b/vulkan.cabal
@@ -498,7 +498,7 @@ library
     extra-libraries:
         vulkan-1
   else
-    extra-libraries:
+    pkgconfig-depends:
         vulkan
   if flag(safe-foreign-calls)
     cpp-options: -DSAFE_FOREIGN_CALLS


### PR DESCRIPTION
I've left the Windows codepath alone since I do not currently have
the ability to test on Windows.

Fixes #228.