### PR TITLE
Fix VMA build with GHC 8.10.3

### DIFF
--- a/VulkanMemoryAllocator/VulkanMemoryAllocator.cabal
+++ b/VulkanMemoryAllocator/VulkanMemoryAllocator.cabal
@@ -72,6 +72,6 @@ library
     cxx-options: -DVMA_RECORDING_ENABLED
   if flag(generic-instances)
     cpp-options: -DGENERIC_INSTANCES
-  if impl(ghc >= 8.10)
+  if impl(ghc >= 8.10) && impl(ghc < 8.10.3)
     ghc-options: -optcxx -std=c++11
   default-language: Haskell2010

--- a/VulkanMemoryAllocator/package.yaml
+++ b/VulkanMemoryAllocator/package.yaml
@@ -34,7 +34,7 @@ library:
     - condition: flag(generic-instances)
       cpp-options: -DGENERIC_INSTANCES
     # Work around https://github.com/haskell/cabal/pull/7074
-    - condition: "impl(ghc >= 8.10)"
+    - condition: "impl(ghc >= 8.10) && impl(ghc < 8.10.3)"
       ghc-options:
         - -optcxx -std=c++11
   ghc-options:


### PR DESCRIPTION
Switching stackage resolvers from `nightly-2020-12-04` to `nightly-2021-01-05` resulted in multiple build errors: https://gist.github.com/dpwiz/cbb64f3f7c687dcf7f469968abd9bebb

It appears the 8.10 workaround requires a workaround now.
