### PR TITLE
update vulkan-utils to 0.6.0 to hide some modules under `Vulkan.Utils.ShaderQQ`

### DIFF
--- a/utils/changelog.md
+++ b/utils/changelog.md
@@ -2,6 +2,15 @@
 
 ## WIP
 
+## [0.6.0] - 2021-03-02
+- Hide some modules under `Vulkan.Utils.ShaderQQ`
+  - hide module `Vulkan.Utils.ShaderQQ.ShaderType`
+  - hide module `Vulkan.Utils.ShaderQQ.Backend.Internal`
+  - hide module `Vulkan.Utils.ShaderQQ.Backend.Glslang.Internal`
+  - hide module `Vulkan.Utils.ShaderQQ.Backend.Shaderc.Internal`
+  - hide module `Vulkan.Utils.ShaderQQ.GLSL`
+  - hide module `Vulkan.Utils.ShaderQQ.HLSL`
+
 ## [0.5.0] - 2021-02-24
 - Refactor module `Vulkan.Utils.ShaderQQ`
   - Remove `Vulkan.Utils.ShaderQQ`

--- a/utils/package.yaml
+++ b/utils/package.yaml
@@ -1,5 +1,5 @@
 name: vulkan-utils
-version: "0.5.0"
+version: "0.6.0"
 synopsis: Utils for the vulkan package
 category: Graphics
 maintainer: Joe Hermaszewski <live.long.and.prosper@monoid.al>

--- a/utils/src/Vulkan/Utils/ShaderQQ/Backend/Glslang/Internal.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/Backend/Glslang/Internal.hs
@@ -1,7 +1,4 @@
-module Vulkan.Utils.ShaderQQ.Backend.Glslang.Internal
-  ( compileShaderQ
-  , compileShader
-  ) where
+module Vulkan.Utils.ShaderQQ.Backend.Glslang.Internal where
 
 import           Control.Monad.IO.Class
 import           Data.ByteString                ( ByteString )

--- a/utils/src/Vulkan/Utils/ShaderQQ/Backend/Internal.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/Backend/Internal.hs
@@ -1,6 +1,4 @@
-module Vulkan.Utils.ShaderQQ.Backend.Internal
-  ( messageProcess
-  ) where
+module Vulkan.Utils.ShaderQQ.Backend.Internal where
 
 import           Data.ByteString                ( ByteString )
 import           Data.List.Extra

--- a/utils/src/Vulkan/Utils/ShaderQQ/Backend/Shaderc/Internal.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/Backend/Shaderc/Internal.hs
@@ -1,7 +1,4 @@
-module Vulkan.Utils.ShaderQQ.Backend.Shaderc.Internal
-  ( compileShaderQ
-  , compileShader
-  ) where
+module Vulkan.Utils.ShaderQQ.Backend.Shaderc.Internal where
 
 import           Control.Monad.IO.Class
 import           Data.ByteString                ( ByteString )

--- a/utils/src/Vulkan/Utils/ShaderQQ/GLSL.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/GLSL.hs
@@ -1,7 +1,4 @@
-module Vulkan.Utils.ShaderQQ.GLSL
-  ( glsl
-  , insertLineDirective
-  ) where
+module Vulkan.Utils.ShaderQQ.GLSL where
 
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote

--- a/utils/src/Vulkan/Utils/ShaderQQ/HLSL.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/HLSL.hs
@@ -1,7 +1,4 @@
-module Vulkan.Utils.ShaderQQ.HLSL
-  ( hlsl
-  , insertLineDirective
-  ) where
+module Vulkan.Utils.ShaderQQ.HLSL where
 
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Quote

--- a/utils/src/Vulkan/Utils/ShaderQQ/ShaderType.hs
+++ b/utils/src/Vulkan/Utils/ShaderQQ/ShaderType.hs
@@ -1,6 +1,4 @@
-module Vulkan.Utils.ShaderQQ.ShaderType
-  ( ShaderType (..)
-  ) where
+module Vulkan.Utils.ShaderQQ.ShaderType where
 
 import           Data.String (IsString (..))
 

--- a/utils/vulkan-utils.cabal
+++ b/utils/vulkan-utils.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           vulkan-utils
-version:        0.5.0
+version:        0.6.0
 synopsis:       Utils for the vulkan package
 category:       Graphics
 homepage:       https://github.com/expipiplus1/vulkan#readme


### PR DESCRIPTION
I made a mistake that I didn't hidden some modules under `Vulkan.Utils.ShaderQQ` correctly. 

I think the [current haddock](https://hackage.haskell.org/package/vulkan-utils-0.5.0) about `ShaderQQ` is a bit messy due to these incorrectly exposed modules. But if this is considered doesn't matter, please close this PR.

<!--

Thanks!

Please update the appropriate changelog.md (in ./ ./utils ./vma ./openxr) WIP section for any non-trivial changes.

Feel free to bump the version number in the appropriate package.yaml, if you do
this then please tie off the WIP section of the changelog with the new version
number.

Make sure to run hpack after modifying any package.yaml files or adding new source files.

-->
