### PR TITLE
Update Vulkan to v1.2.182

### DIFF
--- a/openxr/openxr.cabal
+++ b/openxr/openxr.cabal
@@ -202,5 +202,5 @@ library
   if flag(use-vulkan-types)
     cpp-options: -DUSE_VULKAN_TYPES
     build-depends:
-        vulkan >=3.0 && <3.11
+        vulkan >=3.0 && <3.12
   default-language: Haskell2010


### PR DESCRIPTION
> Integrity holding at ninety percent.


[Diff without documentation changes](null)