### PR TITLE
vulkan-utils: disambiguate records

### DIFF
--- a/utils/changelog.md
+++ b/utils/changelog.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## WIP
+
+## [0.5.7.1] - 2022-09-06
 - Add support for GHC 9.4.
 
 ## [0.5.7] - 2022-03-31

--- a/utils/changelog.md
+++ b/utils/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## WIP
+- Add support for GHC 9.4.
 
 ## [0.5.7] - 2022-03-31
 - Relax bounds on `vulkan`

--- a/utils/package.yaml
+++ b/utils/package.yaml
@@ -1,5 +1,5 @@
 name: vulkan-utils
-version: "0.5.7"
+version: "0.5.7.1"
 synopsis: Utils for the vulkan package
 category: Graphics
 maintainer: Ellie Hermaszewska <live.long.and.prosper@monoid.al>

--- a/utils/src/Vulkan/Utils/Initialization.hs
+++ b/utils/src/Vulkan/Utils/Initialization.hs
@@ -21,6 +21,7 @@ import           Data.Text                      ( Text )
 import           Data.Text.Encoding             ( decodeUtf8 )
 import           Vulkan.CStruct.Extends
 import           Vulkan.Core10
+import qualified Vulkan.Core10 as Instance      ( InstanceCreateInfo(..) )
 import           Vulkan.Extensions.VK_EXT_debug_utils
 import           Vulkan.Extensions.VK_EXT_validation_features
 import           Vulkan.Requirement
@@ -63,8 +64,9 @@ createDebugInstanceFromRequirements required optional baseCreateInfo = do
         :: InstanceCreateInfo
              (DebugUtilsMessengerCreateInfoEXT : ValidationFeaturesEXT : es)
       instanceCreateInfo = baseCreateInfo
-        { next = debugMessengerCreateInfo :& validationFeatures :& next
-                   (baseCreateInfo :: InstanceCreateInfo es)
+        { Instance.next = debugMessengerCreateInfo
+                       :& validationFeatures
+                       :& Instance.next baseCreateInfo
         }
       additionalRequirements =
         [ RequireInstanceExtension

--- a/utils/vulkan-utils.cabal
+++ b/utils/vulkan-utils.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.24
 -- see: https://github.com/sol/hpack
 
 name:           vulkan-utils
-version:        0.5.7
+version:        0.5.7.1
 synopsis:       Utils for the vulkan package
 category:       Graphics
 homepage:       https://github.com/expipiplus1/vulkan#readme


### PR DESCRIPTION
This patch uses the module system to disambiguate record fields,
as the type-directed disambiguation mechanism doesn't work well.

Achieves compatibility with GHC 9.4.