### PR TITLE
Add the LunarG installation path to the vulkan dylib RPATHs

### DIFF
--- a/vulkan.cabal
+++ b/vulkan.cabal
@@ -673,6 +673,26 @@ library
       UndecidableInstances
       ViewPatterns
   ghc-options: -Wall -Wno-unticked-promoted-constructors -Wno-missing-pattern-synonym-signatures -Wno-unused-imports -Wno-missing-signatures -Wno-partial-type-signatures
+
+  -- The LunarG installation script (macOS) copies the vulkan dylibs to /usr/local/lib.
+  --
+  -- By adding this directory to the RPATH entries of the vulkan dylib
+  -- built from this component, we can save a lot of headaches (ie loader
+  -- errors) for macOS users for whom that path is not part of the default
+  -- RPATH entries. This is justified by this being the default installation
+  -- path of the vulkan SDK on macOS.
+  --
+  -- More specifically, vulkan-utils uses template haskell which forces the
+  -- vulkan library to be loaded at compile time, resulting in an especially
+  -- hard to diagnose loader error that is harder to fix than correcting the
+  -- rpath of an executable (#501). This fixes that error for LunarG vulkan
+  -- installations.
+  --
+  -- The caveat is that this fix is predicated on a Cabal bug being fixed: This
+  -- will only work from Cabal 3.10.3+ (after cabal#9554 lands).
+  if os(darwin)
+    extra-lib-dirs: /usr/local/lib
+
   build-depends:
       base <5
     , bytestring


### PR DESCRIPTION
The LunarG installation script (macOS) copies the vulkan dylibs to /usr/local/lib.

By adding this directory to the RPATH entries of the vulkan dylib built from this component, we can save a lot of headaches (ie loader errors) for macOS users for whom that path is not part of the default RPATH entries. This is justified by this being the default installation path of the vulkan SDK on macOS.

More specifically, vulkan-utils uses template haskell which forces the vulkan library to be loaded at compile time, resulting in an especially hard to diagnose loader error that is harder to fix than correcting the rpath of an executable (#501). This fixes that error for LunarG vulkan installations.

The caveat is that this fix is predicated on a Cabal bug being fixed: This will only work from Cabal 3.10.3+ (after cabal#9554 lands).

Fixes #501.

<!--

Thanks!

Please update the appropriate changelog.md (in ./ ./utils ./vma ./openxr) WIP section for any non-trivial changes.

Feel free to bump the version number in the appropriate package.yaml, if you do
this then please tie off the WIP section of the changelog with the new version
number.

Make sure to run hpack after modifying any package.yaml files or adding new source files.

-->
