### PR TITLE
Fix forward type family in boot file (9.8.2)

### DIFF
--- a/generate-new/src/Render/Spec/Extends.hs
+++ b/generate-new/src/Render/Spec/Extends.hs
@@ -186,7 +186,7 @@ classes Spec {..} = do
     tellDoc [qqi|
       class PeekChain (xs :: [Type])
       class PokeChain (xs :: [Type])
-      type family Extends (p :: [Type] -> Type) (x :: Type) :: Constraint
+      type family Extends (p :: [Type] -> Type) (x :: Type) :: Constraint where ..
       type family Extendss (p :: [Type] -> Type) (xs :: [Type]) :: Constraint where
         Extendss p '[]      = ()
         Extendss p (x : xs) = (Extends p x, Extendss p xs)

--- a/src/Vulkan/CStruct/Extends.hs-boot
+++ b/src/Vulkan/CStruct/Extends.hs-boot
@@ -31,7 +31,7 @@ instance FromCStruct BaseOutStructure
 
 class PeekChain (xs :: [Type])
 class PokeChain (xs :: [Type])
-type family Extends (p :: [Type] -> Type) (x :: Type) :: Constraint
+type family Extends (p :: [Type] -> Type) (x :: Type) :: Constraint where ..
 type family Extendss (p :: [Type] -> Type) (xs :: [Type]) :: Constraint where
   Extendss p '[]      = ()
   Extendss p (x : xs) = (Extends p x, Extendss p xs)


### PR DESCRIPTION
Fixes an hs-boot file which had an incorrect forward declaration of a closed type family. vulkan would successfully compile despite the hs-boot error with 9.8.1, but not with 9.8.2 because of bug fixes which makes the compiler now reject this invalid program.

We need to use the weird `type family A x where ..` (with two literal dots after `where`) to declare the type family in the boot file.

