### PR TITLE
compute example autoapply dependency drop and refactoring

### DIFF
--- a/examples/compute/Main.hs
+++ b/examples/compute/Main.hs
@@ -80,6 +80,7 @@ main = runResourceT $ do
 myApiVersion :: Word32
 myApiVersion = API_VERSION_1_0
 
+initializeInstance :: ResourceT IO Instance
 initializeInstance = do
   availableLayers <- map layerName . toList . snd <$> enumerateInstanceLayerProperties
 

--- a/examples/compute/Main.hs
+++ b/examples/compute/Main.hs
@@ -1,159 +1,53 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE Strict #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TupleSections #-}
+
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 
-module Main
-  ( main
-  )
-where
+module Main (main) where
 
-import           AutoApply
-import qualified Codec.Picture                 as JP
-import           Control.Exception.Safe
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Maybe      ( MaybeT(..) )
-import           Control.Monad.Trans.Reader
-import           Control.Monad.Trans.Resource
-import           Data.Bits
-import qualified Data.ByteString.Lazy          as BSL
-import           Data.Foldable
-import           Data.List                      ( partition )
-import           Data.Maybe                     ( catMaybes )
-import           Data.Ord                       ( comparing )
-import           Data.Text                      ( Text )
-import qualified Data.Text                     as T
-import           Data.Text.Encoding             ( decodeUtf8 )
-import qualified Data.Vector                   as V
-import           Data.Word
-import           Foreign.Marshal.Array          ( peekArray )
-import           Foreign.Ptr
-import           Foreign.Storable               ( sizeOf )
-import           Say
+import Codec.Picture                as JP (Image, PixelRGBA8 (..), withImage, encodePng)
+import Control.Exception.Safe       (finally, throwString)
+import Control.Monad.IO.Class       (MonadIO(..))
+import Control.Monad.Trans.Maybe    (MaybeT(..))
+import Control.Monad.Trans.Resource (allocate, runResourceT, ResourceT)
+import Data.ByteString              (StrictByteString, ByteString)
+import Data.ByteString.Lazy         as BSL (writeFile)
+import Data.List                    (partition, maximumBy)
+import Data.Maybe                   (catMaybes)
+import Data.Ord                     (comparing)
+import Data.Text                    as T (pack)
+import Data.Text.Encoding           (decodeUtf8)
+import Data.Vector                  as Vec (toList, fromList, filter, indexed, (!?))
+import Foreign                      (Word32, Word64, Ptr, Bits(..), Storable(..), peekArray, castFunPtr, plusPtr)
+import Say                          (sayErr)
 
-import           Vulkan.CStruct.Extends
-import           Vulkan.CStruct.Utils           ( FixedArray
-                                                , lowerArrayPtr
-                                                )
-import           Vulkan.Core10                 as Vk
-                                         hiding ( withBuffer
-                                                , withImage
-                                                )
-import qualified Vulkan.Core10                 as CommandBufferBeginInfo (CommandBufferBeginInfo(..))
-import qualified Vulkan.Core10                 as CommandPoolCreateInfo (CommandPoolCreateInfo(..))
-import qualified Vulkan.Core10                 as PipelineLayoutCreateInfo (PipelineLayoutCreateInfo(..))
-import qualified Vulkan.Core10.DeviceInitialization as DI
-import           Vulkan.Dynamic                 ( DeviceCmds
-                                                  ( DeviceCmds
-                                                  , pVkGetDeviceProcAddr
-                                                  )
-                                                , InstanceCmds
-                                                  ( InstanceCmds
-                                                  , pVkGetInstanceProcAddr
-                                                  )
-                                                )
-import           Vulkan.Extensions.VK_EXT_debug_utils
-import           Vulkan.Extensions.VK_EXT_validation_features
-import           Vulkan.Utils.Debug
-import           Vulkan.Utils.ShaderQQ.GLSL.Glslang
-import           Vulkan.Zero
-import           VulkanMemoryAllocator         as VMA
-                                         hiding ( getPhysicalDeviceProperties )
-import qualified VulkanMemoryAllocator         as AllocationCreateInfo (AllocationCreateInfo(..))
-
-----------------------------------------------------------------
--- Define the monad in which most of the program will run
-----------------------------------------------------------------
-
--- | @V@ keeps track of a bunch of "global" handles and performs resource
--- management.
-newtype V a = V { unV :: ReaderT GlobalHandles (ResourceT IO) a }
-  deriving newtype ( Functor
-                   , Applicative
-                   , Monad
-                   , MonadFail
-                   , MonadThrow
-                   , MonadCatch
-                   , MonadMask
-                   , MonadIO
-                   , MonadResource
-                   )
-
-runV
-  :: Instance
-  -> PhysicalDevice
-  -> Word32
-  -> Device
-  -> Allocator
-  -> V a
-  -> ResourceT IO a
-runV ghInstance ghPhysicalDevice ghComputeQueueFamilyIndex ghDevice ghAllocator
-  = flip runReaderT GlobalHandles { .. } . unV
-
-data GlobalHandles = GlobalHandles
-  { ghInstance                :: Instance
-  , ghPhysicalDevice          :: PhysicalDevice
-  , ghDevice                  :: Device
-  , ghAllocator               :: Allocator
-  , ghComputeQueueFamilyIndex :: Word32
-  }
-
--- Getters for global handles
-
-getInstance :: V Instance
-getInstance = V (asks ghInstance)
-
-getComputeQueueFamilyIndex :: V Word32
-getComputeQueueFamilyIndex = V (asks ghComputeQueueFamilyIndex)
-
-getPhysicalDevice :: V PhysicalDevice
-getPhysicalDevice = V (asks ghPhysicalDevice)
-
-getDevice :: V Device
-getDevice = V (asks ghDevice)
-
-getAllocator :: V Allocator
-getAllocator = V (asks ghAllocator)
-
-noAllocationCallbacks :: Maybe AllocationCallbacks
-noAllocationCallbacks = Nothing
-
---
--- Wrap a bunch of Vulkan commands so that they automatically pull global
--- handles from 'V'
---
--- Wrapped functions are suffixed with "'"
---
-autoapplyDecs
-  (<> "'")
-  [ 'getDevice
-  , 'getPhysicalDevice
-  , 'getInstance
-  , 'getAllocator
-  , 'noAllocationCallbacks
-  ]
-  -- Allocate doesn't subsume the continuation type on the "with" commands, so
-  -- put it in the unifying group.
-  ['allocate]
-  [ 'invalidateAllocation
-  , 'withBuffer
-  , 'deviceWaitIdle
-  , 'getDeviceQueue
-  , 'waitForFences
-  , 'withCommandBuffers
-  , 'withCommandPool
-  , 'withFence
-  , 'withComputePipelines
-  , 'withInstance
-  , 'withPipelineLayout
-  , 'withShaderModule
-  , 'withDescriptorPool
-  , 'allocateDescriptorSets
-  , 'withDescriptorSetLayout
-  , 'updateDescriptorSets
-  ]
+import Vulkan.CStruct.Extends
+import Vulkan.CStruct.Utils          (FixedArray, lowerArrayPtr)
+import Vulkan.Core10                 as Vk hiding (withBuffer, withImage)
+import Vulkan.Core10                 as CommandBufferBeginInfo (CommandBufferBeginInfo(..))
+import Vulkan.Core10                 as CommandPoolCreateInfo (CommandPoolCreateInfo(..))
+import Vulkan.Core10                 as PipelineLayoutCreateInfo (PipelineLayoutCreateInfo(..))
+import Vulkan.Core10                 as ShaderModuleCreateInfo (ShaderModuleCreateInfo(..))
+import Vulkan.Core10                 as MemoryHeap (MemoryHeap(size)) 
+import Vulkan.Dynamic                (DeviceCmds(..), InstanceCmds(..))
+import Vulkan.Extensions
+import Vulkan.Utils.Debug            (debugCallbackPtr)
+import Vulkan.Utils.ShaderQQ.GLSL.Glslang (comp)
+import Vulkan.Zero                   (Zero(..))
+import VulkanMemoryAllocator         as VMA hiding (getPhysicalDeviceProperties)
+import VulkanMemoryAllocator         as AllocationCreateInfo (AllocationCreateInfo(..))
 
 ----------------------------------------------------------------
 -- The program
@@ -162,37 +56,50 @@ autoapplyDecs
 main :: IO ()
 main = runResourceT $ do
   -- Create Instance, PhysicalDevice, Device and Allocator
-  inst             <- Main.createInstance
-  (phys, pdi, dev) <- Main.createDevice inst
-  (_, allocator)   <- withAllocator
-    zero
-      { flags            = zero
-      , physicalDevice   = physicalDeviceHandle phys
-      , device           = deviceHandle dev
-      , instance'        = instanceHandle inst
-      , vulkanApiVersion = myApiVersion
-      , vulkanFunctions  = Just $ case inst of
-        Instance _ InstanceCmds {..} -> case dev of
-          Device _ DeviceCmds {..} -> zero
-            { vkGetInstanceProcAddr = castFunPtr pVkGetInstanceProcAddr
-            , vkGetDeviceProcAddr   = castFunPtr pVkGetDeviceProcAddr
-            }
-      }
-    allocate
+  inst <- initializeInstance
+
+  (_, devs) <- enumeratePhysicalDevices inst
+  (pdi, phys) <-
+    fmap (maximumBy (comparing fst) . catMaybes)
+    $ mapM (\dev -> (fmap (, dev) <$> physicalDeviceInfo dev)) (toList devs)
+
+  sayErr . ("Using device: " <>) . decodeUtf8 . deviceName =<< getPhysicalDeviceProperties phys
+  (_, device) <- withDevice phys (deviceQueueCreateInfo pdi) Nothing allocate
+  (_, allocator)   <- withAllocator (allocatorCreateInfo device phys inst) allocate
 
   -- Run our application
   -- Wait for the device to become idle before tearing down any resourecs.
-  runV inst phys (pdiComputeQueueFamilyIndex pdi) dev allocator
-    . (`finally` deviceWaitIdle')
-    $ do
-        image <- render
-        let filename = "julia.png"
-        sayErr $ "Writing " <> filename
-        liftIO $ BSL.writeFile filename (JP.encodePng image)
+  finally (do
+      -- Render the Julia set
+      image <- calculateImage device allocator pdi
+      sayErr "Writing file"
+      liftIO $ BSL.writeFile "julia.png" (JP.encodePng image)
+    )
+    (deviceWaitIdle device)
 
--- Render the Julia set
-render :: V (JP.Image JP.PixelRGBA8)
-render = do
+myApiVersion :: Word32
+myApiVersion = API_VERSION_1_0
+
+initializeInstance = do
+  availableLayers <- map layerName . toList . snd <$> enumerateInstanceLayerProperties
+
+  let (layers, missingLayers) = partition (`elem` availableLayers) ["VK_LAYER_KHRONOS_validation"]
+  sayErr $ "Missing optional layer: " <> (T.pack . show) missingLayers
+
+  availableExtensions <- map extensionName . toList . snd <$> enumerateInstanceExtensionProperties Nothing
+
+  let (optExtsHave, optMissing) = partition (`elem` availableExtensions) [EXT_VALIDATION_FEATURES_EXTENSION_NAME]
+  sayErr $ "Missing optional extension: " <> (T.pack . show) optMissing
+
+  let (reqExtsHave, reqMissing) = partition (`elem` availableExtensions) [EXT_DEBUG_UTILS_EXTENSION_NAME]
+  sayErr $ "Missing required extension: " <> (T.pack . show) reqMissing
+
+  (_, inst) <- withInstance (instanceCreateInfo layers (reqExtsHave <> optExtsHave)) Nothing allocate
+  _ <- withDebugUtilsMessengerEXT inst debugMessengerCreateInfo Nothing allocate
+  pure inst
+
+calculateImage :: Device -> Allocator -> PhysicalDeviceInfo -> ResourceT IO (JP.Image PixelRGBA8)
+calculateImage device allocator pdi = do
   -- Some things to reuse, make sure these are the same as the values in the
   -- compute shader. TODO: reduce this duplication.
   let width, height, workgroupX, workgroupY :: Int
@@ -202,122 +109,66 @@ render = do
       workgroupY = 4
 
   -- Create a buffer into which to render
-  --
-  -- Use ALLOCATION_CREATE_MAPPED_BIT and MEMORY_USAGE_GPU_TO_CPU to make sure
-  -- it's readable on the host and starts in the mapped state
-  (_, (buffer, bufferAllocation, bufferAllocationInfo)) <- withBuffer'
-    zero { size  = fromIntegral $ width * height * 4 * sizeOf (0 :: Float)
-         , usage = BUFFER_USAGE_STORAGE_BUFFER_BIT
-         }
-    zero { AllocationCreateInfo.flags = ALLOCATION_CREATE_MAPPED_BIT
-         , usage = MEMORY_USAGE_GPU_TO_CPU
-         }
+  (_, (buffer, bufferAllocation, bufferAllocationInfo)) <-
+    withBuffer allocator (bufferCreateInfo width height) allocationCreateInfo allocate
 
   -- Create a descriptor set and layout for this buffer
   (descriptorSet, descriptorSetLayout) <- do
-    -- Create a descriptor pool
-    (_, descriptorPool) <- withDescriptorPool' zero
-      { maxSets   = 1
-      , poolSizes = [DescriptorPoolSize DESCRIPTOR_TYPE_STORAGE_BUFFER 1]
-      }
-
-    -- Create a set layout
-    (_, descriptorSetLayout) <- withDescriptorSetLayout' zero
-      { bindings = [ zero { binding         = 0
-                          , descriptorType  = DESCRIPTOR_TYPE_STORAGE_BUFFER
-                          , descriptorCount = 1
-                          , stageFlags      = SHADER_STAGE_COMPUTE_BIT
-                          }
-                   ]
-      }
+    (_, descriptorPool) <- withDescriptorPool device descriptorPoolCreateInfo Nothing allocate
+    (_, descriptorSetLayout) <- withDescriptorSetLayout device descriptorSetLayoutCreateInfo Nothing allocate
 
     -- Allocate a descriptor set from the pool with that layout
     -- Don't use `withDescriptorSets` here as the set will be cleaned up when
     -- the pool is destroyed.
-    [descriptorSet] <- allocateDescriptorSets' zero
-      { descriptorPool = descriptorPool
-      , setLayouts     = [descriptorSetLayout]
-      }
+    [descriptorSet] <- allocateDescriptorSets device (descriptorSetAllocateInfo descriptorPool descriptorSetLayout)
     pure (descriptorSet, descriptorSetLayout)
 
   -- Assign the buffer in this descriptor set
-  updateDescriptorSets'
-    [ SomeStruct zero { dstSet          = descriptorSet
-                      , dstBinding      = 0
-                      , descriptorType  = DESCRIPTOR_TYPE_STORAGE_BUFFER
-                      , descriptorCount = 1
-                      , bufferInfo = [DescriptorBufferInfo buffer 0 WHOLE_SIZE]
-                      }
-    ]
-    []
+  updateDescriptorSets device [descriptor descriptorSet buffer] []
 
   -- Create our shader and compute pipeline
-  shader              <- createShader
-  (_, pipelineLayout) <- withPipelineLayout' zero { PipelineLayoutCreateInfo.setLayouts = [descriptorSetLayout] }
-  let pipelineCreateInfo :: ComputePipelineCreateInfo '[]
-      pipelineCreateInfo = zero { layout             = pipelineLayout
-                                , stage              = shader
-                                , basePipelineHandle = zero
-                                }
-  (_, (_, [computePipeline])) <- withComputePipelines'
-    zero
-    [SomeStruct pipelineCreateInfo]
+  (_, shaderModule) <- withShaderModule device zero{ShaderModuleCreateInfo.code = shaderCode} Nothing allocate
+
+  (_, pipelineLayout) <- withPipelineLayout device (pipelineLayoutCreateInfo descriptorSetLayout) Nothing allocate
+  (_, (_, [computePipeline])) <- withComputePipelines device zero [pipelineCreateInfo pipelineLayout shaderModule] Nothing allocate
 
   -- Create a command buffer
-  computeQueueFamilyIndex <- getComputeQueueFamilyIndex
-  let commandPoolCreateInfo = zero { CommandPoolCreateInfo.queueFamilyIndex = computeQueueFamilyIndex }
-  (_, commandPool) <- withCommandPool' commandPoolCreateInfo
-  let commandBufferAllocateInfo = zero { commandPool = commandPool
-                                       , level = COMMAND_BUFFER_LEVEL_PRIMARY
-                                       , commandBufferCount = 1
-                                       }
-  (_, [commandBuffer]) <- withCommandBuffers' commandBufferAllocateInfo
+  (_, commandPool) <- withCommandPool device (commandPoolCreateInfo pdi) Nothing allocate
+
+  (_, [commandBuffer]) <- withCommandBuffers device (commandBufferAllocateInfo commandPool) allocate
 
   -- Fill command buffer
-  useCommandBuffer commandBuffer
-                   zero { CommandBufferBeginInfo.flags = COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT }
-    $ do
-        -- Set up our state, pipeline and descriptor set
-        cmdBindPipeline commandBuffer
-                        PIPELINE_BIND_POINT_COMPUTE
-                        computePipeline
-        cmdBindDescriptorSets commandBuffer
-                              PIPELINE_BIND_POINT_COMPUTE
-                              pipelineLayout
-                              0
-                              [descriptorSet]
-                              []
-
-        -- Dispatch the compute shader
-        cmdDispatch
-          commandBuffer
-          (ceiling (realToFrac width / realToFrac @_ @Float workgroupX))
-          (ceiling (realToFrac height / realToFrac @_ @Float workgroupY))
-          1
+  useCommandBuffer commandBuffer сommandBufferBeginInfo $
+    do
+    cmdBindPipeline commandBuffer PIPELINE_BIND_POINT_COMPUTE computePipeline
+    cmdBindDescriptorSets commandBuffer PIPELINE_BIND_POINT_COMPUTE pipelineLayout 0 [descriptorSet] []
+    cmdDispatch
+      commandBuffer
+      (ceiling (realToFrac width / realToFrac @_ @Float workgroupX))
+      (ceiling (realToFrac height / realToFrac @_ @Float workgroupY))
+      1
 
   -- Create a fence so we can know when render is finished
-  (_, fence) <- withFence' zero
+  (_, fence) <- withFence device zero Nothing allocate
+
   -- Submit the command buffer and wait for it to execute
-  let submitInfo =
-        zero { commandBuffers = [commandBufferHandle commandBuffer] }
-  computeQueue <- getDeviceQueue' computeQueueFamilyIndex 0
-  queueSubmit computeQueue [SomeStruct submitInfo] fence
+  computeQueue <- getDeviceQueue device (pdiComputeQueueFamilyIndex pdi) 0
+  queueSubmit computeQueue [submitInfo commandBuffer] fence
+
   let fenceTimeout = 1e9 -- 1 second
-  waitForFences' [fence] True fenceTimeout >>= \case
+  waitForFences device [fence] True fenceTimeout >>= \case
     TIMEOUT -> throwString "Timed out waiting for compute"
     _       -> pure ()
 
   -- If the buffer allocation is not HOST_COHERENT this will ensure the changes
   -- are present on the CPU.
-  invalidateAllocation' bufferAllocation 0 WHOLE_SIZE
+  invalidateAllocation allocator bufferAllocation 0 WHOLE_SIZE
 
   -- TODO: speed this bit up, it's hopelessly slow
   let pixelAddr :: Int -> Int -> Ptr (FixedArray 4 Float)
       pixelAddr x y = plusPtr (mappedData bufferAllocationInfo)
-                              (((y * width) + x) * 4 * sizeOf (0 :: Float))
-  liftIO $ JP.withImage
-    width
-    height
+        (((y * width) + x) * 4 * sizeOf (0 :: Float))
+  liftIO $ JP.withImage width height
     (\x y -> do
       let ptr = pixelAddr x y
       [r, g, b, a] <- fmap (\f -> round (f * 255))
@@ -325,173 +176,189 @@ render = do
       pure $ JP.PixelRGBA8 r g b a
     )
 
--- | Create a compute shader
-createShader :: V (SomeStruct PipelineShaderStageCreateInfo)
-createShader = do
-  let compCode = [comp|
-        #version 450
-        #extension GL_ARB_separate_shader_objects : enable
 
-        const int width = 512;
-        const int height = width;
-        const int workgroup_x = 32;
-        const int workgroup_y = 4;
+shaderCode :: ByteString
+shaderCode = [comp|
+  #version 450
+  #extension GL_ARB_separate_shader_objects : enable
 
-        // r^2 - r = |c|
-        const vec2 c = vec2(-0.8, 0.156);
-        const float r = 0.5 * (1 + sqrt (4 * dot(c,c) + 1));
+  const int width = 512;
+  const int height = width;
+  const int workgroup_x = 32;
+  const int workgroup_y = 4;
 
-        layout (local_size_x = workgroup_x, local_size_y = workgroup_y, local_size_z = 1 ) in;
-        layout(std140, binding = 0) buffer buf
-        {
-           vec4 imageData[];
-        };
+  // r^2 - r = |c|
+  const vec2 c = vec2(-0.8, 0.156);
+  const float r = 0.5 * (1 + sqrt (4 * dot(c,c) + 1));
+
+  layout (local_size_x = workgroup_x, local_size_y = workgroup_y, local_size_z = 1 ) in;
+  layout(std140, binding = 0) buffer buf
+  {
+     vec4 imageData[];
+  };
 
 
-        // From https://iquilezles.org/www/articles/palettes/palettes.htm
-        //
-        // Traditional Julia blue and orange
-        vec3 color(const float t) {
-          const vec3 a = vec3(0.5);
-          const vec3 b = vec3(0.5);
-          const vec3 c = vec3(8);
-          const vec3 d = vec3(0.5, 0.6, 0.7);
-          return a + b * cos(6.28318530718 * (c * t + d));
-        }
+  // From https://iquilezles.org/www/articles/palettes/palettes.htm
+  //
+  // Traditional Julia blue and orange
+  vec3 color(const float t) {
+    const vec3 a = vec3(0.5);
+    const vec3 b = vec3(0.5);
+    const vec3 c = vec3(8);
+    const vec3 d = vec3(0.5, 0.6, 0.7);
+    return a + b * cos(6.28318530718 * (c * t + d));
+  }
 
-        // complex multiplication
-        vec2 mulC(const vec2 a, const vec2 b) {
-          return vec2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
-        }
+  // complex multiplication
+  vec2 mulC(const vec2 a, const vec2 b) {
+    return vec2(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
+  }
 
-        vec2 f(const vec2 z) {
-          return mulC(z,z) + c;
-        }
+  vec2 f(const vec2 z) {
+    return mulC(z,z) + c;
+  }
 
-        // Algorithm from https://en.wikipedia.org/wiki/Julia_set
-        void main() {
-          vec2 z = vec2
-            ( float(gl_GlobalInvocationID.y) / float(height) * 2 * r - r
-            , float(gl_GlobalInvocationID.x) / float(width) * 2 * r - r
-            );
+  // Algorithm from https://en.wikipedia.org/wiki/Julia_set
+  void main() {
+    vec2 z = vec2
+      ( float(gl_GlobalInvocationID.y) / float(height) * 2 * r - r
+      , float(gl_GlobalInvocationID.x) / float(width) * 2 * r - r
+      );
 
-          uint iteration = 0;
-          const int max_iteration = 1000;
+    uint iteration = 0;
+    const int max_iteration = 1000;
 
-          while (dot(z,z) < dot(r,r) && iteration < max_iteration) {
-            z = f(z);
-            iteration++;
-          }
+    while (dot(z,z) < dot(r,r) && iteration < max_iteration) {
+      z = f(z);
+      iteration++;
+    }
 
-          const uint i = width * gl_GlobalInvocationID.y + gl_GlobalInvocationID.x;
-          if (iteration == max_iteration) {
-            imageData[i] = vec4(0,0,0,1);
-          } else {
-            imageData[i] = vec4(color(float(iteration) / float(max_iteration)),1);
-          }
-        }
-      |]
-  (_, compModule) <- withShaderModule' zero { code = compCode }
-  let compShaderStageCreateInfo = zero { stage   = SHADER_STAGE_COMPUTE_BIT
-                                       , module' = compModule
-                                       , name    = "main"
-                                       }
-  pure $ SomeStruct compShaderStageCreateInfo
+    const uint i = width * gl_GlobalInvocationID.y + gl_GlobalInvocationID.x;
+    if (iteration == max_iteration) {
+      imageData[i] = vec4(0,0,0,1);
+    } else {
+      imageData[i] = vec4(color(float(iteration) / float(max_iteration)),1);
+    }
+  }
+|]
 
-----------------------------------------------------------------
--- Initialization
-----------------------------------------------------------------
+deviceQueueCreateInfo :: PhysicalDeviceInfo -> DeviceCreateInfo '[]
+deviceQueueCreateInfo pdi = 
+  let queueCreateInfo = SomeStruct zero{queueFamilyIndex = pdiComputeQueueFamilyIndex pdi, queuePriorities  = [1]}
+  in zero{queueCreateInfos = [queueCreateInfo]}
 
-myApiVersion :: Word32
-myApiVersion = API_VERSION_1_0
+allocatorCreateInfo :: Device -> PhysicalDevice -> Instance -> AllocatorCreateInfo
+allocatorCreateInfo dev@(Device _ DeviceCmds{..}) phys inst@(Instance _ InstanceCmds{..}) = zero
+  { flags            = zero
+  , physicalDevice   = physicalDeviceHandle phys
+  , device           = deviceHandle dev
+  , instance'        = instanceHandle inst
+  , vulkanApiVersion = myApiVersion
+  , vulkanFunctions  = Just zero
+    { vkGetInstanceProcAddr = castFunPtr pVkGetInstanceProcAddr
+    , vkGetDeviceProcAddr   = castFunPtr pVkGetDeviceProcAddr
+    }
+  }
 
--- | Create an instance with a debug messenger
-createInstance :: MonadResource m => m Instance
-createInstance = do
-  availableExtensionNames <-
-    toList
-    .   fmap extensionName
-    .   snd
-    <$> enumerateInstanceExtensionProperties Nothing
-  availableLayerNames <-
-    toList . fmap layerName . snd <$> enumerateInstanceLayerProperties
+-- Use ALLOCATION_CREATE_MAPPED_BIT and MEMORY_USAGE_GPU_TO_CPU to make sure
+-- it's readable on the host and starts in the mapped state
+bufferCreateInfo :: Int -> Int -> BufferCreateInfo '[]
+bufferCreateInfo width height = zero
+  { size  = fromIntegral $ width * height * 4 * sizeOf (0 :: Float)
+  , usage = BUFFER_USAGE_STORAGE_BUFFER_BIT
+  }
 
-  let requiredLayers     = []
-      optionalLayers     = ["VK_LAYER_KHRONOS_validation"]
-      requiredExtensions = [EXT_DEBUG_UTILS_EXTENSION_NAME]
-      optionalExtensions = [EXT_VALIDATION_FEATURES_EXTENSION_NAME]
+allocationCreateInfo :: AllocationCreateInfo
+allocationCreateInfo = zero
+  { AllocationCreateInfo.flags = ALLOCATION_CREATE_MAPPED_BIT
+  , usage = MEMORY_USAGE_GPU_TO_CPU
+  }
 
-  extensions <- partitionOptReq "extension"
-                                availableExtensionNames
-                                optionalExtensions
-                                requiredExtensions
-  layers <- partitionOptReq "layer"
-                            availableLayerNames
-                            optionalLayers
-                            requiredLayers
+descriptorPoolCreateInfo :: DescriptorPoolCreateInfo '[]
+descriptorPoolCreateInfo = zero
+  { maxSets   = 1
+  , poolSizes = [DescriptorPoolSize DESCRIPTOR_TYPE_STORAGE_BUFFER 1]
+  }
 
-  let debugMessengerCreateInfo = zero
-        { messageSeverity = DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
-                              .|. DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
-        , messageType     = DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT
-                            .|. DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
-                            .|. DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT
-        , pfnUserCallback = debugCallbackPtr
-        }
-      instanceCreateInfo =
-        zero
-            { applicationInfo       = Just zero { applicationName = Nothing
-                                                , apiVersion      = myApiVersion
-                                                }
-            , enabledLayerNames     = V.fromList layers
-            , enabledExtensionNames = V.fromList extensions
-            }
-          ::& debugMessengerCreateInfo
-          :&  ValidationFeaturesEXT
-                [VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT]
-                []
-          :&  ()
-  (_, inst) <- withInstance' instanceCreateInfo
-  _ <- withDebugUtilsMessengerEXT inst debugMessengerCreateInfo Nothing allocate
-  pure inst
+descriptorSetLayoutCreateInfo :: DescriptorSetLayoutCreateInfo '[]
+descriptorSetLayoutCreateInfo = zero
+  { bindings = [
+    zero
+      { binding         = 0
+      , descriptorType  = DESCRIPTOR_TYPE_STORAGE_BUFFER
+      , descriptorCount = 1
+      , stageFlags      = SHADER_STAGE_COMPUTE_BIT
+      }
+    ]
+  }
 
-createDevice
-  :: (MonadResource m, MonadThrow m)
-  => Instance
-  -> m (PhysicalDevice, PhysicalDeviceInfo, Device)
-createDevice inst = do
-  (pdi, phys) <- pickPhysicalDevice inst physicalDeviceInfo
-  sayErr . ("Using device: " <>) =<< physicalDeviceName phys
+descriptorSetAllocateInfo :: DescriptorPool -> DescriptorSetLayout -> DescriptorSetAllocateInfo '[]
+descriptorSetAllocateInfo descriptorPool descriptorSetLayout = zero
+  { descriptorPool = descriptorPool
+  , setLayouts     = [descriptorSetLayout]
+  }
 
-  let deviceCreateInfo = zero
-        { queueCreateInfos =
-          [ SomeStruct zero { queueFamilyIndex = pdiComputeQueueFamilyIndex pdi
-                            , queuePriorities  = [1]
-                            }
-          ]
-        }
+descriptor :: DescriptorSet -> Buffer -> SomeStruct WriteDescriptorSet
+descriptor descriptorSet buffer = SomeStruct zero
+  { dstSet          = descriptorSet
+  , dstBinding      = 0
+  , descriptorType  = DESCRIPTOR_TYPE_STORAGE_BUFFER
+  , descriptorCount = 1
+  , bufferInfo      = [DescriptorBufferInfo buffer 0 WHOLE_SIZE]
+  }
 
-  (_, dev) <- withDevice phys deviceCreateInfo Nothing allocate
-  pure (phys, pdi, dev)
+pipelineLayoutCreateInfo :: DescriptorSetLayout -> PipelineLayoutCreateInfo
+pipelineLayoutCreateInfo descriptorSetLayout = zero{PipelineLayoutCreateInfo.setLayouts = [descriptorSetLayout]}
+
+pipelineCreateInfo :: PipelineLayout -> ShaderModule -> SomeStruct ComputePipelineCreateInfo
+pipelineCreateInfo pipelineLayout shaderModule = SomeStruct zero
+  { layout             = pipelineLayout
+  , stage              = compShaderStageCreateInfo shaderModule
+  , basePipelineHandle = zero
+  }
+
+compShaderStageCreateInfo :: ShaderModule -> SomeStruct PipelineShaderStageCreateInfo
+compShaderStageCreateInfo compModule = SomeStruct zero
+  { stage   = SHADER_STAGE_COMPUTE_BIT
+  , module' = compModule
+  , name    = "main"
+  }
+
+commandPoolCreateInfo :: PhysicalDeviceInfo -> CommandPoolCreateInfo
+commandPoolCreateInfo pdi = zero{CommandPoolCreateInfo.queueFamilyIndex = pdiComputeQueueFamilyIndex pdi}
+
+commandBufferAllocateInfo :: CommandPool -> CommandBufferAllocateInfo
+commandBufferAllocateInfo commandPool = zero{commandPool = commandPool, level = COMMAND_BUFFER_LEVEL_PRIMARY, commandBufferCount = 1}
+
+debugMessengerCreateInfo :: DebugUtilsMessengerCreateInfoEXT
+debugMessengerCreateInfo = zero
+  { messageSeverity = DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
+                      .|. DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
+  , messageType     = DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT
+                      .|. DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT
+                      .|. DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT
+  , pfnUserCallback = debugCallbackPtr
+  }
+
+instanceCreateInfo :: [StrictByteString] -> [StrictByteString] -> InstanceCreateInfo      [DebugUtilsMessengerCreateInfoEXT, ValidationFeaturesEXT]
+instanceCreateInfo layers extensions = zero
+  { applicationInfo = Just zero{applicationName = Nothing, apiVersion = myApiVersion}
+  , enabledLayerNames     = Vec.fromList layers
+  , enabledExtensionNames = Vec.fromList extensions
+  }
+  ::& debugMessengerCreateInfo
+  :&  ValidationFeaturesEXT [VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT] []
+  :&  ()
+
+сommandBufferBeginInfo :: CommandBufferBeginInfo '[]
+сommandBufferBeginInfo = zero{CommandBufferBeginInfo.flags = COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT}
+
+submitInfo :: CommandBuffer -> SomeStruct SubmitInfo
+submitInfo commandBuffer = SomeStruct zero{commandBuffers = [commandBufferHandle commandBuffer]}
 
 ----------------------------------------------------------------
 -- Physical device tools
 ----------------------------------------------------------------
-
--- | Get a single PhysicalDevice deciding with a scoring function
-pickPhysicalDevice
-  :: (MonadIO m, MonadThrow m, Ord a)
-  => Instance
-  -> (PhysicalDevice -> m (Maybe a))
-  -- ^ Some "score" for a PhysicalDevice, Nothing if it is not to be chosen.
-  -> m (a, PhysicalDevice)
-pickPhysicalDevice inst devScore = do
-  (_, devs) <- enumeratePhysicalDevices inst
-  scores    <- catMaybes
-    <$> sequence [ fmap (, d) <$> devScore d | d <- toList devs ]
-  case scores of
-    [] -> throwString "Unable to find appropriate PhysicalDevice"
-    _  -> pure (maximumBy (comparing fst) scores)
 
 -- | The Ord instance prioritises devices with more memory
 data PhysicalDeviceInfo = PhysicalDeviceInfo
@@ -501,48 +368,14 @@ data PhysicalDeviceInfo = PhysicalDeviceInfo
   }
   deriving (Eq, Ord)
 
-physicalDeviceInfo
-  :: MonadIO m => PhysicalDevice -> m (Maybe PhysicalDeviceInfo)
+physicalDeviceInfo :: MonadIO m => PhysicalDevice -> m (Maybe PhysicalDeviceInfo)
 physicalDeviceInfo phys = runMaybeT $ do
-  pdiTotalMemory <- do
-    heaps <- memoryHeaps <$> getPhysicalDeviceMemoryProperties phys
-    pure $ sum (DI.size <$> heaps)
+  pdiTotalMemory <- sum . fmap MemoryHeap.size . memoryHeaps <$> getPhysicalDeviceMemoryProperties phys
   pdiComputeQueueFamilyIndex <- do
     queueFamilyProperties <- getPhysicalDeviceQueueFamilyProperties phys
-    let isComputeQueue q =
-          (QUEUE_COMPUTE_BIT .&&. queueFlags q) && (queueCount q > 0)
-        computeQueueIndices = fromIntegral . fst <$> V.filter
+    let isComputeQueue q = (QUEUE_COMPUTE_BIT .&. queueFlags q /= zeroBits) && (queueCount q > 0)
+        computeQueueIndices = fromIntegral . fst <$> Vec.filter
           (isComputeQueue . snd)
-          (V.indexed queueFamilyProperties)
-    MaybeT (pure $ computeQueueIndices V.!? 0)
+          (Vec.indexed queueFamilyProperties)
+    MaybeT (pure $ computeQueueIndices Vec.!? 0)
   pure PhysicalDeviceInfo { .. }
-
-physicalDeviceName :: MonadIO m => PhysicalDevice -> m Text
-physicalDeviceName phys = do
-  props <- getPhysicalDeviceProperties phys
-  pure $ decodeUtf8 (deviceName props)
-
-----------------------------------------------------------------
--- Utils
-----------------------------------------------------------------
-
-partitionOptReq
-  :: (Show a, Eq a, MonadIO m) => Text -> [a] -> [a] -> [a] -> m [a]
-partitionOptReq type' available optional required = do
-  let (optHave, optMissing) = partition (`elem` available) optional
-      (reqHave, reqMissing) = partition (`elem` available) required
-      tShow                 = T.pack . show
-  for_ optMissing
-    $ \n -> sayErr $ "Missing optional " <> type' <> ": " <> tShow n
-  case reqMissing of
-    []  -> pure ()
-    [x] -> sayErr $ "Missing required " <> type' <> ": " <> tShow x
-    xs  -> sayErr $ "Missing required " <> type' <> "s: " <> tShow xs
-  pure (reqHave <> optHave)
-
-----------------------------------------------------------------
--- Bit utils
-----------------------------------------------------------------
-
-(.&&.) :: Bits a => a -> a -> Bool
-x .&&. y = (/= zeroBits) (x .&. y)

--- a/examples/package.yaml
+++ b/examples/package.yaml
@@ -65,7 +65,6 @@ executables:
     dependencies:
     - JuicyPixels
     - VulkanMemoryAllocator
-    - autoapply >= 0.4
     - base <5
     - bytestring
     - resourcet

--- a/examples/vulkan-examples.cabal
+++ b/examples/vulkan-examples.cabal
@@ -125,45 +125,10 @@ executable compute
       Paths_vulkan_examples
   hs-source-dirs:
       compute
-  default-extensions:
-      DataKinds
-      DefaultSignatures
-      DeriveFoldable
-      DeriveFunctor
-      DeriveTraversable
-      DerivingStrategies
-      DuplicateRecordFields
-      FlexibleContexts
-      FlexibleInstances
-      GADTs
-      GeneralizedNewtypeDeriving
-      InstanceSigs
-      LambdaCase
-      MagicHash
-      NamedFieldPuns
-      NoMonomorphismRestriction
-      NumDecimals
-      OverloadedStrings
-      PatternSynonyms
-      PolyKinds
-      QuantifiedConstraints
-      RankNTypes
-      RecordWildCards
-      RoleAnnotations
-      ScopedTypeVariables
-      StandaloneDeriving
-      Strict
-      TupleSections
-      TypeApplications
-      TypeFamilyDependencies
-      TypeOperators
-      TypeSynonymInstances
-      ViewPatterns
-  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -O2 -threaded -rtsopts -main-is graphics -with-rtsopts=-N
   build-depends:
       JuicyPixels
     , VulkanMemoryAllocator
-    , autoapply >=0.4
     , base <5
     , bytestring
     , resourcet


### PR DESCRIPTION
Dropped autoapply dependency and simplified `compute example` source code

It was too hard for me to understand what's going on behind library API calls via template haskell. So I decided to:
1. Rewrite it in a more straightforward way with direct arguments passing
2. Drop the autoapply dependency which has lack of support (cannot build it on ghc 9.6 without overrides)
3. Move the top level functions to start of the file

Have not tested this change since need to setup flake.nix for local development. Want to check build via CI pipeline
