### PR TITLE
Fix sdl-triangle build by including language extensions.

### DIFF
--- a/examples/sdl-triangle/Main.hs
+++ b/examples/sdl-triangle/Main.hs
@@ -1,5 +1,17 @@
-{-# LANGUAGE OverloadedLists #-}
-{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE
+    DataKinds
+  , DefaultSignatures
+  , DuplicateRecordFields
+  , FlexibleContexts
+  , QuasiQuotes
+  , GADTs
+  , LambdaCase
+  , NamedFieldPuns
+  , NoMonomorphismRestriction
+  , OverloadedStrings
+  , OverloadedLists
+  , RecordWildCards
+  #-}
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
 
 module Main where


### PR DESCRIPTION
The lack of DuplicateRecordFields was causing "Ambiguous occurrence" compile errors, I added all the language extensions that seem to be necessary to build sdl-triangle alone.

<!--

Thanks!

Please update the appropriate changelog.md (in ./ ./utils ./vma ./openxr) WIP section for any non-trivial changes.

Feel free to bump the version number in the appropriate package.yaml, if you do
this then please tie off the WIP section of the changelog with the new version
number.

Make sure to run hpack after modifying any package.yaml files or adding new source files.

-->
