### PR TITLE
Test and fix for MoltenVK

### DIFF
--- a/examples/hlsl/Render.hs
+++ b/examples/hlsl/Render.hs
@@ -52,5 +52,5 @@ renderFrame vc renderPass pipeline framebuffers f = do
       Vk.cmdBindPipeline cb Vk.PIPELINE_BIND_POINT_GRAPHICS pipeline
       Vk.cmdDraw cb 3 1 0 0
 
-  queueSubmitFrame vc f [commands]
+  queueSubmitFrame vc f imageIndex [commands]
   presentFrameImage vc f acquireResult imageIndex

--- a/examples/lib/Triangle.hs
+++ b/examples/lib/Triangle.hs
@@ -106,7 +106,7 @@ drawTriangle vc renderPass pipeline framebuffers f = do
       Vk.cmdBindPipeline cb Vk.PIPELINE_BIND_POINT_GRAPHICS pipeline
       Vk.cmdDraw cb 3 1 0 0
 
-  queueSubmitFrame vc f [commands]
+  queueSubmitFrame vc f imageIndex [commands]
   presentFrameImage vc f acquireResult imageIndex
 
 ----------------------------------------------------------------

--- a/examples/rays/Render.hs
+++ b/examples/rays/Render.hs
@@ -117,7 +117,7 @@ renderFrame vc vma rs f = do
   commands <- recordCommands vc f \cb ->
     recordCommandBuffer cb rs sc descriptorSet imageIndex
 
-  queueSubmitFrame vc f [commands]
+  queueSubmitFrame vc f imageIndex [commands]
   presentFrameImage vc f acquireResult imageIndex
 
 ----------------------------------------------------------------

--- a/examples/resize/Julia.hs
+++ b/examples/resize/Julia.hs
@@ -90,17 +90,17 @@ createJuliaPipeline dev = do
       , jpDescriptorSetLayout = descriptorSetLayout
       }
 
-{- | One descriptor set per swapchain image, bound to its image view. Allocated
-from a fresh descriptor pool so that releasing this scope frees the lot.
+{- | One descriptor set per supplied image view, bound to that view.
+Allocated from a fresh descriptor pool so that releasing this scope frees the lot.
 -}
 createJuliaDescriptorSets
   :: (MonadResource m)
   => Vk.Device
   -> Vk.DescriptorSetLayout
   -> Vector Vk.ImageView
-  -> m (Vector Vk.DescriptorSet)
+  -> m (ReleaseKey, Vector Vk.DescriptorSet)
 createJuliaDescriptorSets dev descriptorSetLayout imageViews = do
-  (_, descriptorPool) <-
+  (poolKey, descriptorPool) <-
     Vk.withDescriptorPool
       dev
       zero
@@ -147,7 +147,7 @@ createJuliaDescriptorSets dev descriptorSetLayout imageViews = do
     )
     []
 
-  pure descriptorSets
+  pure (poolKey, descriptorSets)
 
 juliaShader
   :: (MonadResource m)

--- a/examples/resize/Main.hs
+++ b/examples/resize/Main.hs
@@ -6,14 +6,15 @@ module Main
   ( main
   ) where
 
-import Control.Exception (handle)
+import Control.Exception (handle, mask_)
 import Control.Lens.Getter ((^.))
 import Control.Monad (when)
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
-import Data.Vector (Vector)
+import Data.Bits ((.|.))
+import Data.IORef (IORef, atomicModifyIORef', newIORef, readIORef, writeIORef)
 import qualified Data.Vector as V
-import Data.Word (Word64)
+import Data.Word (Word32, Word64)
 import Julia (JuliaPipeline (..), createJuliaDescriptorSets, createJuliaPipeline, juliaWorkgroupX, juliaWorkgroupY)
 import Linear.Affine (Point (..))
 import Linear.Metric (norm)
@@ -22,17 +23,21 @@ import qualified SDL
 import Say (sayErrString)
 import UnliftIO.Exception (displayException)
 import UnliftIO.Foreign (allocaBytes, plusPtr, poke)
-import Vulkan.CStruct.Extends (SomeStruct (..))
+import Vulkan.CStruct.Extends (SomeStruct (..), pattern (:&), pattern (::&))
+import qualified Vulkan.Core10 as CommandBufferBeginInfo (CommandBufferBeginInfo (..))
+import qualified Vulkan.Core10 as CommandPoolCreateInfo (CommandPoolCreateInfo (..))
 import qualified Vulkan.Core10 as Vk
+import Vulkan.Core12.Promoted_From_VK_KHR_timeline_semaphore (TimelineSemaphoreSubmitInfo (..))
 import Vulkan.Exception
-import Vulkan.Extensions.VK_KHR_surface as SurfaceFormatKHR (SurfaceFormatKHR (..))
-import Vulkan.Utils.Frame (Frame (..), acquireFrameImage, presentFrameImage, queueSubmitFrame, recordCommands)
-import qualified Vulkan.Utils.Framebuffer as Framebuffer
-import qualified Vulkan.Utils.RenderPass as RenderPass
+import Vulkan.Utils.Frame (Frame (..), acquireFrameImage, presentFrameImage, queueSubmitFrame, recordCommands, withTimelineSemaphore)
+import Vulkan.Utils.QueueAssignment (QueueFamilyIndex (..))
+import Vulkan.Utils.Queues (Queues (..))
 import Vulkan.Utils.Swapchain (Swapchain (..), SwapchainConfig (..), defaultSwapchainConfig)
-import Vulkan.Utils.VulkanContext (VulkanContext (..))
+import Vulkan.Utils.VulkanContext (RecycledResources (..), VulkanContext (..))
 import Vulkan.Utils.WindowLoop (WindowLoop (..), noOnExit, runWindowLoop)
 import Vulkan.Zero (zero)
+import qualified VulkanMemoryAllocator as AllocationCreateInfo (AllocationCreateInfo (..))
+import qualified VulkanMemoryAllocator as VMA
 import Window.SDL2 (createWindow, drawableSize, sdl2Adapter, shouldQuit, withSDL)
 import WindowedBoot (WindowedConfig (..), withWindowedVk)
 
@@ -47,29 +52,23 @@ main = prettyError . runResourceT $ do
   sdlWindow <- createWindow "Haskell ❤️ Vulkan" initWidth initHeight
   SDL.showWindow sdlWindow
 
-  (vc, _vma, initialSC) <-
-    withWindowedVk
-      WindowedConfig
-        { wcAppName = "Haskell ❤️ Vulkan"
-        , wcInstanceReqs = []
-        , wcDeviceReqs = []
-        , wcVmaFlags = zero
-        , wcSwapchainConfig =
-            defaultSwapchainConfig
-              { scRequiredUsageFlags =
-                  [Vk.IMAGE_USAGE_COLOR_ATTACHMENT_BIT, Vk.IMAGE_USAGE_STORAGE_BIT]
-              , scRequiredFormatFeatures = [Vk.FORMAT_FEATURE_STORAGE_IMAGE_BIT]
-              }
-        }
-      (sdl2Adapter sdlWindow)
+  (vc, vma, initialSC) <- withWindowedVk windowConfig (sdl2Adapter sdlWindow)
   let dev = vcDevice vc
 
-  (_, renderPass) <-
-    RenderPass.createColorRenderPass
-      dev
-      (SurfaceFormatKHR.format (sFormat initialSC))
-      Vk.IMAGE_LAYOUT_PRESENT_SRC_KHR
   juliaPL <- createJuliaPipeline dev
+
+  -- Pick the synchronization strategy once, from the queue layout. If the
+  -- compute slot landed in the graphics family we can keep everything on one
+  -- queue and sync with a pipeline barrier; otherwise we run compute on the
+  -- async queue and hand the offscreen image across with a timeline semaphore
+  -- plus a queue-family ownership transfer.
+  computeSync <-
+    if fst (qGraphics (vcQueues vc)) == fst (qCompute (vcQueues vc))
+      then pure SharedQueue
+      else do
+        (_, readyTimeline) <- withTimelineSemaphore dev 0
+        lastBlitDone <- liftIO (newIORef 0)
+        pure (AsyncCompute readyTimeline lastBlitDone)
 
   runWindowLoop
     vc
@@ -77,50 +76,142 @@ main = prettyError . runResourceT $ do
     (drawableSize sdlWindow)
     (shouldQuit sdlWindow)
     WindowLoop
-      { wlMkState = createBindings dev renderPass juliaPL
-      , wlRender = \bindings f -> renderJulia vc juliaPL bindings f
+      { wlMkState = createBindings dev vma juliaPL
+      , wlRender = \bindings f -> renderJulia vc juliaPL computeSync bindings f
       , wlOnFrame = \start end -> reportFrameTime (end - start)
       , wlOnExit = noOnExit
       }
+
+windowConfig :: WindowedConfig
+windowConfig =
+  WindowedConfig
+    { wcAppName = "Haskell ❤️ Vulkan"
+    , wcInstanceReqs = []
+    , wcDeviceReqs = []
+    , wcVmaFlags = zero
+    , wcSwapchainConfig =
+        defaultSwapchainConfig
+          { scRequiredUsageFlags =
+              -- TRANSFER_DST for the blit; COLOR_ATTACHMENT so the
+              -- swapchain helper can still build (view-compatible) image
+              -- views for each image.
+              [ Vk.IMAGE_USAGE_TRANSFER_DST_BIT
+              , Vk.IMAGE_USAGE_COLOR_ATTACHMENT_BIT
+              ]
+          , scRequiredFormatFeatures = [Vk.FORMAT_FEATURE_BLIT_DST_BIT]
+          }
+    }
 
 prettyError :: IO () -> IO ()
 prettyError =
   handle (\e@(VulkanException _) -> sayErrString (displayException e))
 
 ----------------------------------------------------------------
+-- Synchronization strategy
+----------------------------------------------------------------
+
+{- | How compute hands its result to the blit, decided once from the queue
+layout (see 'main').
+-}
+data ComputeSync
+  = {- | Compute shares the graphics queue family: one command buffer, an
+    intra-queue pipeline barrier between the dispatch and the blit.
+    -}
+    SharedQueue
+  | {- | Compute runs on a distinct queue family: two command buffers on two
+    queues, handed over with this timeline semaphore and a queue-family
+    ownership transfer of the offscreen image. The 'IORef' tracks the
+    timeline value of the last frame that actually submitted a blit, so the
+    next frame's compute can wait for that read to finish before reusing the
+    single shared buffer — without deadlocking when a frame aborts (e.g. an
+    out-of-date swapchain on resize) and never signals its value.
+    -}
+    AsyncCompute Vk.Semaphore (IORef Word64)
+
+----------------------------------------------------------------
 -- Per-swapchain bindings
 ----------------------------------------------------------------
 
 data Bindings = Bindings
-  { bFramebuffers :: Vector Vk.Framebuffer
-  , bJuliaDescriptorSets :: Vector Vk.DescriptorSet
+  { bOffscreenImage :: Vk.Image
+  {- ^ The single compute render target; blitted to whichever swapchain image
+  the frame acquires.
+  -}
+  , bOffscreenView :: Vk.ImageView
+  -- ^ View of 'bOffscreenImage', bound into 'bJuliaDescriptorSet'.
+  , bJuliaDescriptorSet :: Vk.DescriptorSet
+  -- ^ Storage-image descriptor pointing at 'bOffscreenView'.
   }
 
 createBindings
   :: Vk.Device
-  -> Vk.RenderPass
+  -> VMA.Allocator
   -> JuliaPipeline
   -> Swapchain
   -> ResourceT IO (Bindings, ReleaseKey)
-createBindings dev renderPass jp sc = do
-  -- Framebuffers (one per swapchain image) for the dormant graphics pipeline.
-  (framebuffers, fbKey) <-
-    Framebuffer.createFramebuffers dev renderPass (sImageViews sc) (sExtent sc)
+createBindings dev allocator jp sc = do
+  -- A single offscreen RGBA8 storage image (+ view). Compute writes here; a
+  -- blit then copies (and converts RGBA→BGRA) to the acquired swapchain image.
+  -- It is recreated per swapchain only because its extent tracks the window.
+  (imageKey, (image, _, _)) <-
+    VMA.withImage allocator (offscreenImageInfo (sExtent sc)) offscreenAllocInfo allocate
+  (viewKey, view) <- Vk.withImageView dev (offscreenViewInfo image) Nothing allocate
 
-  -- Julia descriptor sets (one per swapchain image).
-  juliaSets <-
-    createJuliaDescriptorSets
-      dev
-      (jpDescriptorSetLayout jp)
-      (sImageViews sc)
+  (poolKey, juliaSets) <-
+    createJuliaDescriptorSets dev (jpDescriptorSetLayout jp) [view]
+
+  -- runWindowLoop fires exactly one release key on resize: free the pool (and
+  -- its sets) first, then the view, then the image.
+  bindingsKey <- register (mapM_ release ([poolKey, viewKey, imageKey] :: [ReleaseKey]))
 
   pure
     ( Bindings
-        { bFramebuffers = framebuffers
-        , bJuliaDescriptorSets = juliaSets
+        { bOffscreenImage = image
+        , bOffscreenView = view
+        , bJuliaDescriptorSet = V.head juliaSets
         }
-    , fbKey
+    , bindingsKey
     )
+
+offscreenFormat :: Vk.Format
+offscreenFormat = Vk.FORMAT_R8G8B8A8_UNORM
+
+offscreenImageInfo :: Vk.Extent2D -> Vk.ImageCreateInfo '[]
+offscreenImageInfo (Vk.Extent2D w h) =
+  zero
+    { Vk.imageType = Vk.IMAGE_TYPE_2D
+    , Vk.format = offscreenFormat
+    , Vk.extent = Vk.Extent3D w h 1
+    , Vk.mipLevels = 1
+    , Vk.arrayLayers = 1
+    , Vk.samples = Vk.SAMPLE_COUNT_1_BIT
+    , Vk.tiling = Vk.IMAGE_TILING_OPTIMAL
+    , Vk.usage =
+        Vk.IMAGE_USAGE_STORAGE_BIT .|. Vk.IMAGE_USAGE_TRANSFER_SRC_BIT
+    , Vk.initialLayout = Vk.IMAGE_LAYOUT_UNDEFINED
+    }
+
+offscreenAllocInfo :: VMA.AllocationCreateInfo
+offscreenAllocInfo = zero{AllocationCreateInfo.usage = VMA.MEMORY_USAGE_GPU_ONLY}
+
+offscreenViewInfo :: Vk.Image -> Vk.ImageViewCreateInfo '[]
+offscreenViewInfo image =
+  zero
+    { Vk.image = image
+    , Vk.viewType = Vk.IMAGE_VIEW_TYPE_2D
+    , Vk.format = offscreenFormat
+    , Vk.subresourceRange = colorSubresourceRange
+    }
+
+colorSubresourceRange :: Vk.ImageSubresourceRange
+colorSubresourceRange =
+  Vk.ImageSubresourceRange
+    { Vk.aspectMask = Vk.IMAGE_ASPECT_COLOR_BIT
+    , Vk.baseMipLevel = 0
+    , Vk.levelCount = 1
+    , Vk.baseArrayLayer = 0
+    , Vk.layerCount = 1
+    }
 
 ----------------------------------------------------------------
 -- Per-frame rendering
@@ -129,108 +220,352 @@ createBindings dev renderPass jp sc = do
 renderJulia
   :: VulkanContext
   -> JuliaPipeline
+  -> ComputeSync
   -> Bindings
   -> Frame
   -> ResourceT IO ()
-renderJulia vc jp bindings f = do
+renderJulia vc jp computeSync bindings f = do
   (acquireResult, imageIndex) <- acquireFrameImage vc f
-  let
-    image = sImages sc V.! fromIntegral imageIndex
-    descriptorSet = bJuliaDescriptorSets bindings V.! fromIntegral imageIndex
+  let swapImage = sImages sc V.! fromIntegral imageIndex
 
-  commands <- recordCommands vc f \cb -> do
-    -- Transition image to general (compute write target).
-    Vk.cmdPipelineBarrier
-      cb
-      Vk.PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT
-      Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT
-      zero
-      []
-      []
-      [ SomeStruct
+  case computeSync of
+    SharedQueue -> do
+      commands <- recordCommands vc f \cb -> do
+        -- Offscreen → GENERAL for the compute write. The TRANSFER source stage
+        -- makes this write wait for the previous frame's blit read of the same
+        -- (shared) image — a barrier orders against prior submissions on one
+        -- queue, so this is the cross-frame Write-after-Read hazard fence.
+        beginComputeWrite cb offscreen Vk.PIPELINE_STAGE_TRANSFER_BIT
+        dispatchJulia jp (sExtent sc) descriptorSet cb
+
+        -- Offscreen → transfer source, swapchain → transfer destination.
+        Vk.cmdPipelineBarrier
+          cb
+          Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT
+          Vk.PIPELINE_STAGE_TRANSFER_BIT
           zero
-            { Vk.srcAccessMask = zero
-            , Vk.dstAccessMask = Vk.ACCESS_SHADER_WRITE_BIT
-            , Vk.oldLayout = Vk.IMAGE_LAYOUT_UNDEFINED
-            , Vk.newLayout = Vk.IMAGE_LAYOUT_GENERAL
-            , Vk.image = image
-            , Vk.subresourceRange = imageSubresourceRange
-            }
-      ]
+          []
+          []
+          [ offscreenToTransferSrc offscreen Vk.ACCESS_SHADER_WRITE_BIT Nothing
+          , swapchainToTransferDst swapImage
+          ]
+        blitOffscreen (sExtent sc) offscreen swapImage cb
+        swapchainToPresent swapImage cb
 
-    Vk.cmdBindPipeline cb Vk.PIPELINE_BIND_POINT_COMPUTE (jpPipeline jp)
+      queueSubmitFrame vc f [commands]
+    AsyncCompute readyTimeline lastBlitDone -> do
+      let
+        QueueFamilyIndex graphicsFam = fst (qGraphics (vcQueues vc))
+        QueueFamilyIndex computeFam = fst (qCompute (vcQueues vc))
 
-    -- Mouse-driven push constants.
-    P m <- SDL.getAbsoluteMouseLocation
-    let
-      m' :: V2 Float
-      m' = fmap realToFrac m / imageSizeF
-      c :: V2 Float
-      c = (m' * 2) - 1
-      r = 0.5 * (1 + sqrt (4 * norm c + 1))
-      imageSizeF = realToFrac <$> V2 imageWidth imageHeight
-      aspect = pure (recip (min (imageSizeF ^. _x) (imageSizeF ^. _y)))
-      frameScale = aspect * 2 * pure r
-      frameOffset = negate (imageSizeF * aspect) * pure r
-      constantBytes = 4 * (2 + 2 + 2 + 1)
-      escapeRadius = 12 :: Float
-    allocaBytes constantBytes $ \p -> do
-      liftIO $ poke (p `plusPtr` 0) frameScale
-      liftIO $ poke (p `plusPtr` 8) frameOffset
-      liftIO $ poke (p `plusPtr` 16) c
-      liftIO $ poke (p `plusPtr` 24) escapeRadius
-      Vk.cmdPushConstants
-        cb
-        (jpPipelineLayout jp)
-        Vk.SHADER_STAGE_COMPUTE_BIT
-        0
-        constantBytes
-        p
-    Vk.cmdBindDescriptorSets
-      cb
-      Vk.PIPELINE_BIND_POINT_COMPUTE
-      (jpPipelineLayout jp)
-      0
-      [descriptorSet]
-      []
-    Vk.cmdDispatch
-      cb
-      ((imageWidth + juliaWorkgroupX - 1) `quot` juliaWorkgroupX)
-      ((imageHeight + juliaWorkgroupY - 1) `quot` juliaWorkgroupY)
-      1
+      -- Compute on its own queue. The per-frame pool is allocated in the
+      -- frame's ResourceT scope, so it is freed only after this frame's GPU
+      -- work completes — no manual ping-pong needed.
+      computeCb <- do
+        (_, computePool) <-
+          Vk.withCommandPool
+            (vcDevice vc)
+            zero{CommandPoolCreateInfo.queueFamilyIndex = computeFam}
+            Nothing
+            allocate
+        recordOnPool vc computePool \cb -> do
+          -- Cross-frame Write-after-Read hazard is handled by the timeline wait below, so a plain
+          -- top-of-pipe transition into GENERAL is enough here.
+          beginComputeWrite cb offscreen Vk.PIPELINE_STAGE_TOP_OF_PIPE_BIT
+          dispatchJulia jp (sExtent sc) descriptorSet cb
+          -- Release the offscreen image from the compute family.
+          Vk.cmdPipelineBarrier
+            cb
+            Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT
+            Vk.PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
+            zero
+            []
+            []
+            [ offscreenToTransferSrc
+                offscreen
+                Vk.ACCESS_SHADER_WRITE_BIT
+                (Just (computeFam, graphicsFam))
+            ]
 
-    -- Transition image back to present.
-    Vk.cmdPipelineBarrier
-      cb
-      Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT
-      Vk.PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
-      zero
-      []
-      []
-      [ SomeStruct
+      graphicsCb <- recordCommands vc f \cb -> do
+        -- Acquire the offscreen image onto the graphics family, and bring the
+        -- swapchain image up as a transfer destination.
+        Vk.cmdPipelineBarrier
+          cb
+          Vk.PIPELINE_STAGE_TOP_OF_PIPE_BIT
+          Vk.PIPELINE_STAGE_TRANSFER_BIT
           zero
-            { Vk.srcAccessMask = Vk.ACCESS_SHADER_WRITE_BIT
-            , Vk.dstAccessMask = zero
-            , Vk.oldLayout = Vk.IMAGE_LAYOUT_GENERAL
-            , Vk.newLayout = Vk.IMAGE_LAYOUT_PRESENT_SRC_KHR
-            , Vk.image = image
-            , Vk.subresourceRange = imageSubresourceRange
-            }
-      ]
+          []
+          []
+          [ offscreenToTransferSrc offscreen zero (Just (computeFam, graphicsFam))
+          , swapchainToTransferDst swapImage
+          ]
+        blitOffscreen (sExtent sc) offscreen swapImage cb
+        swapchainToPresent swapImage cb
 
-  queueSubmitFrame vc f [commands]
+      submitAsync vc f readyTimeline lastBlitDone computeCb graphicsCb
+
   presentFrameImage vc f acquireResult imageIndex
   where
     sc = fSwapchain f
-    Vk.Extent2D imageWidth imageHeight = sExtent sc
-    imageSubresourceRange =
-      Vk.ImageSubresourceRange
-        { Vk.aspectMask = Vk.IMAGE_ASPECT_COLOR_BIT
-        , Vk.baseMipLevel = 0
-        , Vk.levelCount = 1
-        , Vk.baseArrayLayer = 0
-        , Vk.layerCount = 1
+    offscreen = bOffscreenImage bindings
+    descriptorSet = bJuliaDescriptorSet bindings
+
+-- | Bind the Julia pipeline, push the mouse-driven constants, and dispatch.
+dispatchJulia
+  :: (MonadUnliftIO m)
+  => JuliaPipeline
+  -> Vk.Extent2D
+  -> Vk.DescriptorSet
+  -> Vk.CommandBuffer
+  -> m ()
+dispatchJulia jp (Vk.Extent2D imageWidth imageHeight) descriptorSet cb = do
+  Vk.cmdBindPipeline cb Vk.PIPELINE_BIND_POINT_COMPUTE (jpPipeline jp)
+
+  P m <- SDL.getAbsoluteMouseLocation
+  let
+    m' :: V2 Float
+    m' = fmap realToFrac m / imageSizeF
+    c :: V2 Float
+    c = (m' * 2) - 1
+    r = 0.5 * (1 + sqrt (4 * norm c + 1))
+    imageSizeF = realToFrac <$> V2 imageWidth imageHeight
+    aspect = pure (recip (min (imageSizeF ^. _x) (imageSizeF ^. _y)))
+    frameScale = aspect * 2 * pure r
+    frameOffset = negate (imageSizeF * aspect) * pure r
+    constantBytes = 4 * (2 + 2 + 2 + 1)
+    escapeRadius = 12 :: Float
+  allocaBytes constantBytes $ \p -> do
+    liftIO $ poke (p `plusPtr` 0) frameScale
+    liftIO $ poke (p `plusPtr` 8) frameOffset
+    liftIO $ poke (p `plusPtr` 16) c
+    liftIO $ poke (p `plusPtr` 24) escapeRadius
+    Vk.cmdPushConstants
+      cb
+      (jpPipelineLayout jp)
+      Vk.SHADER_STAGE_COMPUTE_BIT
+      0
+      constantBytes
+      p
+  Vk.cmdBindDescriptorSets
+    cb
+    Vk.PIPELINE_BIND_POINT_COMPUTE
+    (jpPipelineLayout jp)
+    0
+    [descriptorSet]
+    []
+  Vk.cmdDispatch
+    cb
+    ((imageWidth + juliaWorkgroupX - 1) `quot` juliaWorkgroupX)
+    ((imageHeight + juliaWorkgroupY - 1) `quot` juliaWorkgroupY)
+    1
+
+----------------------------------------------------------------
+-- Command-buffer building blocks
+----------------------------------------------------------------
+
+{- | Transition an image UNDEFINED → GENERAL ahead of a compute write. The
+caller supplies the source pipeline stage that the write must wait on.
+-}
+beginComputeWrite
+  :: (MonadIO m) => Vk.CommandBuffer -> Vk.Image -> Vk.PipelineStageFlags -> m ()
+beginComputeWrite cb image srcStage =
+  Vk.cmdPipelineBarrier
+    cb
+    srcStage
+    Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT
+    zero
+    []
+    []
+    [ SomeStruct
+        zero
+          { Vk.srcAccessMask = zero
+          , Vk.dstAccessMask = Vk.ACCESS_SHADER_WRITE_BIT
+          , Vk.oldLayout = Vk.IMAGE_LAYOUT_UNDEFINED
+          , Vk.newLayout = Vk.IMAGE_LAYOUT_GENERAL
+          , Vk.image = image
+          , Vk.subresourceRange = colorSubresourceRange
+          }
+    ]
+
+{- | Offscreen GENERAL → TRANSFER_SRC barrier, ready for the blit. The caller
+supplies the source access mask and, when the dispatch and blit run on
+different queue families, @Just (srcFamily, dstFamily)@ to make this a
+queue-family ownership transfer (release on the source, acquire on the dest).
+-}
+offscreenToTransferSrc
+  :: Vk.Image
+  -> Vk.AccessFlags
+  -> Maybe (Word32, Word32)
+  -> SomeStruct Vk.ImageMemoryBarrier
+offscreenToTransferSrc image srcAccess ownership =
+  let (srcFam, dstFam) =
+        maybe (Vk.QUEUE_FAMILY_IGNORED, Vk.QUEUE_FAMILY_IGNORED) id ownership
+  in SomeStruct
+       zero
+         { Vk.srcAccessMask = srcAccess
+         , Vk.dstAccessMask = Vk.ACCESS_TRANSFER_READ_BIT
+         , Vk.oldLayout = Vk.IMAGE_LAYOUT_GENERAL
+         , Vk.newLayout = Vk.IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
+         , Vk.srcQueueFamilyIndex = srcFam
+         , Vk.dstQueueFamilyIndex = dstFam
+         , Vk.image = image
+         , Vk.subresourceRange = colorSubresourceRange
+         }
+
+-- | Swapchain UNDEFINED → TRANSFER_DST barrier, ready to receive the blit.
+swapchainToTransferDst :: Vk.Image -> SomeStruct Vk.ImageMemoryBarrier
+swapchainToTransferDst image =
+  SomeStruct
+    zero
+      { Vk.srcAccessMask = zero
+      , Vk.dstAccessMask = Vk.ACCESS_TRANSFER_WRITE_BIT
+      , Vk.oldLayout = Vk.IMAGE_LAYOUT_UNDEFINED
+      , Vk.newLayout = Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+      , Vk.image = image
+      , Vk.subresourceRange = colorSubresourceRange
+      }
+
+-- | Swapchain TRANSFER_DST → PRESENT barrier, after the blit.
+swapchainToPresent :: (MonadIO m) => Vk.Image -> Vk.CommandBuffer -> m ()
+swapchainToPresent image cb =
+  Vk.cmdPipelineBarrier
+    cb
+    Vk.PIPELINE_STAGE_TRANSFER_BIT
+    Vk.PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT
+    zero
+    []
+    []
+    [ SomeStruct
+        zero
+          { Vk.srcAccessMask = Vk.ACCESS_TRANSFER_WRITE_BIT
+          , Vk.dstAccessMask = zero
+          , Vk.oldLayout = Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+          , Vk.newLayout = Vk.IMAGE_LAYOUT_PRESENT_SRC_KHR
+          , Vk.image = image
+          , Vk.subresourceRange = colorSubresourceRange
+          }
+    ]
+
+-- | Blit the fractal onto the swapchain image (handles RGBA→BGRA).
+blitOffscreen
+  :: (MonadIO m) => Vk.Extent2D -> Vk.Image -> Vk.Image -> Vk.CommandBuffer -> m ()
+blitOffscreen extent offscreen swapImage cb =
+  Vk.cmdBlitImage
+    cb
+    offscreen
+    Vk.IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL
+    swapImage
+    Vk.IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL
+    [ Vk.ImageBlit
+        { Vk.srcSubresource = colorSubresourceLayers
+        , Vk.srcOffsets = fullExtentOffsets extent
+        , Vk.dstSubresource = colorSubresourceLayers
+        , Vk.dstOffsets = fullExtentOffsets extent
         }
+    ]
+    Vk.FILTER_NEAREST
+
+colorSubresourceLayers :: Vk.ImageSubresourceLayers
+colorSubresourceLayers =
+  Vk.ImageSubresourceLayers
+    { Vk.aspectMask = Vk.IMAGE_ASPECT_COLOR_BIT
+    , Vk.mipLevel = 0
+    , Vk.baseArrayLayer = 0
+    , Vk.layerCount = 1
+    }
+
+fullExtentOffsets :: Vk.Extent2D -> (Vk.Offset3D, Vk.Offset3D)
+fullExtentOffsets (Vk.Extent2D w h) =
+  (Vk.Offset3D 0 0 0, Vk.Offset3D (fromIntegral w) (fromIntegral h) 1)
+
+----------------------------------------------------------------
+-- Async-compute submission
+----------------------------------------------------------------
+
+{- | Record into a one-time-submit primary command buffer from a caller-supplied
+pool (the async-compute path needs a compute-family pool, which the recycled
+graphics pool can't provide). Mirrors 'recordCommands'.
+-}
+recordOnPool
+  :: (MonadResource m, MonadFail m)
+  => VulkanContext
+  -> Vk.CommandPool
+  -> (Vk.CommandBuffer -> m ())
+  -> m Vk.CommandBuffer
+recordOnPool vc pool record = do
+  (_, [cb]) <-
+    Vk.withCommandBuffers
+      (vcDevice vc)
+      zero
+        { Vk.commandPool = pool
+        , Vk.level = Vk.COMMAND_BUFFER_LEVEL_PRIMARY
+        , Vk.commandBufferCount = 1
+        }
+      allocate
+  Vk.useCommandBuffer cb zero{CommandBufferBeginInfo.flags = Vk.COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT} $
+    record cb
+  pure cb
+
+{- | The two-queue submission for the async-compute path:
+
+* compute runs on the compute queue, waiting on the host-timeline value of the
+  last frame that actually blitted (tracked in @lastBlitDone@) so it never
+  overwrites the shared offscreen image while the prior blit is still reading
+  it, and signalling @readyTimeline@ at @fIndex@. Waiting on the
+  last-submitted value (rather than @fIndex - 1@) keeps this deadlock-free when
+  a frame aborts mid-flight and never signals its own value;
+* the graphics blit waits on @readyTimeline@ (and image-available) and signals
+  render-finished plus the host timeline, exactly like 'queueSubmitFrame'.
+-}
+submitAsync
+  :: (MonadIO m)
+  => VulkanContext
+  -> Frame
+  -> Vk.Semaphore
+  -> IORef Word64
+  -> Vk.CommandBuffer
+  -> Vk.CommandBuffer
+  -> m ()
+submitAsync vc Frame{..} readyTimeline lastBlitDone computeCb graphicsCb = liftIO . mask_ $ do
+  prevBlitDone <- readIORef lastBlitDone
+  let computeSubmit =
+        zero
+          { Vk.waitSemaphores = [fHostTimeline]
+          , Vk.waitDstStageMask = [Vk.PIPELINE_STAGE_COMPUTE_SHADER_BIT]
+          , Vk.commandBuffers = [Vk.commandBufferHandle computeCb]
+          , Vk.signalSemaphores = [readyTimeline]
+          }
+          ::& zero
+            { waitSemaphoreValues = [prevBlitDone]
+            , signalSemaphoreValues = [fIndex]
+            }
+            :& ()
+  Vk.queueSubmit (snd $ qCompute (vcQueues vc)) [SomeStruct computeSubmit] Vk.NULL_HANDLE
+
+  let
+    RecycledResources{rrImageAvailable, rrRenderFinished} = fRecycled
+    graphicsSubmit =
+      zero
+        { Vk.waitSemaphores = [rrImageAvailable, readyTimeline]
+        , Vk.waitDstStageMask =
+            [ Vk.PIPELINE_STAGE_TOP_OF_PIPE_BIT
+            , Vk.PIPELINE_STAGE_TRANSFER_BIT
+            ]
+        , Vk.commandBuffers = [Vk.commandBufferHandle graphicsCb]
+        , Vk.signalSemaphores = [rrRenderFinished, fHostTimeline]
+        }
+        ::& zero
+          { -- Binary semaphores ignore their value entry; the timeline ones use it.
+            waitSemaphoreValues = [0, fIndex]
+          , signalSemaphoreValues = [0, fIndex]
+          }
+          :& ()
+
+  Vk.queueSubmit (snd $ qGraphics (vcQueues vc)) [SomeStruct graphicsSubmit] Vk.NULL_HANDLE
+  atomicModifyIORef' fGPUWork $ \jobs -> ((fHostTimeline, fIndex) : jobs, ())
+  -- This frame's blit is now in flight; the next frame's compute waits on it.
+  writeIORef lastBlitDone fIndex
 
 ----------------------------------------------------------------
 -- Frame timing

--- a/examples/resize/Main.hs
+++ b/examples/resize/Main.hs
@@ -252,7 +252,7 @@ renderJulia vc jp computeSync bindings f = do
         blitOffscreen (sExtent sc) offscreen swapImage cb
         swapchainToPresent swapImage cb
 
-      queueSubmitFrame vc f [commands]
+      queueSubmitFrame vc f imageIndex [commands]
     AsyncCompute readyTimeline lastBlitDone -> do
       let
         QueueFamilyIndex graphicsFam = fst (qGraphics (vcQueues vc))
@@ -303,7 +303,7 @@ renderJulia vc jp computeSync bindings f = do
         blitOffscreen (sExtent sc) offscreen swapImage cb
         swapchainToPresent swapImage cb
 
-      submitAsync vc f readyTimeline lastBlitDone computeCb graphicsCb
+      submitAsync vc f imageIndex readyTimeline lastBlitDone computeCb graphicsCb
 
   presentFrameImage vc f acquireResult imageIndex
   where
@@ -522,12 +522,13 @@ submitAsync
   :: (MonadIO m)
   => VulkanContext
   -> Frame
+  -> Word32
   -> Vk.Semaphore
   -> IORef Word64
   -> Vk.CommandBuffer
   -> Vk.CommandBuffer
   -> m ()
-submitAsync vc Frame{..} readyTimeline lastBlitDone computeCb graphicsCb = liftIO . mask_ $ do
+submitAsync vc Frame{..} imageIndex readyTimeline lastBlitDone computeCb graphicsCb = liftIO . mask_ $ do
   prevBlitDone <- readIORef lastBlitDone
   let computeSubmit =
         zero
@@ -544,7 +545,8 @@ submitAsync vc Frame{..} readyTimeline lastBlitDone computeCb graphicsCb = liftI
   Vk.queueSubmit (snd $ qCompute (vcQueues vc)) [SomeStruct computeSubmit] Vk.NULL_HANDLE
 
   let
-    RecycledResources{rrImageAvailable, rrRenderFinished} = fRecycled
+    RecycledResources{rrImageAvailable} = fRecycled
+    renderFinished = sRenderFinished fSwapchain V.! fromIntegral imageIndex
     graphicsSubmit =
       zero
         { Vk.waitSemaphores = [rrImageAvailable, readyTimeline]
@@ -553,7 +555,7 @@ submitAsync vc Frame{..} readyTimeline lastBlitDone computeCb graphicsCb = liftI
             , Vk.PIPELINE_STAGE_TRANSFER_BIT
             ]
         , Vk.commandBuffers = [Vk.commandBufferHandle graphicsCb]
-        , Vk.signalSemaphores = [rrRenderFinished, fHostTimeline]
+        , Vk.signalSemaphores = [renderFinished, fHostTimeline]
         }
         ::& zero
           { -- Binary semaphores ignore their value entry; the timeline ones use it.

--- a/examples/triangle-dynamic/TriangleDynamic.hs
+++ b/examples/triangle-dynamic/TriangleDynamic.hs
@@ -85,7 +85,7 @@ drawTriangle vc pipeline f = do
       Vk.cmdBindPipeline cb Vk.PIPELINE_BIND_POINT_GRAPHICS pipeline
       Vk.cmdDraw cb 3 1 0 0
     cmdTransitionForPresent cb image
-  queueSubmitFrame vc f [commands]
+  queueSubmitFrame vc f imageIndex [commands]
   presentFrameImage vc f acquireResult imageIndex
   where
     Swapchain{sExtent, sImages, sImageViews} = fSwapchain f

--- a/utils/src/Vulkan/Utils/Frame.hs
+++ b/utils/src/Vulkan/Utils/Frame.hs
@@ -3,9 +3,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 {-| Per-frame state and the recycling-Frame loop. Each frame owns a binary
-image-available semaphore, a binary render-finished semaphore, and a
-command pool — those three are 'RecycledResources' that get handed back
-to a channel in 'VulkanContext' once the frame's GPU work has completed.
+image-available semaphore and a command pool — those are 'RecycledResources'
+that get handed back to a channel in 'VulkanContext' once the frame's GPU work
+has completed. (The present-wait/render-finished semaphore is per swapchain
+image, on the 'Vulkan.Utils.Swapchain.Swapchain', because it is only safe to
+reuse once its image is re-acquired — not when the frame's render finishes.)
 
 The host-side timeline semaphore (@fHostTimeline@) lives across frames:
 each frame increments it to its own 'fIndex' on the GPU, and the host
@@ -65,8 +67,8 @@ data Frame = Frame
   in flight keeps its swapchain alive across recreation.
   -}
   , fRecycled :: RecycledResources
-  {- ^ This frame's image-available / render-finished / command-pool — all
-  borrowed from the recycle channel; returned at retire time.
+  {- ^ This frame's image-available semaphore + command pool — borrowed from
+  the recycle channel; returned at retire time.
   -}
   , fHostTimeline :: Vk.Semaphore
   {- ^ Long-lived timeline semaphore. Each frame increments it to 'fIndex'
@@ -238,9 +240,9 @@ recordCommands vc Frame{fRecycled} record = do
 bookkeeping the host wait thread will block on.
 
 Builds the standard frame submit from context/frame: waits on the frame's
-image-available semaphore at @COLOR_ATTACHMENT_OUTPUT@, signals its
-render-finished semaphore plus its timeline value, and submits on the
-graphics queue.
+image-available semaphore at @COLOR_ATTACHMENT_OUTPUT@, signals the
+swapchain's per-image render-finished semaphore (at @imageIndex@) plus its
+timeline value, and submits on the graphics queue.
 
 For a non-standard submit shape (multiple submit infos, different wait
 stage, extra signals), call 'Vk.queueSubmit' directly and append
@@ -250,27 +252,31 @@ queueSubmitFrame
   :: (MonadIO m)
   => VulkanContext
   -> Frame
+  -> Word32
+  -- ^ Acquired image index (from 'acquireFrameImage'); selects the per-image
+  -- present-wait semaphore to signal.
   -> V.Vector Vk.CommandBuffer
   -> m ()
 {-# INLINE queueSubmitFrame #-}
-queueSubmitFrame vc Frame{..} cbs = liftIO . mask_ $ do
+queueSubmitFrame vc Frame{..} imageIndex cbs = liftIO . mask_ $ do
   Vk.queueSubmit gQ [SomeStruct submitInfo] Vk.NULL_HANDLE
   atomicModifyIORef' fGPUWork $ \jobs -> ((fHostTimeline, fIndex) : jobs, ())
   where
     gQ = snd (qGraphics (vcQueues vc))
+    renderFinished = sRenderFinished fSwapchain V.! fromIntegral imageIndex
     submitInfo =
       zero
         { Vk.waitSemaphores = [rrImageAvailable]
         , Vk.waitDstStageMask = [Vk.PIPELINE_STAGE_TOP_OF_PIPE_BIT]
         , Vk.commandBuffers = fmap Vk.commandBufferHandle cbs
-        , Vk.signalSemaphores = [rrRenderFinished, fHostTimeline]
+        , Vk.signalSemaphores = [renderFinished, fHostTimeline]
         }
         ::& zero
           { waitSemaphoreValues = [1]
           , signalSemaphoreValues = [1, fIndex]
           }
           :& ()
-    RecycledResources{rrImageAvailable, rrRenderFinished} = fRecycled
+    RecycledResources{rrImageAvailable} = fRecycled
 
 {- | Acquire the next swapchain image for this frame, signalling the frame's
 image-available semaphore on completion.
@@ -302,8 +308,8 @@ acquireFrameImage vc Frame{..} =
     oneSecond :: Word64
     oneSecond = 1000000000
 
-{- | Present this frame's acquired image, waiting on the frame's
-render-finished semaphore. Presents on the graphics queue
+{- | Present this frame's acquired image, waiting on the swapchain's per-image
+render-finished semaphore (at @imageIndex@). Presents on the graphics queue
 (@qGraphics . vcQueues@).
 
 If either the prior acquire (passed in) or this present reports
@@ -317,14 +323,14 @@ presentFrameImage vc f acquireResult imageIndex = liftIO $ do
     KHR.queuePresentKHR
       gQ
       zero
-        { KHR.waitSemaphores = [rrRenderFinished]
+        { KHR.waitSemaphores = [renderFinished]
         , KHR.swapchains = [sSwapchain (fSwapchain f)]
         , KHR.imageIndices = [imageIndex]
         }
   when (acquireResult == Vk.SUBOPTIMAL_KHR || presentResult == Vk.SUBOPTIMAL_KHR) $
     throwIO (VulkanException Vk.ERROR_OUT_OF_DATE_KHR)
   where
-    RecycledResources{rrRenderFinished} = fRecycled f
+    renderFinished = sRenderFinished (fSwapchain f) V.! fromIntegral imageIndex
     gQ = snd (qGraphics (vcQueues vc))
 
 {- | Shutdown drain: spawn the unrendered current frame's wait/recycle thread,
@@ -360,18 +366,13 @@ withTimelineSemaphore dev initial =
 -- Internals
 ----------------------------------------------------------------
 
-{- | Build one set of recycled resources: two binary semaphores + a
-command pool keyed to the graphics queue family.
+{- | Build one set of recycled resources: a binary image-available semaphore
++ a command pool keyed to the graphics queue family. (The present-wait
+semaphore is per swapchain image, on the 'Swapchain', not here.)
 -}
 mkRecycledResources :: (MonadResource m) => VulkanContext -> m RecycledResources
 mkRecycledResources vc = do
   (_, rrImageAvailable) <-
-    Vk.withSemaphore
-      dev
-      (zero ::& SemaphoreTypeCreateInfo SEMAPHORE_TYPE_BINARY 0 :& ())
-      Nothing
-      allocate
-  (_, rrRenderFinished) <-
     Vk.withSemaphore
       dev
       (zero ::& SemaphoreTypeCreateInfo SEMAPHORE_TYPE_BINARY 0 :& ())

--- a/utils/src/Vulkan/Utils/Frame.hs
+++ b/utils/src/Vulkan/Utils/Frame.hs
@@ -254,13 +254,14 @@ queueSubmitFrame
   -> m ()
 {-# INLINE queueSubmitFrame #-}
 queueSubmitFrame vc Frame{..} cbs = liftIO . mask_ $ do
-  let
-    RecycledResources{rrImageAvailable, rrRenderFinished} = fRecycled
+  Vk.queueSubmit gQ [SomeStruct submitInfo] Vk.NULL_HANDLE
+  atomicModifyIORef' fGPUWork $ \jobs -> ((fHostTimeline, fIndex) : jobs, ())
+  where
     gQ = snd (qGraphics (vcQueues vc))
     submitInfo =
       zero
         { Vk.waitSemaphores = [rrImageAvailable]
-        , Vk.waitDstStageMask = [Vk.PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT]
+        , Vk.waitDstStageMask = [Vk.PIPELINE_STAGE_TOP_OF_PIPE_BIT]
         , Vk.commandBuffers = fmap Vk.commandBufferHandle cbs
         , Vk.signalSemaphores = [rrRenderFinished, fHostTimeline]
         }
@@ -269,8 +270,7 @@ queueSubmitFrame vc Frame{..} cbs = liftIO . mask_ $ do
           , signalSemaphoreValues = [1, fIndex]
           }
           :& ()
-  Vk.queueSubmit gQ [SomeStruct submitInfo] Vk.NULL_HANDLE
-  atomicModifyIORef' fGPUWork ((,()) . ((fHostTimeline, fIndex) :))
+    RecycledResources{rrImageAvailable, rrRenderFinished} = fRecycled
 
 {- | Acquire the next swapchain image for this frame, signalling the frame's
 image-available semaphore on completion.
@@ -313,9 +313,6 @@ recreates the swapchain.
 presentFrameImage :: (MonadIO m) => VulkanContext -> Frame -> Vk.Result -> Word32 -> m ()
 {-# INLINE presentFrameImage #-}
 presentFrameImage vc f acquireResult imageIndex = liftIO $ do
-  let
-    RecycledResources{rrRenderFinished} = fRecycled f
-    gQ = snd (qGraphics (vcQueues vc))
   presentResult <-
     KHR.queuePresentKHR
       gQ
@@ -326,6 +323,9 @@ presentFrameImage vc f acquireResult imageIndex = liftIO $ do
         }
   when (acquireResult == Vk.SUBOPTIMAL_KHR || presentResult == Vk.SUBOPTIMAL_KHR) $
     throwIO (VulkanException Vk.ERROR_OUT_OF_DATE_KHR)
+  where
+    RecycledResources{rrRenderFinished} = fRecycled f
+    gQ = snd (qGraphics (vcQueues vc))
 
 {- | Shutdown drain: spawn the unrendered current frame's wait/recycle thread,
 then block on the recycle channel until both this frame's and the previous
@@ -365,9 +365,6 @@ command pool keyed to the graphics queue family.
 -}
 mkRecycledResources :: (MonadResource m) => VulkanContext -> m RecycledResources
 mkRecycledResources vc = do
-  let
-    dev = vcDevice vc
-    QueueFamilyIndex qfi = fst (qGraphics (vcQueues vc))
   (_, rrImageAvailable) <-
     Vk.withSemaphore
       dev
@@ -387,6 +384,9 @@ mkRecycledResources vc = do
       Nothing
       allocate
   pure RecycledResources{..}
+  where
+    dev = vcDevice vc
+    (QueueFamilyIndex qfi, _) = qGraphics (vcQueues vc)
 
 {- | Wait for some semaphores; if the wait times out, give the device one
 more chance with a zero timeout. Catches the case where the host was

--- a/utils/src/Vulkan/Utils/Initialization.hs
+++ b/utils/src/Vulkan/Utils/Initialization.hs
@@ -10,6 +10,7 @@ module Vulkan.Utils.Initialization
     -- * macOS portability
   , portabilityRequirements
   , portabilityFlags
+  , devicePortabilityRequirements
 
     -- * Device creation
   , createDeviceFromRequirements
@@ -45,6 +46,8 @@ import           Vulkan.Core10.Enums.InstanceCreateFlagBits
                                                 ( pattern INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR )
 import           Vulkan.Extensions.VK_KHR_portability_enumeration
                                                 ( pattern KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME )
+import           Vulkan.Extensions.VK_KHR_portability_subset
+                                                ( pattern KHR_PORTABILITY_SUBSET_EXTENSION_NAME )
 #endif
 
 ----------------------------------------------------------------
@@ -146,15 +149,18 @@ createInstanceFromRequirements required optional baseCreateInfo = do
 -- macOS portability + windowing-friendly instance creation
 ----------------------------------------------------------------
 
-{- | Instance requirements needed on macOS to enumerate non-conformant drivers
-such as MoltenVK. Empty on every other platform.
--}
 portabilityRequirements :: [InstanceRequirement]
 
 {- | Instance create flag bits that pair with 'portabilityRequirements'.
 'zero' on every non-macOS platform.
 -}
 portabilityFlags :: InstanceCreateFlags
+
+{- | Device requirements needed on macOS: the Vulkan spec mandates that
+@VK_KHR_portability_subset@ be enabled whenever a physical device advertises
+it (as MoltenVK does). Empty on every other platform.
+-}
+devicePortabilityRequirements :: [DeviceRequirement]
 
 #if defined(darwin_HOST_OS)
 portabilityRequirements =
@@ -165,9 +171,17 @@ portabilityRequirements =
       }
   ]
 portabilityFlags = INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR
+devicePortabilityRequirements =
+  [ RequireDeviceExtension
+      { deviceExtensionLayerName  = Nothing
+      , deviceExtensionName       = KHR_PORTABILITY_SUBSET_EXTENSION_NAME
+      , deviceExtensionMinVersion = minBound
+      }
+  ]
 #else
 portabilityRequirements = []
 portabilityFlags        = zero
+devicePortabilityRequirements = []
 #endif
 
 {- | Build a Vulkan 'Instance' from a backend-supplied extension list plus
@@ -225,7 +239,7 @@ createDeviceFromRequirements
 createDeviceFromRequirements required optional phys baseCreateInfo = do
   (mbDCI, rrs, ors) <-
     checkDeviceRequirements
-      required
+      (devicePortabilityRequirements <> required)
       optional
       phys
       baseCreateInfo

--- a/utils/src/Vulkan/Utils/Queues.hs
+++ b/utils/src/Vulkan/Utils/Queues.hs
@@ -27,8 +27,13 @@ module Vulkan.Utils.Queues
 
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Resource
+import Data.Foldable (foldl', toList)
+import Data.List (sortOn)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Traversable (mapAccumL)
 import qualified Data.Vector as V
-import Data.Word (Word64)
+import Data.Word (Word32, Word64)
 import Vulkan.CStruct.Extends (SomeStruct (..))
 import qualified Vulkan.Core10 as Vk
 import qualified Vulkan.Core10.DeviceInitialization as DI
@@ -51,7 +56,7 @@ data Queues a = Queues
   , qTransfer :: a
   -- ^ transfer (prefers transfer-only family), priority 0.2
   }
-  deriving (Functor, Foldable, Traversable)
+  deriving (Show, Functor, Foldable, Traversable)
 
 -- | Elementwise zip — handy for combining priorities with family predicates.
 instance Applicative Queues where
@@ -89,10 +94,18 @@ withDevice inst mSurface extraReqs = do
     Nothing -> fail "No physical device with the required G/C/T queue families"
 
   let
+    prios = Queues 1.0 0.5 0.2
     mkSpec target prio = QueueSpec prio (\i _ -> pure (i == target))
-    specs = mkSpec <$> qFams <*> Queues 1.0 0.5 0.2
+    specs = mkSpec <$> qFams <*> prios
 
-  Just (qInfos, getQs) <- assignQueues phys specs
+  -- Prefer 'assignQueues', which hands each slot its own queue for maximum
+  -- parallelism. When the hardware can't supply that many distinct queues
+  -- (e.g. a lone graphics+compute family exposing a single queue, as some
+  -- mobile and translation-layer drivers do) fall back to sharing rather than
+  -- failing: the triple still works, just with serialized submission.
+  (qInfos, getQs) <- assignQueues phys specs >>= \case
+    Just qs -> pure qs
+    Nothing -> shareQueues phys ((,) <$> qFams <*> prios)
 
   dev <-
     createDeviceFromRequirements
@@ -155,3 +168,85 @@ discoverFamilies mSurf phys = do
       let score = sum (DI.size <$> heaps) :: Word64
       pure (Just (Queues gp cp tf, score))
     _ -> pure Nothing
+
+{- | Robust fallback for 'withDevice' when 'assignQueues' can't give every
+slot its own queue. Allocates as many distinct queues per family as the
+hardware exposes, then aliases the surplus slots onto them round-robin, so it
+always succeeds.
+
+A shared queue keeps every capability it was selected for — a graphics+compute
+family also handles transfer — so the result is correct, just less concurrent.
+Two slots that resolve to the same 'Vk.Queue' compare equal, so a caller who
+cares can detect aliasing. Callers submitting from multiple threads must
+externally synchronize a shared queue themselves; see
+'Vulkan.Utils.QueueAssignment'.
+-}
+shareQueues
+  :: (MonadIO m)
+  => Vk.PhysicalDevice
+  -> Queues (QueueFamilyIndex, Float)
+  -- ^ The resolved family and queue priority for each slot.
+  -> m
+       ( V.Vector (Vk.DeviceQueueCreateInfo '[])
+       , Vk.Device -> IO (Queues (QueueFamilyIndex, Vk.Queue))
+       )
+shareQueues phys famPrios = do
+  capacities <- familyCapacities phys
+  let
+    capOf fam = Map.findWithDefault 0 fam capacities
+
+    -- Hand each slot a queue index within its family, wrapping at the family's
+    -- capacity so surplus slots reuse (alias) earlier queues.
+    step counts (fam, prio) =
+      let
+        used = Map.findWithDefault 0 fam counts
+        idx = used `mod` max 1 (capOf fam)
+      in
+        (Map.insert fam (used + 1) counts, (fam, prio, idx))
+
+    slots :: Queues (QueueFamilyIndex, Float, Word32)
+    slots = snd (mapAccumL step Map.empty famPrios)
+
+    -- The highest requested priority wins for a queue shared by several slots.
+    priorityAt :: Map (QueueFamilyIndex, Word32) Float
+    priorityAt =
+      foldl'
+        (\acc (fam, prio, idx) -> Map.insertWith max (fam, idx) prio acc)
+        Map.empty
+        (toList slots)
+
+    -- One create-info per family, priorities ordered by queue index.
+    perFamily :: Map QueueFamilyIndex [(Word32, Float)]
+    perFamily =
+      Map.fromListWith
+        (<>)
+        [(fam, [(idx, prio)]) | ((fam, idx), prio) <- Map.toList priorityAt]
+
+    createInfos =
+      V.fromList
+        [ zero
+            { Vk.queueFamilyIndex = unQueueFamilyIndex fam
+            , Vk.queuePriorities = V.fromList (snd <$> sortOn fst idxPrios)
+            }
+        | (fam, idxPrios) <- Map.toList perFamily
+        ]
+
+    getQueues dev =
+      traverse
+        ( \(fam, _, idx) ->
+            (fam,) <$> Vk.getDeviceQueue dev (unQueueFamilyIndex fam) idx
+        )
+        slots
+
+  pure (createInfos, getQueues)
+
+-- | The number of queues each queue family of a 'Vk.PhysicalDevice' exposes.
+familyCapacities
+  :: (MonadIO m) => Vk.PhysicalDevice -> m (Map QueueFamilyIndex Word32)
+familyCapacities phys = do
+  props <- Vk.getPhysicalDeviceQueueFamilyProperties phys
+  pure $
+    Map.fromList
+      [ (QueueFamilyIndex (fromIntegral i), Vk.queueCount qfp)
+      | (i, qfp) <- zip [0 :: Int ..] (V.toList props)
+      ]

--- a/utils/src/Vulkan/Utils/Swapchain.hs
+++ b/utils/src/Vulkan/Utils/Swapchain.hs
@@ -28,7 +28,9 @@ import Data.Foldable (for_, traverse_)
 import Data.Vector (Vector)
 import qualified Data.Vector as V
 import GHC.Generics (Generic)
+import Vulkan.CStruct.Extends (pattern (:&), pattern (::&))
 import qualified Vulkan.Core10 as Vk
+import Vulkan.Core12.Promoted_From_VK_KHR_timeline_semaphore (SemaphoreTypeCreateInfo (..), pattern SEMAPHORE_TYPE_BINARY)
 import Vulkan.Exception (VulkanException (..))
 import Vulkan.Extensions.VK_KHR_surface as SurfaceCapabilitiesKHR (SurfaceCapabilitiesKHR (..))
 import Vulkan.Extensions.VK_KHR_surface as SurfaceFormatKHR (SurfaceFormatKHR (..))
@@ -96,6 +98,13 @@ data Swapchain = Swapchain
   , sPresentMode :: KHR.PresentModeKHR
   , sImages :: Vector Vk.Image
   , sImageViews :: Vector Vk.ImageView
+  , sRenderFinished :: Vector Vk.Semaphore
+  {- ^ Per-image present-wait binary semaphore, indexed by the acquired image
+  index (@length == length sImages@). A frame's submit signals
+  @sRenderFinished ! imageIndex@ and the present waits on it; reusing it is
+  safe only once that image is re-acquired, which is why it lives here (per
+  image) rather than in the per-frame 'RecycledResources'. Freed by 'sRelease'.
+  -}
   , sRelease :: RefCounted
   -- ^ Held until no in-flight frame still uses this swapchain.
   , sConfig :: SwapchainConfig
@@ -128,8 +137,19 @@ allocSwapchain phys dev cfg oldSwapchain windowSize surface = do
     fmap V.unzip . V.forM sImages $ \image ->
       createImageView dev (SurfaceFormatKHR.format sFormat) image
 
+  -- One present-wait binary semaphore per swapchain image, indexed by the
+  -- acquired image index (see 'sRenderFinished').
+  (renderFinishedKeys, sRenderFinished) <-
+    fmap V.unzip . V.forM sImages $ \_image ->
+      Vk.withSemaphore
+        dev
+        (zero ::& SemaphoreTypeCreateInfo SEMAPHORE_TYPE_BINARY 0 :& ())
+        Nothing
+        allocate
+
   -- Released by the next 'recreateSwapchain' (when frames stop using it).
   sRelease <- newRefCounted $ do
+    traverse_ release renderFinishedKeys
     traverse_ release imageViewKeys
     release swapchainKey
 

--- a/utils/src/Vulkan/Utils/VulkanContext.hs
+++ b/utils/src/Vulkan/Utils/VulkanContext.hs
@@ -35,13 +35,17 @@ data VulkanContext = VulkanContext
   -}
   }
 
-{- | The bits of state recycled between frames: two binary semaphores used
-for image-acquire / render-done synchronisation, and the command pool the
-frame's commands are recorded into.
+{- | The bits of state recycled between frames: a binary image-available
+semaphore (signalled by image acquisition, waited on by the frame's submit)
+and the command pool the frame's commands are recorded into.
+
+The render-finished / present-wait semaphore is /not/ here — it is per
+swapchain image (see 'Vulkan.Utils.Swapchain.sRenderFinished'), because a
+present-wait semaphore is only safe to reuse once its image is re-acquired,
+not when the frame's render completes.
 -}
 data RecycledResources = RecycledResources
   { rrImageAvailable :: Vk.Semaphore
-  , rrRenderFinished :: Vk.Semaphore
   , rrCommandPool :: Vk.CommandPool
   }
 

--- a/utils/src/Vulkan/Utils/WindowLoop.hs
+++ b/utils/src/Vulkan/Utils/WindowLoop.hs
@@ -77,6 +77,16 @@ runWindowLoop vc initialSC getSize shouldQuit WindowLoop{..} = do
         if needsNew
           then do
             newSize <- liftIO getSize
+            -- A swapchain recreation retires the old swapchain. Drain the
+            -- graphics/present queue first so the old swapchain's pending
+            -- presents — and this frame's GPU work behind the old
+            -- per-swapchain state — all complete before we free the old
+            -- per-image present-wait semaphores, the old swapchain, and the
+            -- old state. A present-wait semaphore cannot otherwise be known
+            -- idle (its present has no host-visible completion without
+            -- VK_KHR_swapchain_maintenance1). Recreation is rare, so this
+            -- one-shot wait is cheap.
+            Vk.deviceWaitIdle (vcDevice vc)
             sc' <- recreateSwapchain (vcPhysicalDevice vc) (vcDevice vc) newSize currentSC
             (newSt, newKey) <- wlMkState sc'
             (_, oldKey) <- liftIO $ readIORef stRef


### PR DESCRIPTION
- Default queues fallback to shared for the utils helper. Meh, but better for "time to first triangle".
- `resize` example changed to "compute offscreen, then blit" instead of computing to swapchain directly due to format mismatch.
  -  Now also shows sync/async compute